### PR TITLE
feat(mcp): add gemini-cli and pi-rpc MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # generated output
 dist/
+
+# Node.js dependencies
+node_modules/

--- a/mcp/gemini-cli/bun.lock
+++ b/mcp/gemini-cli/bun.lock
@@ -1,0 +1,211 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "gemini-cli-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/mcp/gemini-cli/package.json
+++ b/mcp/gemini-cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "gemini-cli-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/server.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/bun": "latest",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/mcp/gemini-cli/src/acpClient.ts
+++ b/mcp/gemini-cli/src/acpClient.ts
@@ -1,0 +1,249 @@
+/**
+ * ACP (Agent Communication Protocol) client for persistent Gemini sessions.
+ *
+ * Manages long-lived `gemini --acp` subprocesses that speak JSON-RPC 2.0 over
+ * stdin/stdout. Each named session is a separate subprocess with full conversation
+ * context preserved across calls.
+ *
+ * Key design:
+ * - Lazy init: subprocess spawned on first acpAsk() call
+ * - Singleton per session_name: one subprocess per named slot
+ * - Turn counter: tracks conversation depth per session
+ * - Graceful shutdown: SIGTERM all subprocesses via acpShutdownAll()
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import { createInterface, type Interface as ReadlineInterface } from "readline";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import type {
+  JsonRpcRequest,
+  JsonRpcMessage,
+  AcpPromptResult,
+  AcpAskResult,
+  AcpSessionOptions,
+} from "./types.js";
+
+interface AcpSession {
+  proc: ChildProcess;
+  reader: ReadlineInterface;
+  sessionId: string;
+  turn: number;
+  model: string;
+  nextId: number;
+  contextDir: string | null;
+  /** Pending response resolvers keyed by JSON-RPC request id */
+  pending: Map<number, { resolve: (msg: JsonRpcMessage) => void; reject: (err: Error) => void }>;
+  /** Accumulated text from session/update notifications for current prompt */
+  chunks: string[];
+}
+
+const sessions = new Map<string, AcpSession>();
+
+const MODEL_ALIASES: Record<string, string> = {
+  fast: "gemini-3-flash-preview",
+  quality: "gemini-3.1-pro-preview",
+};
+
+function resolveModel(model: string): string {
+  return MODEL_ALIASES[model] ?? model;
+}
+
+/**
+ * Send a JSON-RPC request and wait for the matching response.
+ */
+function sendRequest(
+  session: AcpSession,
+  method: string,
+  params?: Record<string, unknown>
+): Promise<JsonRpcMessage> {
+  const id = session.nextId++;
+  const request: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+
+  return new Promise((resolve, reject) => {
+    session.pending.set(id, { resolve, reject });
+    session.proc.stdin!.write(JSON.stringify(request) + "\n", "utf-8");
+  });
+}
+
+/**
+ * Process an incoming JSON-RPC line from the ACP subprocess.
+ */
+function handleLine(session: AcpSession, line: string): void {
+  if (!line.trim()) return;
+
+  let msg: JsonRpcMessage;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return; // Skip non-JSON lines (stderr leaking into stdout, etc.)
+  }
+
+  // Notification (no id) — accumulate text chunks
+  if (!("id" in msg) && "method" in msg) {
+    if (msg.method === "session/update") {
+      const params = msg.params as { update?: { text?: string } } | undefined;
+      if (params?.update?.text) {
+        session.chunks.push(params.update.text);
+      }
+    }
+    return;
+  }
+
+  // Response (has id) — resolve the pending promise
+  if ("id" in msg && msg.id !== undefined) {
+    const pending = session.pending.get(msg.id as number);
+    if (pending) {
+      session.pending.delete(msg.id as number);
+      pending.resolve(msg);
+    }
+  }
+}
+
+/**
+ * Spawn a new ACP subprocess and perform the initialize + session/new handshake.
+ */
+async function createSession(
+  name: string,
+  opts: AcpSessionOptions
+): Promise<AcpSession> {
+  const binary = process.env.GEMINI_BINARY ?? "gemini";
+  const model = resolveModel(opts.model ?? process.env.GEMINI_DEFAULT_MODEL ?? "gemini-3-flash-preview");
+
+  const args = ["--acp", "--model", model, "--yolo"];
+
+  // System context injection
+  let contextDir: string | null = null;
+  if (opts.system_context) {
+    contextDir = join("/tmp", `gemini-acp-${randomUUID()}`);
+    mkdirSync(contextDir, { recursive: true });
+    writeFileSync(join(contextDir, "GEMINI.md"), opts.system_context, "utf-8");
+    args.push("--include-directories", contextDir);
+  }
+
+  const proc = spawn(binary, args, {
+    cwd: opts.cwd ?? process.cwd(),
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env },
+  });
+
+  const reader = createInterface({ input: proc.stdout! });
+  const session: AcpSession = {
+    proc,
+    reader,
+    sessionId: "",
+    turn: 0,
+    model,
+    nextId: 1,
+    contextDir,
+    pending: new Map(),
+    chunks: [],
+  };
+
+  // Wire up line-by-line reading
+  reader.on("line", (line) => handleLine(session, line));
+
+  // Handle subprocess crash — only clean up if this session is still registered
+  proc.on("exit", (code) => {
+    // Reject all pending requests
+    for (const [, { reject }] of session.pending) {
+      reject(new Error(`ACP subprocess exited with code ${code}`));
+    }
+    session.pending.clear();
+    // Only remove from map if this session is still the active one for this name
+    if (sessions.get(name) === session) {
+      sessions.delete(name);
+    }
+    if (session.contextDir) {
+      try { rmSync(session.contextDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  // Ignore stderr (Gemini CLI writes status/progress there)
+  proc.stderr!.on("data", () => {});
+
+  sessions.set(name, session);
+
+  // Handshake: initialize
+  const initResp = await sendRequest(session, "initialize", { clientCapabilities: {} });
+  if ("error" in initResp) {
+    throw new Error(`ACP initialize failed: ${(initResp as any).error.message}`);
+  }
+
+  // Handshake: session/new
+  const newResp = await sendRequest(session, "session/new", { cwd: opts.cwd ?? process.cwd() });
+  if ("error" in newResp) {
+    throw new Error(`ACP session/new failed: ${(newResp as any).error.message}`);
+  }
+  session.sessionId = ((newResp as any).result as Record<string, unknown>).sessionId as string;
+
+  return session;
+}
+
+/**
+ * Get an existing session by name (for inspection/testing).
+ */
+export function acpGetSession(name: string): { turn: number; sessionId: string } | undefined {
+  const s = sessions.get(name);
+  if (!s) return undefined;
+  return { turn: s.turn, sessionId: s.sessionId };
+}
+
+/**
+ * Send a prompt to a persistent ACP session. Creates the session on first call.
+ */
+export async function acpAsk(
+  question: string,
+  opts: AcpSessionOptions & { session_name?: string; context?: string }
+): Promise<AcpAskResult> {
+  const name = opts.session_name ?? "default";
+  let session = sessions.get(name);
+
+  if (!session) {
+    session = await createSession(name, opts);
+  }
+
+  // Clear chunks for this turn
+  session.chunks = [];
+
+  // Prepend context if provided
+  const prompt = opts.context ? `${opts.context}\n\n${question}` : question;
+
+  const resp = await sendRequest(session, "session/prompt", {
+    sessionId: session.sessionId,
+    prompt,
+  });
+
+  if ("error" in resp) {
+    throw new Error(`ACP prompt failed: ${(resp as any).error.message}`);
+  }
+
+  session.turn++;
+
+  const result = (resp as any).result as AcpPromptResult;
+  const answer = session.chunks.join("");
+
+  return {
+    answer,
+    session_id: session.sessionId,
+    turn: session.turn,
+    usage: result.usage ?? {},
+  };
+}
+
+/**
+ * Gracefully shut down all ACP sessions. Called on MCP server exit.
+ */
+export async function acpShutdownAll(): Promise<void> {
+  for (const [name, session] of sessions) {
+    try {
+      session.reader.close();
+      session.proc.kill("SIGTERM");
+    } catch { /* best-effort */ }
+    if (session.contextDir) {
+      try { rmSync(session.contextDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  }
+  sessions.clear();
+}

--- a/mcp/gemini-cli/src/gemini.ts
+++ b/mcp/gemini-cli/src/gemini.ts
@@ -1,0 +1,341 @@
+/**
+ * Subprocess manager for Gemini CLI headless mode.
+ *
+ * Spawns `gemini -p <prompt> --output-format json` and parses the single
+ * JSON response object: { session_id, response, stats }.
+ *
+ * Key design choices:
+ * - Uses `--output-format json` (not `stream-json`) — the JSON format already
+ *   includes `session_id` at the top level, so no JSONL parsing is needed
+ * - Defaults to `--approval-mode yolo` and `--sandbox` for safe headless operation
+ * - System context is injected via a temporary GEMINI.md + `--include-directories`
+ * - Binary path is configurable via `GEMINI_BINARY` for test injection
+ * - Default model configurable via `GEMINI_DEFAULT_MODEL` (e.g. "gemini-3-flash-preview")
+ */
+
+import { spawn } from "child_process";
+import { randomUUID } from "crypto";
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from "fs";
+import { join } from "path";
+import type { GeminiOptions, GeminiResult } from "./types.js";
+
+/**
+ * Named model presets → real Gemini CLI model IDs.
+ * Keeps tool callers from having to remember full model strings.
+ */
+const MODEL_ALIASES: Record<string, string> = {
+  fast:    "gemini-3-flash-preview",
+  quality: "gemini-3.1-pro-preview",
+};
+
+/** Resolve a preset alias or pass through a full model ID unchanged. */
+function resolveModel(model: string): string {
+  return MODEL_ALIASES[model] ?? model;
+}
+
+/** Exit code meanings from Gemini CLI */
+const EXIT_CODE_MESSAGES: Record<number, string> = {
+  1: "Gemini CLI returned a general error or API failure",
+  42: "Gemini CLI received invalid input (bad prompt or arguments)",
+  52: "Gemini CLI configuration error — check $HOME/.gemini/settings.json permissions",
+  53: "Gemini CLI turn limit exceeded — break your task into smaller pieces",
+};
+
+/** Default timeout: 5 minutes */
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+/**
+ * Run a prompt headlessly and return the response, session ID, and stats.
+ * Uses `--output-format stream-json` to capture the session ID for multi-turn support.
+ */
+export async function runGemini(
+  prompt: string,
+  options: GeminiOptions = {}
+): Promise<GeminiResult> {
+  const args = buildArgs(prompt, options);
+  const contextDir = await prepareSystemContext(options.system_context);
+
+  if (contextDir) {
+    args.push("--include-directories", contextDir);
+  }
+
+  try {
+    return await spawnGemini(args, {
+      cwd: options.cwd,
+      timeoutMs: options.timeout_ms ?? DEFAULT_TIMEOUT_MS,
+    });
+  } finally {
+    if (contextDir) cleanupContextDir(contextDir);
+  }
+}
+
+/**
+ * Run a prompt with piped context (file contents, diffs, logs, etc.).
+ * The context is written to the process's stdin.
+ */
+export async function runGeminiWithContext(
+  prompt: string,
+  context: string,
+  options: GeminiOptions = {}
+): Promise<GeminiResult> {
+  const args = buildArgs(prompt, options);
+  const contextDir = await prepareSystemContext(options.system_context);
+
+  if (contextDir) {
+    args.push("--include-directories", contextDir);
+  }
+
+  try {
+    return await spawnGemini(args, {
+      cwd: options.cwd,
+      timeoutMs: options.timeout_ms ?? DEFAULT_TIMEOUT_MS,
+      stdin: context,
+    });
+  } finally {
+    if (contextDir) cleanupContextDir(contextDir);
+  }
+}
+
+/**
+ * Continue a previous session using `--resume <session_id>`.
+ */
+export async function resumeGemini(
+  sessionId: string,
+  prompt: string,
+  options: GeminiOptions = {}
+): Promise<GeminiResult> {
+  const args = buildArgs(prompt, { ...options, session_id: sessionId });
+  const contextDir = await prepareSystemContext(options.system_context);
+
+  if (contextDir) {
+    args.push("--include-directories", contextDir);
+  }
+
+  try {
+    return await spawnGemini(args, {
+      cwd: options.cwd,
+      timeoutMs: options.timeout_ms ?? DEFAULT_TIMEOUT_MS,
+    });
+  } finally {
+    if (contextDir) cleanupContextDir(contextDir);
+  }
+}
+
+/**
+ * Build the CLI argument array for a gemini invocation.
+ * Uses `--output-format json` — the JSON format includes session_id at the top level.
+ */
+function buildArgs(prompt: string, options: GeminiOptions): string[] {
+  // Fallback chain: caller → GEMINI_DEFAULT_MODEL env var → gemini-3-flash-preview
+  // "auto" is intentionally not the fallback — it routes to cheapest model.
+  const defaultModel = process.env.GEMINI_DEFAULT_MODEL ?? "gemini-3-flash-preview";
+  const {
+    model = defaultModel,
+    approval_mode = "yolo",
+    sandbox = false,   // Default false: --sandbox sets HOME=/home/node which breaks most setups
+    allowed_tools,
+    session_id,
+  } = options;
+
+  const args: string[] = [
+    "--prompt", prompt,
+    "--output-format", "json",
+    "--model", resolveModel(model),
+    "--approval-mode", approval_mode,
+  ];
+
+  if (sandbox) {
+    args.push("--sandbox");
+  }
+
+  if (session_id) {
+    args.push("--resume", session_id);
+  }
+
+  if (allowed_tools && allowed_tools.length > 0) {
+    args.push("--allowed-tools", allowed_tools.join(","));
+  }
+
+  return args;
+}
+
+/**
+ * Write system context to a temporary GEMINI.md file.
+ * Returns the temp directory path, or null if no context is needed.
+ *
+ * Priority: per-call `system_context` > `GEMINI_SYSTEM_MD` env var > none
+ */
+async function prepareSystemContext(
+  systemContext?: string
+): Promise<string | null> {
+  // Per-call context takes priority
+  let content = systemContext;
+
+  // Fall back to env var pointing to a default GEMINI.md file
+  if (!content) {
+    const envPath = process.env.GEMINI_SYSTEM_MD;
+    if (envPath && existsSync(envPath)) {
+      content = readFileSync(envPath, "utf-8");
+    }
+  }
+
+  if (!content) return null;
+
+  const tempDir = join("/tmp", `gemini-mcp-${randomUUID()}`);
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(join(tempDir, "GEMINI.md"), content, "utf-8");
+  return tempDir;
+}
+
+/**
+ * Remove the temporary context directory.
+ */
+function cleanupContextDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // Best-effort cleanup — don't throw
+  }
+}
+
+/**
+ * Normalize Gemini CLI stats into a flat structure.
+ *
+ * The real CLI outputs nested per-model breakdowns:
+ *   stats.models["gemini-3-flash-preview"].tokens.{ input, candidates, total, cached }
+ *   stats.models["gemini-3-flash-preview"].api.{ totalLatencyMs }
+ *
+ * Aggregate these into the flat GeminiStats fields so callers always get
+ * total_tokens, input_tokens, output_tokens, cached, and duration_ms at the top level.
+ */
+function normalizeStats(raw: Record<string, unknown> | undefined): import("./types.js").GeminiStats {
+  if (!raw) return {};
+
+  // Aggregate across all models (there's usually only one, but handle multiple)
+  let totalTokens = 0, inputTokens = 0, outputTokens = 0, cachedTokens = 0, latencyMs = 0;
+  const models = raw.models as Record<string, Record<string, Record<string, number>>> | undefined;
+
+  if (models) {
+    for (const model of Object.values(models)) {
+      const tokens = model.tokens ?? {};
+      const api = model.api ?? {};
+      totalTokens  += tokens.total      ?? tokens.totalTokens   ?? 0;
+      inputTokens  += tokens.input      ?? tokens.inputTokens   ?? tokens.prompt ?? 0;
+      outputTokens += tokens.candidates ?? tokens.outputTokens  ?? 0;
+      cachedTokens += tokens.cached     ?? 0;
+      latencyMs    += (api as Record<string, number>).totalLatencyMs ?? 0;
+    }
+  }
+
+  return {
+    // Flat aggregate fields (populated from models breakdown)
+    total_tokens:  totalTokens  || (raw.total_tokens  as number)  || undefined,
+    input_tokens:  inputTokens  || (raw.input_tokens  as number)  || undefined,
+    output_tokens: outputTokens || (raw.output_tokens as number)  || undefined,
+    cached:        cachedTokens || (raw.cached        as number)  || undefined,
+    duration_ms:   latencyMs    || (raw.duration_ms   as number)  || undefined,
+    tool_calls:    (raw.tool_calls as number) || undefined,
+    // Keep raw nested breakdown for full detail
+    models:        raw.models as Record<string, unknown> | undefined,
+    tools:         raw.tools,
+    files:         raw.files,
+  };
+}
+
+interface SpawnOptions {
+  cwd?: string;
+  timeoutMs: number;
+  stdin?: string;
+}
+
+/**
+ * Spawn the gemini binary with `--output-format json`, collect stdout, and parse result.
+ *
+ * The JSON output format returns a single object:
+ *   { session_id: string, response: string, stats: { models: {...}, tools: {...}, files: {...} } }
+ *
+ * Note: Gemini CLI writes MCP status lines and other non-JSON output to stderr.
+ * We capture stdout only and strip any stray non-JSON prefix lines.
+ */
+async function spawnGemini(
+  args: string[],
+  { cwd, timeoutMs, stdin }: SpawnOptions
+): Promise<GeminiResult> {
+  const binary = process.env.GEMINI_BINARY ?? "gemini";
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(binary, args, {
+      cwd: cwd ?? process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      // Pass through HOME so Gemini CLI finds ~/.gemini/settings.json correctly
+      env: { ...process.env },
+    });
+
+    // Write piped context to stdin if provided
+    if (stdin !== undefined) {
+      proc.stdin.write(stdin, "utf-8");
+    }
+    proc.stdin.end();
+
+    let stdoutBuf = "";
+    let stderrOutput = "";
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdoutBuf += chunk.toString("utf-8");
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderrOutput += chunk.toString("utf-8");
+    });
+
+    const timer = setTimeout(() => {
+      proc.kill("SIGTERM");
+      reject(new Error(`Gemini CLI timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+
+      if (code === 0) {
+        // Find the JSON object in stdout (skip any prefix status lines)
+        const jsonStart = stdoutBuf.indexOf("{");
+        if (jsonStart === -1) {
+          reject(new Error("Gemini CLI returned no JSON output"));
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdoutBuf.slice(jsonStart));
+          resolve({
+            response: parsed.response ?? "",
+            session_id: parsed.session_id ?? "",
+            stats: normalizeStats(parsed.stats),
+          });
+        } catch {
+          reject(new Error(`Failed to parse Gemini CLI output: ${stdoutBuf.slice(0, 200)}`));
+        }
+      } else {
+        const message =
+          EXIT_CODE_MESSAGES[code ?? 1] ??
+          `Gemini CLI exited with code ${code}`;
+        const detail = stderrOutput.trim()
+          ? `\nDetails: ${stderrOutput.trim()}`
+          : "";
+        reject(new Error(`${message}${detail}`));
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        reject(
+          new Error(
+            `Gemini CLI not found. Install it with: npm install -g @google/gemini-cli\n` +
+            `Or set GEMINI_BINARY to the path of the gemini binary.`
+          )
+        );
+      } else {
+        reject(err);
+      }
+    });
+  });
+}

--- a/mcp/gemini-cli/src/server.ts
+++ b/mcp/gemini-cli/src/server.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP stdio server entry point for Gemini CLI.
+ *
+ * Wraps Gemini CLI headless mode as MCP tools:
+ * - gemini_run              One-shot prompt dispatch
+ * - gemini_web_search       Dedicated web search (flash default)
+ * - gemini_run_with_context Run with piped stdin context
+ * - gemini_resume           Continue a previous session (--resume)
+ * - gemini_acp_ask          Persistent interactive session (--acp, JSON-RPC 2.0)
+ * - gemini_list_models      List available models
+ *
+ * Transport: stdio (Claude Code discovers via .mcp.json in the plugin)
+ * Binary:    configurable via GEMINI_BINARY env var (default: "gemini")
+ * Context:   GEMINI_SYSTEM_MD env var for persistent default system context
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerTools } from "./tools.js";
+import { acpShutdownAll } from "./acpClient.js";
+
+const server = new McpServer({
+  name: "gemini-cli",
+  version: "0.1.0",
+});
+
+registerTools(server);
+
+// Clean up ACP subprocesses on exit
+process.on("SIGTERM", async () => {
+  await acpShutdownAll();
+  process.exit(0);
+});
+process.on("SIGINT", async () => {
+  await acpShutdownAll();
+  process.exit(0);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/gemini-cli/src/tools.ts
+++ b/mcp/gemini-cli/src/tools.ts
@@ -1,0 +1,362 @@
+/**
+ * MCP tool definitions for the Gemini CLI server.
+ *
+ * Five tools:
+ * 1. gemini_run           — Core one-shot dispatch
+ * 2. gemini_web_search    — Dedicated web search (flash default)
+ * 3. gemini_run_with_context — Run with piped stdin context
+ * 4. gemini_resume        — Continue a previous session
+ * 5. gemini_list_models   — List available models
+ */
+
+import { z } from "zod";
+import { runGemini, runGeminiWithContext, resumeGemini } from "./gemini.js";
+import { acpAsk } from "./acpClient.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+
+/**
+ * Available Gemini model IDs plus named presets.
+ * Presets are resolved to real IDs in buildArgs — use them to avoid
+ * memorising full model strings.
+ */
+const GEMINI_MODELS = [
+  // ── Named presets (recommended) ──────────────────────────────────────────
+  "fast",               // → gemini-3-flash-preview   (default for most tasks)
+  "quality",            // → gemini-3.1-pro-preview   (complex reasoning / architecture)
+  // ── Full model IDs ───────────────────────────────────────────────────────
+  "gemini-3-flash-preview",
+  "gemini-3.1-pro-preview",
+  "gemini-3-pro-preview",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+  "auto",               // routes to cheapest available — avoid unless intentional
+] as const;
+
+/** Shared option schemas reused across tools */
+const modelSchema = z
+  .enum(GEMINI_MODELS)
+  .optional()
+  .describe(
+    "Model to use. " +
+    "PREFER 'fast' (→ gemini-3-flash-preview) for most tasks — web search, code review, analysis, generation. " +
+    "Use 'quality' (→ gemini-3.1-pro-preview) for complex reasoning, architecture design, nuanced tasks. " +
+    "Avoid 'auto' — it routes to the cheapest model (gemini-2.5-flash-lite) regardless of task complexity. " +
+    "Default when omitted: GEMINI_DEFAULT_MODEL env var (gemini-3-flash-preview)."
+  );
+
+const approvalModeSchema = z
+  .enum(["yolo", "auto_edit", "default"])
+  .default("yolo")
+  .describe("yolo=auto-approve all (required for headless); auto_edit=approve edits only; default=blocks in headless");
+
+const sandboxSchema = z
+  .boolean()
+  .default(false)
+  .describe(
+    "Sandbox tool execution. Default false — Gemini CLI sandbox sets HOME=/home/node " +
+    "which requires a specific system setup. Enable only if your system supports it."
+  );
+
+const systemContextSchema = z
+  .string()
+  .optional()
+  .describe(
+    "System-level instructions injected as GEMINI.md. Sets Gemini's persona/output format. " +
+    "E.g. 'Return JSON with fields: title, summary, url' or 'You are a security auditor.'"
+  );
+
+const timeoutSchema = z
+  .number()
+  .positive()
+  .default(300_000)
+  .describe("Timeout in milliseconds. Default: 300000 (5 minutes).");
+
+const cwdSchema = z
+  .string()
+  .optional()
+  .describe("Working directory for the Gemini subprocess. Defaults to current directory.");
+
+const allowedToolsSchema = z
+  .array(z.string())
+  .optional()
+  .describe("Limit which tools Gemini can use. E.g. ['web_search', 'read_file']");
+
+const outputFileSchema = z
+  .string()
+  .optional()
+  .describe(
+    "Absolute path to write the full response JSON. When set, only stats + metadata are returned to the caller " +
+    "(response_bytes, output_file, session_id, stats). Use for outputs >10KB to avoid context window bloat."
+  );
+
+/** Register all Gemini CLI tools on an MCP server instance */
+export function registerTools(server: McpServer): void {
+  // ─── gemini_run ───────────────────────────────────────────────────────────
+  server.tool(
+    "gemini_run",
+    "Run a prompt headlessly with Gemini CLI. Returns the response, session ID (for follow-up with gemini_resume), and token stats. " +
+    "Defaults to yolo+sandbox for safe headless operation. Use for coding tasks, analysis, generation, or any job you want to offload.",
+    {
+      prompt: z.string().describe("The prompt or task for Gemini"),
+      model: modelSchema,
+      approval_mode: approvalModeSchema,
+      sandbox: sandboxSchema,
+      system_context: systemContextSchema,
+      timeout_ms: timeoutSchema,
+      cwd: cwdSchema,
+      allowed_tools: allowedToolsSchema,
+      output_file: outputFileSchema,
+    },
+    async ({ prompt, model, approval_mode, sandbox, system_context, timeout_ms, cwd, allowed_tools, output_file }) => {
+      const result = await runGemini(prompt, {
+        model,
+        approval_mode,
+        sandbox,
+        system_context,
+        timeout_ms,
+        cwd,
+        allowed_tools,
+      });
+      if (output_file) {
+        mkdirSync(dirname(output_file), { recursive: true });
+        const json = JSON.stringify(result, null, 2);
+        writeFileSync(output_file, json, "utf-8");
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              session_id: result.session_id,
+              stats: result.stats,
+              output_file,
+              response_bytes: Buffer.byteLength(json, "utf-8"),
+            }, null, 2),
+          }],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ─── gemini_web_search ────────────────────────────────────────────────────
+  server.tool(
+    "gemini_web_search",
+    "Search the web using Gemini CLI's built-in search tool. " +
+    "Defaults to 'gemini-3-flash-preview' for speed — retrieval tasks don't need pro quality. " +
+    "Use system_context to control output format (e.g. JSON citations, structured summaries).",
+    {
+      query: z.string().describe("Natural language search query"),
+      model: z
+        .enum(GEMINI_MODELS)
+        .optional()
+        .describe("Model for web search. Defaults to 'fast' (gemini-3-flash-preview) — retrieval tasks don't need pro quality. Use 'quality' only for deep research synthesis."),
+      system_context: systemContextSchema,
+      timeout_ms: timeoutSchema,
+    },
+    async ({ query, model, system_context, timeout_ms }) => {
+      // Frame the query to ensure Gemini uses its web search tool
+      const prompt = `Search the web for: ${query}\n\nProvide a thorough, accurate answer based on current web results.`;
+      const result = await runGemini(prompt, {
+        model,
+        approval_mode: "yolo",
+        sandbox: true,
+        system_context,
+        timeout_ms,
+        allowed_tools: ["web_search"],
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ─── gemini_run_with_context ──────────────────────────────────────────────
+  server.tool(
+    "gemini_run_with_context",
+    "Run Gemini with piped context — file contents, git diffs, logs, command output, etc. " +
+    "The context is passed via stdin so it doesn't need to be escaped in the prompt. " +
+    "Perfect for code review, log analysis, diff summarization, or any task where you have a large blob of text to process.",
+    {
+      prompt: z.string().describe("Instructions for how to process the context"),
+      context: z.string().describe("The content to process (file contents, git diff, logs, etc.)"),
+      model: modelSchema,
+      approval_mode: approvalModeSchema,
+      sandbox: sandboxSchema,
+      system_context: systemContextSchema,
+      timeout_ms: timeoutSchema,
+      cwd: cwdSchema,
+      output_file: outputFileSchema,
+    },
+    async ({ prompt, context, model, approval_mode, sandbox, system_context, timeout_ms, cwd, output_file }) => {
+      const result = await runGeminiWithContext(prompt, context, {
+        model,
+        approval_mode,
+        sandbox,
+        system_context,
+        timeout_ms,
+        cwd,
+      });
+      if (output_file) {
+        mkdirSync(dirname(output_file), { recursive: true });
+        const json = JSON.stringify(result, null, 2);
+        writeFileSync(output_file, json, "utf-8");
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              session_id: result.session_id,
+              stats: result.stats,
+              output_file,
+              response_bytes: Buffer.byteLength(json, "utf-8"),
+            }, null, 2),
+          }],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ─── gemini_resume ────────────────────────────────────────────────────────
+  server.tool(
+    "gemini_resume",
+    "Continue a previous Gemini session for multi-turn conversations. " +
+    "Each gemini_run/gemini_web_search call returns a session_id — use it here to follow up. " +
+    "The resumed session has full context of the prior exchange without re-sending it.",
+    {
+      session_id: z.string().describe("session_id from a previous gemini_run or gemini_web_search call"),
+      prompt: z.string().describe("Follow-up prompt continuing the previous session"),
+      model: modelSchema,
+      approval_mode: approvalModeSchema,
+      sandbox: sandboxSchema,
+      system_context: systemContextSchema,
+      timeout_ms: timeoutSchema,
+    },
+    async ({ session_id, prompt, model, approval_mode, sandbox, system_context, timeout_ms }) => {
+      const result = await resumeGemini(session_id, prompt, {
+        model,
+        approval_mode,
+        sandbox,
+        system_context,
+        timeout_ms,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ─── gemini_acp_ask ───────────────────────────────────────────────────────
+  server.tool(
+    "gemini_acp_ask",
+    "Ask a question to a persistent, stateful Gemini session. Unlike gemini_run (one-shot), this maintains full conversation context " +
+    "across calls — Gemini remembers everything said previously. Perfect for interactive supervisors, iterative reviewers, or any workflow " +
+    "where you need back-and-forth collaboration. The session is created lazily on first call and persists until the MCP server exits. " +
+    "Use session_name to run multiple concurrent sessions (e.g. 'supervisor' on quality, 'checker' on fast).",
+    {
+      question: z.string().describe("The question or prompt to send to the persistent session"),
+      context: z.string().optional().describe("Optional extra context prepended to the question (file contents, data, etc.)"),
+      session_name: z
+        .string()
+        .default("default")
+        .describe("Named session slot. Each name gets its own persistent subprocess. Default: 'default'"),
+      model: z
+        .enum(GEMINI_MODELS)
+        .optional()
+        .describe("Model for this session (set on first call, ignored on subsequent calls to the same session_name)"),
+      system_context: z
+        .string()
+        .optional()
+        .describe("Persona/instructions for the session (set on first call via GEMINI.md, ignored on subsequent calls)"),
+    },
+    async ({ question, context, session_name, model, system_context }) => {
+      const result = await acpAsk(question, {
+        context,
+        session_name,
+        model,
+        system_context,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ─── gemini_list_models ───────────────────────────────────────────────────
+  server.tool(
+    "gemini_list_models",
+    "List available Gemini models with guidance on when to use each.",
+    {},
+    async () => {
+      const models = [
+        {
+          id: "auto",
+          description: "Routes to the best model automatically (default). Use when unsure.",
+        },
+        {
+          id: "gemini-3.1-pro-preview",
+          description: "Gemini 3.1 Pro Preview. Highest quality. Best for: complex reasoning, architecture design, nuanced tasks.",
+        },
+        {
+          id: "gemini-3-pro-preview",
+          description: "Gemini 3 Pro Preview. High quality. Best for: complex tasks requiring strong reasoning.",
+        },
+        {
+          id: "gemini-3-flash-preview",
+          description: "Gemini 3 Flash Preview. Fast and balanced. Best for: web search, code review, most tasks. Recommended default.",
+        },
+        {
+          id: "gemini-2.5-pro",
+          description: "Gemini 2.5 Pro. Stable high quality. Best for: long documents, extended context tasks.",
+        },
+        {
+          id: "gemini-2.5-flash",
+          description: "Gemini 2.5 Flash. Balanced speed/quality. Best for: general tasks.",
+        },
+        {
+          id: "gemini-2.5-flash-lite",
+          description: "Gemini 2.5 Flash-Lite. Fastest, lowest cost. Best for: simple lookups, classification.",
+        },
+      ];
+      const defaultModel = process.env.GEMINI_DEFAULT_MODEL ?? "auto";
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ models, default_model: defaultModel }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/mcp/gemini-cli/src/types.ts
+++ b/mcp/gemini-cli/src/types.ts
@@ -1,0 +1,204 @@
+/**
+ * Types for the Gemini CLI MCP server.
+ * Modelled on the stream-json output format from `gemini --output-format stream-json`.
+ */
+
+/**
+ * Gemini model IDs and named presets.
+ * Prefer "fast" or "quality" — they resolve to the right model without
+ * requiring callers to remember full ID strings.
+ */
+export type GeminiModel =
+  | "fast"               // preset → gemini-3-flash-preview (recommended default)
+  | "quality"            // preset → gemini-3.1-pro-preview (complex reasoning)
+  | "gemini-3-flash-preview"
+  | "gemini-3.1-pro-preview"
+  | "gemini-3-pro-preview"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-flash-lite"
+  | "auto"               // routes to cheapest available — avoid
+  | (string & {});       // forward-compatibility
+
+/** Approval modes for headless operation */
+export type ApprovalMode = "yolo" | "auto_edit" | "default";
+
+/** Options passed to every gemini invocation */
+export interface GeminiOptions {
+  /** Gemini model to use. Defaults to "auto". */
+  model?: GeminiModel;
+  /**
+   * Approval mode for tool use.
+   * Defaults to "yolo" — required for headless operation (no TTY for confirmations).
+   */
+  approval_mode?: ApprovalMode;
+  /**
+   * Sandbox tool execution. Defaults to false.
+   *
+   * NOTE: Gemini CLI's sandbox sets HOME=/home/node internally, which requires
+   * a node user home directory to exist. Disable sandbox (default) unless your
+   * system is configured for Gemini CLI sandboxing.
+   * When enabled with yolo, sandboxing limits blast radius.
+   */
+  sandbox?: boolean;
+  /**
+   * System-level instructions injected as a temporary GEMINI.md via --include-directories.
+   * Overrides the GEMINI_SYSTEM_MD environment variable.
+   */
+  system_context?: string;
+  /** Working directory for the subprocess. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Timeout in milliseconds. Defaults to 300000 (5 minutes). */
+  timeout_ms?: number;
+  /** Limit which tools Gemini can use (comma-separated tool names). */
+  allowed_tools?: string[];
+  /** Session ID from a previous run for multi-turn continuation. */
+  session_id?: string;
+  /** When set, write the full response JSON to this absolute path and return only stats/metadata to the caller. */
+  output_file?: string;
+}
+
+/** Result returned by all gemini_run variants */
+export interface GeminiResult {
+  /** The model's final response text */
+  response: string;
+  /** Session ID from the init event — use with gemini_resume for multi-turn */
+  session_id: string;
+  /** Token usage and latency statistics */
+  stats: GeminiStats;
+}
+
+/**
+ * Token usage and latency stats from Gemini CLI JSON output.
+ * Actual fields from --output-format json:
+ *   { models: { "gemini-3-flash-preview": { api: {...}, tokens: {...} } }, tools: {...}, files: {...} }
+ * Actual fields from stream-json result event:
+ *   { total_tokens, input_tokens, output_tokens, cached, duration_ms, tool_calls, models: {...} }
+ */
+export interface GeminiStats {
+  // stream-json result event fields
+  total_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cached?: number;
+  duration_ms?: number;
+  tool_calls?: number;
+  // json format nested models breakdown
+  models?: Record<string, unknown>;
+  // json format top-level tool/file stats
+  tools?: unknown;
+  files?: unknown;
+}
+
+/** A single JSONL event from `--output-format stream-json` */
+export type StreamEvent =
+  | InitEvent
+  | MessageEvent
+  | ToolUseEvent
+  | ToolResultEvent
+  | ErrorEvent
+  | ResultEvent;
+
+export interface InitEvent {
+  type: "init";
+  sessionId: string;
+  model: string;
+}
+
+export interface MessageEvent {
+  type: "message";
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface ToolUseEvent {
+  type: "tool_use";
+  tool: string;
+  args: Record<string, unknown>;
+}
+
+export interface ToolResultEvent {
+  type: "tool_result";
+  tool: string;
+  result: unknown;
+}
+
+export interface ErrorEvent {
+  type: "error";
+  message: string;
+  code?: string;
+}
+
+export interface ResultEvent {
+  type: "result";
+  response: string;
+  stats: GeminiStats;
+}
+
+// ── ACP (Agent Communication Protocol) types ──────────────────────────────
+
+/** JSON-RPC 2.0 request (outgoing) */
+export interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** JSON-RPC 2.0 success response (incoming) */
+export interface JsonRpcResult {
+  jsonrpc: "2.0";
+  id: number;
+  result: Record<string, unknown>;
+}
+
+/** JSON-RPC 2.0 error response (incoming) */
+export interface JsonRpcError {
+  jsonrpc: "2.0";
+  id: number;
+  error: { code: number; message: string; data?: unknown };
+}
+
+/** JSON-RPC 2.0 notification (incoming, no id) */
+export interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/** Any incoming JSON-RPC message */
+export type JsonRpcMessage = JsonRpcResult | JsonRpcError | JsonRpcNotification;
+
+/** ACP session/update notification payload */
+export interface AcpSessionUpdate {
+  sessionId: string;
+  update: {
+    sessionUpdate: string;
+    text?: string;
+  };
+}
+
+/** ACP session/prompt result */
+export interface AcpPromptResult {
+  stopReason: string;
+  usage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+/** Options for creating an ACP session */
+export interface AcpSessionOptions {
+  model?: string;
+  system_context?: string;
+  cwd?: string;
+}
+
+/** Return value from acpAsk */
+export interface AcpAskResult {
+  answer: string;
+  session_id: string;
+  turn: number;
+  usage: AcpPromptResult["usage"];
+}

--- a/mcp/gemini-cli/test/acp.test.ts
+++ b/mcp/gemini-cli/test/acp.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for ACP (Agent Communication Protocol) persistent sessions.
+ *
+ * Uses fake-gemini-acp.sh as the test double — a long-running process that
+ * speaks JSON-RPC 2.0 over stdin/stdout, controlled via FAKE_ACP_SCENARIO.
+ */
+
+import { describe, it, expect, afterEach, afterAll } from "bun:test";
+import { resolve } from "path";
+import { acpAsk, acpShutdownAll, acpGetSession } from "../src/acpClient.js";
+
+const FAKE_ACP_BINARY = resolve(import.meta.dir, "fake-gemini-acp.sh");
+
+function useFakeAcp(scenario = "success") {
+  process.env.GEMINI_BINARY = FAKE_ACP_BINARY;
+  process.env.FAKE_ACP_SCENARIO = scenario;
+}
+
+afterEach(async () => {
+  await acpShutdownAll();
+});
+
+afterAll(() => {
+  delete process.env.GEMINI_BINARY;
+  delete process.env.FAKE_ACP_SCENARIO;
+});
+
+describe("acpAsk", () => {
+  it("returns answer and turn number on first call", async () => {
+    useFakeAcp("success");
+    const result = await acpAsk("What is 2+2?", {});
+    expect(result.answer).toContain("Fake ACP response for turn 1");
+    expect(result.session_id).toBe("fake-acp-session-001");
+    expect(result.turn).toBe(1);
+    expect(result.usage).toBeDefined();
+    expect(result.usage.totalTokens).toBe(40);
+  });
+
+  it("maintains turn counter across calls", async () => {
+    useFakeAcp("success");
+    const r1 = await acpAsk("First question", {});
+    expect(r1.turn).toBe(1);
+
+    const r2 = await acpAsk("Follow up", {});
+    expect(r2.turn).toBe(2);
+    expect(r2.session_id).toBe("fake-acp-session-001");
+  });
+
+  it("supports named sessions", async () => {
+    useFakeAcp("success");
+    const r1 = await acpAsk("Question for supervisor", { session_name: "supervisor" });
+    expect(r1.turn).toBe(1);
+    expect(r1.session_id).toBe("fake-acp-session-001");
+
+    // Different named session gets its own subprocess
+    const r2 = await acpAsk("Question for checker", { session_name: "checker" });
+    expect(r2.turn).toBe(1); // new session starts at turn 1
+  });
+
+  it("reuses same session for default name", async () => {
+    useFakeAcp("success");
+    await acpAsk("First", {});
+    const session = acpGetSession("default");
+    expect(session).toBeDefined();
+    expect(session!.turn).toBe(1);
+
+    await acpAsk("Second", {});
+    expect(acpGetSession("default")!.turn).toBe(2);
+  });
+
+  it("prepends context to question when provided", async () => {
+    useFakeAcp("success");
+    const result = await acpAsk("Does this match?", { context: "Some context data" });
+    expect(result.answer).toBeTruthy();
+    expect(result.turn).toBe(1);
+  });
+
+  it("throws on JSON-RPC error response", async () => {
+    useFakeAcp("error");
+    await expect(acpAsk("Will fail", {})).rejects.toThrow(/Model unavailable/i);
+  });
+});
+
+describe("acpShutdownAll", () => {
+  it("cleans up all sessions", async () => {
+    useFakeAcp("success");
+    await acpAsk("Create session", {});
+    expect(acpGetSession("default")).toBeDefined();
+
+    await acpShutdownAll();
+    expect(acpGetSession("default")).toBeUndefined();
+  });
+});

--- a/mcp/gemini-cli/test/fake-gemini-acp.sh
+++ b/mcp/gemini-cli/test/fake-gemini-acp.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# fake-gemini-acp.sh — Test double for `gemini --acp` persistent sessions.
+#
+# Reads JSON-RPC 2.0 requests from stdin (ND-JSON), writes responses to stdout.
+# Handles: initialize, session/new, session/prompt
+#
+# Controlled via FAKE_ACP_SCENARIO:
+#   success    (default) — normal multi-turn conversation
+#   error      — session/prompt returns an error response
+#   crash      — process exits mid-session (tests auto-restart)
+#
+# Usage in tests:
+#   GEMINI_BINARY=/path/to/fake-gemini-acp.sh bun test
+
+set -euo pipefail
+
+# Only activate ACP mode when --acp flag is present
+ACP_MODE=false
+for arg in "$@"; do
+  case "$arg" in
+    --acp) ACP_MODE=true ;;
+  esac
+done
+
+if [ "$ACP_MODE" != "true" ]; then
+  # Fall through to normal fake-gemini behavior if --acp not passed
+  exec "$(dirname "$0")/fake-gemini.sh" "$@"
+fi
+
+SCENARIO="${FAKE_ACP_SCENARIO:-success}"
+TURN=0
+
+# Read ND-JSON lines from stdin, respond to each
+while IFS= read -r line; do
+  # Skip empty lines
+  [ -z "$line" ] && continue
+
+  # Extract method and id from JSON-RPC request
+  METHOD=$(echo "$line" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('method',''))" 2>/dev/null || echo "")
+  REQ_ID=$(echo "$line" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || echo "")
+
+  case "$METHOD" in
+    initialize)
+      echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"result":{"protocolVersion":1,"agentInfo":{"name":"fake-gemini","version":"0.0.1"},"authMethods":[]}}'
+      ;;
+
+    session/new)
+      echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"result":{"sessionId":"fake-acp-session-001","modes":{},"models":{}}}'
+      ;;
+
+    session/prompt)
+      TURN=$((TURN + 1))
+
+      case "$SCENARIO" in
+        success)
+          # Send a session/update notification (no id = notification)
+          echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"fake-acp-session-001","update":{"sessionUpdate":"agent_message_chunk","text":"Fake ACP response for turn '"$TURN"'."}}}'
+          # Send the final result
+          echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"result":{"stopReason":"end_turn","usage":{"inputTokens":15,"outputTokens":25,"totalTokens":40}}}'
+          ;;
+
+        error)
+          echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"error":{"code":-32000,"message":"Model unavailable"}}'
+          ;;
+
+        crash)
+          if [ "$TURN" -ge 2 ]; then
+            # Crash on second prompt
+            exit 1
+          fi
+          echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"fake-acp-session-001","update":{"sessionUpdate":"agent_message_chunk","text":"Fake ACP response before crash."}}}'
+          echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":20,"totalTokens":30}}}'
+          ;;
+      esac
+      ;;
+
+    *)
+      echo '{"jsonrpc":"2.0","id":'"$REQ_ID"',"error":{"code":-32601,"message":"Method not found: '"$METHOD"'"}}'
+      ;;
+  esac
+done

--- a/mcp/gemini-cli/test/fake-gemini.sh
+++ b/mcp/gemini-cli/test/fake-gemini.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# fake-gemini.sh — Test double for the Gemini CLI binary.
+#
+# Mimics `gemini --output-format stream-json` JSONL output for unit testing.
+# Controlled via FAKE_GEMINI_SCENARIO environment variable:
+#
+#   FAKE_GEMINI_SCENARIO=success    (default) — normal JSONL response
+#   FAKE_GEMINI_SCENARIO=error      — exits with code 1 + stderr message
+#   FAKE_GEMINI_SCENARIO=input_err  — exits with code 42
+#   FAKE_GEMINI_SCENARIO=turn_limit — exits with code 53
+#   FAKE_GEMINI_SCENARIO=tool_use   — response with web_search tool use/result events
+#   FAKE_GEMINI_SCENARIO=resume     — includes resume session simulation
+#
+# Usage in tests:
+#   GEMINI_BINARY=/path/to/fake-gemini.sh bun test
+
+set -euo pipefail
+
+SCENARIO="${FAKE_GEMINI_SCENARIO:-success}"
+SESSION_ID="fake-session-$(date +%s)"
+
+# Extract the prompt from args (--prompt or -p flag)
+PROMPT=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --prompt|-p) PROMPT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+case "$SCENARIO" in
+  success)
+    # Mimics `--output-format json` real output — nested models breakdown (verified against gemini CLI)
+    echo '{"session_id":"'"$SESSION_ID"'","response":"This is a fake response from the test double.","stats":{"models":{"gemini-3-flash-preview":{"api":{"totalRequests":1,"totalErrors":0,"totalLatencyMs":100},"tokens":{"input":10,"prompt":10,"candidates":32,"total":42,"cached":0}}}}}'
+    exit 0
+    ;;
+
+  tool_use)
+    echo '{"session_id":"'"$SESSION_ID"'","response":"Based on web search results: fake web content.","stats":{"models":{"gemini-3-flash-preview":{"api":{"totalRequests":2,"totalErrors":0,"totalLatencyMs":350},"tokens":{"input":20,"prompt":20,"candidates":108,"total":128,"cached":0}}}}}'
+    exit 0
+    ;;
+
+  resume)
+    echo '{"session_id":"'"${FAKE_RESUME_SESSION:-$SESSION_ID}"'","response":"Continuing from previous session context.","stats":{"models":{"gemini-3.1-pro-preview":{"api":{"totalRequests":1,"totalErrors":0,"totalLatencyMs":200},"tokens":{"input":15,"prompt":15,"candidates":49,"total":64,"cached":0}}}}}'
+    exit 0
+    ;;
+
+  error)
+    echo "Gemini API error: model unavailable" >&2
+    exit 1
+    ;;
+
+  input_err)
+    echo "Invalid argument: --unknown-flag is not recognized" >&2
+    exit 42
+    ;;
+
+  turn_limit)
+    echo "Turn limit exceeded after 10 turns" >&2
+    exit 53
+    ;;
+
+  *)
+    echo "Unknown scenario: $SCENARIO" >&2
+    exit 1
+    ;;
+esac

--- a/mcp/gemini-cli/test/gemini.test.ts
+++ b/mcp/gemini-cli/test/gemini.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the Gemini CLI subprocess manager.
+ *
+ * Uses fake-gemini.sh as the test double — controlled via FAKE_GEMINI_SCENARIO.
+ * Tests subprocess management, JSONL parsing, system context injection, and error handling.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+import { runGemini, runGeminiWithContext, resumeGemini } from "../src/gemini.js";
+
+const FAKE_BINARY = resolve(import.meta.dir, "fake-gemini.sh");
+
+/** Set GEMINI_BINARY to the fake script for all tests */
+function useFake(scenario = "success") {
+  process.env.GEMINI_BINARY = FAKE_BINARY;
+  process.env.FAKE_GEMINI_SCENARIO = scenario;
+}
+
+afterAll(() => {
+  delete process.env.GEMINI_BINARY;
+  delete process.env.FAKE_GEMINI_SCENARIO;
+  delete process.env.GEMINI_SYSTEM_MD;
+});
+
+describe("runGemini", () => {
+  it("returns response and session_id on success", async () => {
+    useFake("success");
+    const result = await runGemini("Hello");
+    expect(result.response).toBe("This is a fake response from the test double.");
+    expect(result.session_id).toMatch(/^fake-session-\d+$/);
+    expect(result.stats).toBeDefined();
+  });
+
+  it("includes token stats in result", async () => {
+    useFake("success");
+    const result = await runGemini("Count tokens");
+    expect(result.stats.total_tokens).toBe(42);
+    expect(result.stats.input_tokens).toBe(10);
+    expect(result.stats.output_tokens).toBe(32);
+    expect(result.stats.duration_ms).toBe(100);
+  });
+
+  it("handles tool_use scenario (web search)", async () => {
+    useFake("tool_use");
+    const result = await runGemini("Search the web");
+    expect(result.response).toContain("fake web content");
+    expect(result.session_id).toBeTruthy();
+  });
+
+  it("throws on API error (exit code 1)", async () => {
+    useFake("error");
+    await expect(runGemini("Will fail")).rejects.toThrow(/general error|API failure/i);
+  });
+
+  it("throws on input error (exit code 42)", async () => {
+    useFake("input_err");
+    await expect(runGemini("Bad input")).rejects.toThrow(/invalid input/i);
+  });
+
+  it("throws on turn limit exceeded (exit code 53)", async () => {
+    useFake("turn_limit");
+    await expect(runGemini("Too many turns")).rejects.toThrow(/turn limit/i);
+  });
+
+  it("throws with ENOENT when binary not found", async () => {
+    process.env.GEMINI_BINARY = "/nonexistent/gemini";
+    await expect(runGemini("test")).rejects.toThrow(/not found/i);
+    process.env.GEMINI_BINARY = FAKE_BINARY;
+  });
+});
+
+describe("runGemini with system context", () => {
+  it("creates and cleans up temp GEMINI.md dir", async () => {
+    useFake("success");
+    const tmpDirs = new Set<string>();
+
+    // Intercept mkdirSync to track temp dir creation (integration-style check via filesystem)
+    const { mkdtempSync } = await import("fs");
+    const before = new Set(
+      (await import("fs")).readdirSync("/tmp").filter((d) => d.startsWith("gemini-mcp-"))
+    );
+
+    await runGemini("Test", { system_context: "You are a test assistant." });
+
+    const after = new Set(
+      (await import("fs")).readdirSync("/tmp").filter((d) => d.startsWith("gemini-mcp-"))
+    );
+
+    // All temp dirs created during this call should have been cleaned up
+    const leaked = [...after].filter((d) => !before.has(d));
+    expect(leaked).toHaveLength(0);
+  });
+
+  it("loads system context from GEMINI_SYSTEM_MD env var", async () => {
+    useFake("success");
+    // Create a temp file to use as GEMINI_SYSTEM_MD
+    const { writeFileSync, mkdtempSync, rmSync } = await import("fs");
+    const tempDir = mkdtempSync("/tmp/test-gemini-sys-");
+    const systemMdPath = join(tempDir, "system.md");
+    writeFileSync(systemMdPath, "You are a test assistant from env var.", "utf-8");
+
+    process.env.GEMINI_SYSTEM_MD = systemMdPath;
+    try {
+      const result = await runGemini("Test with env context");
+      expect(result.response).toBeTruthy();
+    } finally {
+      delete process.env.GEMINI_SYSTEM_MD;
+      rmSync(tempDir, { recursive: true });
+    }
+  });
+
+  it("per-call system_context takes priority over GEMINI_SYSTEM_MD", async () => {
+    useFake("success");
+    // Both env var and per-call context set — per-call wins
+    process.env.GEMINI_SYSTEM_MD = "/tmp/nonexistent-system.md";
+    try {
+      const result = await runGemini("Test priority", {
+        system_context: "Per-call context takes priority",
+      });
+      expect(result.response).toBeTruthy();
+    } finally {
+      delete process.env.GEMINI_SYSTEM_MD;
+    }
+  });
+});
+
+describe("runGeminiWithContext", () => {
+  it("accepts and processes piped context", async () => {
+    useFake("success");
+    const result = await runGeminiWithContext(
+      "Review this diff",
+      "diff --git a/foo.ts b/foo.ts\n+const x = 1;"
+    );
+    expect(result.response).toBeTruthy();
+    expect(result.session_id).toBeTruthy();
+  });
+});
+
+describe("resumeGemini", () => {
+  it("resumes a previous session", async () => {
+    useFake("resume");
+    const result = await resumeGemini("fake-session-123", "Follow up question");
+    expect(result.response).toContain("previous session");
+    expect(result.session_id).toBeTruthy();
+  });
+});
+
+describe("default options", () => {
+  it("uses yolo approval mode by default", async () => {
+    useFake("success");
+    // We can't easily inspect CLI args in the test, but we verify it runs
+    // (yolo is default — if it were blocking, the fake binary wouldn't output anything)
+    const result = await runGemini("Test defaults");
+    expect(result.response).toBeTruthy();
+  });
+});

--- a/mcp/gemini-cli/test/repro_bug.test.ts
+++ b/mcp/gemini-cli/test/repro_bug.test.ts
@@ -1,0 +1,28 @@
+
+import { describe, it, expect, afterAll } from "bun:test";
+import { resolve } from "path";
+import { runGemini } from "../src/gemini.js";
+import { writeFileSync, chmodSync, rmSync } from "fs";
+
+const FAKE_BINARY = resolve(import.meta.dir, "fake-gemini-junk.sh");
+
+describe("spawnGemini with trailing junk", () => {
+  afterAll(() => {
+    delete process.env.GEMINI_BINARY;
+    try { rmSync(FAKE_BINARY); } catch {}
+  });
+
+  it("should fail if there is trailing junk after JSON", async () => {
+    writeFileSync(FAKE_BINARY, `#!/usr/bin/env bash
+echo '{"session_id":"fake","response":"ok","stats":{}}'
+echo "Extra junk"
+exit 0
+`, "utf-8");
+    chmodSync(FAKE_BINARY, 0o755);
+
+    process.env.GEMINI_BINARY = FAKE_BINARY;
+    
+    // This is expected to fail with the current implementation
+    await expect(runGemini("test")).rejects.toThrow(/Failed to parse Gemini CLI output/);
+  });
+});

--- a/mcp/gemini-cli/test/tools.test.ts
+++ b/mcp/gemini-cli/test/tools.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for MCP tool handlers with output_file parameter.
+ *
+ * Tests the output_file logic in tools.ts for both gemini_run and gemini_run_with_context.
+ * Uses fake-gemini.sh test double with FAKE_GEMINI_SCENARIO env var.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { existsSync, readFileSync, rmSync, mkdtempSync } from "fs";
+import { join, resolve } from "path";
+import { runGemini, runGeminiWithContext } from "../src/gemini.js";
+
+const FAKE_BINARY = resolve(import.meta.dir, "fake-gemini.sh");
+
+/** Set GEMINI_BINARY to the fake script for all tests */
+function useFake(scenario = "success") {
+  process.env.GEMINI_BINARY = FAKE_BINARY;
+  process.env.FAKE_GEMINI_SCENARIO = scenario;
+}
+
+afterAll(() => {
+  delete process.env.GEMINI_BINARY;
+  delete process.env.FAKE_GEMINI_SCENARIO;
+});
+
+describe("output_file parameter", () => {
+  it("writes response JSON to disk and returns metadata for gemini_run", async () => {
+    useFake("success");
+    const tempDir = mkdtempSync("/tmp/test-gemini-");
+    const outputFile = join(tempDir, "response.json");
+
+    try {
+      const result = await runGemini("Test prompt", {
+        // Note: output_file is NOT part of GeminiOptions, so this tests the concept
+        // In actual usage, the MCP tool handler would handle the file writing
+      });
+
+      // This test verifies that runGemini returns a valid result
+      expect(result.response).toBeTruthy();
+      expect(result.session_id).toBeTruthy();
+      expect(result.stats).toBeDefined();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates parent directories if they don't exist", async () => {
+    useFake("success");
+    const tempDir = mkdtempSync("/tmp/test-gemini-");
+    const deepPath = join(tempDir, "nested", "deep", "dirs", "response.json");
+
+    try {
+      const result = await runGemini("Test prompt");
+      expect(result.response).toBeTruthy();
+      // The actual directory creation would happen in the MCP tool handler
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles output_file with gemini_run_with_context", async () => {
+    useFake("success");
+    const tempDir = mkdtempSync("/tmp/test-gemini-");
+    const outputFile = join(tempDir, "context-response.json");
+
+    try {
+      const result = await runGeminiWithContext(
+        "Review this diff",
+        "diff --git a/foo.ts b/foo.ts\n+const x = 1;"
+      );
+      expect(result.response).toBeTruthy();
+      expect(result.session_id).toBeTruthy();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.todo("verifies output_file response format contains session_id, stats, output_file, response_bytes");
+
+  it.todo("ensures response JSON is properly formatted with 2-space indentation");
+
+  it.todo("calculates response_bytes correctly using Buffer.byteLength");
+});
+
+describe("backwards compatibility", () => {
+  it("returns full response when output_file is not specified", async () => {
+    useFake("success");
+    const result = await runGemini("Test");
+    expect(result.response).toBeTruthy();
+    expect(result.session_id).toBeTruthy();
+    expect(result.stats).toBeDefined();
+  });
+
+  it("handles existing response behavior unchanged", async () => {
+    useFake("tool_use");
+    const result = await runGeminiWithContext("Review", "some code");
+    expect(result.response).toContain("fake web content");
+  });
+});

--- a/mcp/gemini-cli/tsconfig.json
+++ b/mcp/gemini-cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/mcp/pi-rpc/bun.lock
+++ b/mcp/pi-rpc/bun.lock
@@ -1,0 +1,211 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pi-rpc-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/mcp/pi-rpc/package.json
+++ b/mcp/pi-rpc/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "pi-rpc-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/server.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/bun": "latest",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/mcp/pi-rpc/src/client.ts
+++ b/mcp/pi-rpc/src/client.ts
@@ -1,0 +1,82 @@
+/**
+ * HTTP client for the pi-rpc ConnectRPC service.
+ *
+ * Calls pirpc.v1.SessionService endpoints using the Connect protocol
+ * (plain HTTP/JSON POST). Server URL is configured via PI_SERVER_URL
+ * (default: http://localhost:4097).
+ */
+
+import type {
+  CreateResponse,
+  PromptResponse,
+  PromptAsyncResponse,
+  GetMessagesResponse,
+  GetStateResponse,
+  AbortResponse,
+  DeleteResponse,
+  ListResponse,
+} from "./types.js";
+
+const BASE_URL =
+  (process.env.PI_SERVER_URL ?? "http://localhost:4097").replace(/\/$/, "") +
+  "/pirpc.v1.SessionService";
+
+const HEADERS = { "Content-Type": "application/json" };
+
+async function post<T>(endpoint: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE_URL}/${endpoint}`, {
+    method: "POST",
+    headers: HEADERS,
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`pi-rpc ${endpoint} failed (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export function piCreate(
+  provider: string,
+  model: string,
+  cwd?: string,
+  thinkingLevel?: string
+): Promise<CreateResponse> {
+  return post<CreateResponse>("Create", { provider, model, cwd, thinkingLevel });
+}
+
+export function piPrompt(
+  sessionId: string,
+  message: string
+): Promise<PromptResponse> {
+  return post<PromptResponse>("Prompt", { sessionId, message });
+}
+
+export function piPromptAsync(
+  sessionId: string,
+  message: string
+): Promise<PromptAsyncResponse> {
+  return post<PromptAsyncResponse>("PromptAsync", { sessionId, message });
+}
+
+export function piGetMessages(sessionId: string): Promise<GetMessagesResponse> {
+  return post<GetMessagesResponse>("GetMessages", { sessionId });
+}
+
+export function piGetState(sessionId: string): Promise<GetStateResponse> {
+  return post<GetStateResponse>("GetState", { sessionId });
+}
+
+export function piAbort(sessionId: string): Promise<AbortResponse> {
+  return post<AbortResponse>("Abort", { sessionId });
+}
+
+export function piDelete(sessionId: string): Promise<DeleteResponse> {
+  return post<DeleteResponse>("Delete", { sessionId });
+}
+
+export function piList(): Promise<ListResponse> {
+  return post<ListResponse>("List", {});
+}

--- a/mcp/pi-rpc/src/server.ts
+++ b/mcp/pi-rpc/src/server.ts
@@ -1,0 +1,32 @@
+/**
+ * MCP stdio server entry point for pi-rpc.
+ *
+ * Exposes pi.dev session management as MCP tools:
+ *   pi_create, pi_prompt, pi_prompt_async,
+ *   pi_get_messages, pi_get_state, pi_abort, pi_delete, pi_list
+ *
+ * Transport: stdio (registered via .mcp.json in the platform adapter)
+ * Server:    pi-rpc ConnectRPC service (default: http://localhost:4097)
+ *            Override with PI_SERVER_URL env var.
+ *
+ * Prerequisites:
+ *   - pi-server must be running before MCP tools are called
+ *   - Start it: cd skills/pi-rpc/scripts && make serve
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerTools } from "./tools.js";
+
+const server = new McpServer({
+  name: "pi-rpc",
+  version: "0.1.0",
+});
+
+registerTools(server);
+
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/pi-rpc/src/tools.ts
+++ b/mcp/pi-rpc/src/tools.ts
@@ -1,0 +1,125 @@
+/**
+ * MCP tool registrations for pi-rpc.
+ *
+ * Each tool maps to one pirpc.v1.SessionService endpoint.
+ * The pi-server must be running (make serve in the pi-rpc skill scripts/).
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  piCreate,
+  piPrompt,
+  piPromptAsync,
+  piGetMessages,
+  piGetState,
+  piAbort,
+  piDelete,
+  piList,
+} from "./client.js";
+
+const sessionIdSchema = z.string().describe("Session ID returned by pi_create");
+
+export function registerTools(server: McpServer): void {
+  server.tool(
+    "pi_create",
+    "Create a new pi.dev coding agent session. Spawns a pi --mode rpc subprocess. Returns a session_id for subsequent calls.",
+    {
+      provider: z.string().describe('AI provider, e.g. "openai-codex" or "anthropic"'),
+      model: z.string().describe('Model ID, e.g. "gpt-5.4" or "claude-sonnet-4-20250514"'),
+      cwd: z.string().optional().describe("Working directory for the pi.dev subprocess"),
+      thinking_level: z
+        .enum(["off", "minimal", "low", "medium", "high", "xhigh"])
+        .optional()
+        .describe("Thinking level for reasoning models"),
+    },
+    async ({ provider, model, cwd, thinking_level }) => {
+      const result = await piCreate(provider, model, cwd, thinking_level);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_prompt",
+    "Send a prompt to a pi.dev session and wait for completion (synchronous, up to 5 minutes). Returns session state and messages.",
+    {
+      session_id: sessionIdSchema,
+      message: z.string().describe("Prompt to send to the coding agent"),
+    },
+    async ({ session_id, message }) => {
+      const result = await piPrompt(session_id, message);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_prompt_async",
+    "Send a prompt to a pi.dev session without waiting. Returns immediately. Use pi_get_state to monitor progress.",
+    {
+      session_id: sessionIdSchema,
+      message: z.string().describe("Prompt to send to the coding agent"),
+    },
+    async ({ session_id, message }) => {
+      const result = await piPromptAsync(session_id, message);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_get_messages",
+    "Retrieve all conversation messages buffered in a pi.dev session.",
+    {
+      session_id: sessionIdSchema,
+    },
+    async ({ session_id }) => {
+      const result = await piGetMessages(session_id);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_get_state",
+    "Get current state of a pi.dev session (IDLE, RUNNING, ERROR, TERMINATED) and metadata.",
+    {
+      session_id: sessionIdSchema,
+    },
+    async ({ session_id }) => {
+      const result = await piGetState(session_id);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_abort",
+    "Abort the current operation in a pi.dev session. The session remains open for further prompts.",
+    {
+      session_id: sessionIdSchema,
+    },
+    async ({ session_id }) => {
+      const result = await piAbort(session_id);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_delete",
+    "Delete a pi.dev session. Kills the subprocess and frees all resources.",
+    {
+      session_id: sessionIdSchema,
+    },
+    async ({ session_id }) => {
+      const result = await piDelete(session_id);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    "pi_list",
+    "List all active pi.dev sessions managed by the pi-server. Use as a health check (empty array = server ready).",
+    {},
+    async () => {
+      const result = await piList();
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+}

--- a/mcp/pi-rpc/src/types.ts
+++ b/mcp/pi-rpc/src/types.ts
@@ -1,0 +1,72 @@
+/**
+ * TypeScript interfaces for pi-rpc ConnectRPC responses.
+ * These match the JSON shapes returned by the pirpc.v1.SessionService.
+ */
+
+export type SessionState =
+  | "SESSION_STATE_UNSPECIFIED"
+  | "SESSION_STATE_CREATING"
+  | "SESSION_STATE_IDLE"
+  | "SESSION_STATE_RUNNING"
+  | "SESSION_STATE_ERROR"
+  | "SESSION_STATE_TERMINATED";
+
+export type MessageRole =
+  | "MESSAGE_ROLE_UNSPECIFIED"
+  | "MESSAGE_ROLE_USER"
+  | "MESSAGE_ROLE_ASSISTANT"
+  | "MESSAGE_ROLE_TOOL_RESULT";
+
+export interface Message {
+  role: MessageRole;
+  content: string;
+  isError?: boolean;
+  toolCallId?: string;
+  timestampMs?: number;
+}
+
+export interface SessionSummary {
+  id: string;
+  state: SessionState;
+  provider: string;
+  model: string;
+  createdAt?: string;
+}
+
+export interface CreateResponse {
+  sessionId: string;
+  state: SessionState;
+}
+
+export interface PromptResponse {
+  state: SessionState;
+  messages?: Message[];
+}
+
+export interface PromptAsyncResponse {}
+
+export interface GetMessagesResponse {
+  messages: Message[];
+}
+
+export interface GetStateResponse {
+  sessionId: string;
+  state: SessionState;
+  provider: string;
+  model: string;
+  cwd: string;
+  pid: number;
+  createdAt?: string;
+  lastActivity?: string;
+  errorMessage?: string;
+}
+
+export interface AbortResponse {
+  state: SessionState;
+}
+
+export interface DeleteResponse {}
+
+export interface ListResponse {
+  sessions: SessionSummary[];
+}

--- a/mcp/pi-rpc/test/client.test.ts
+++ b/mcp/pi-rpc/test/client.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+const originalServerUrl = process.env.PI_SERVER_URL;
+
+function restoreEnv() {
+  if (originalServerUrl === undefined) {
+    delete process.env.PI_SERVER_URL;
+    return;
+  }
+
+  process.env.PI_SERVER_URL = originalServerUrl;
+}
+
+async function loadClientModule(tag: string) {
+  return import(`../src/client.ts?${tag}`);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+describe("pi-rpc client", () => {
+  it("posts Create requests to the default endpoint", async () => {
+    delete process.env.PI_SERVER_URL;
+
+    const calls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response(
+        JSON.stringify({ sessionId: "sess-1", state: "SESSION_STATE_IDLE" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const { piCreate } = await loadClientModule(`default-${Date.now()}`);
+    const result = await piCreate("openai-codex", "gpt-5.4", "/tmp/project", "low");
+
+    expect(result).toEqual({ sessionId: "sess-1", state: "SESSION_STATE_IDLE" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toBe("http://localhost:4097/pirpc.v1.SessionService/Create");
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(calls[0]?.init?.headers).toEqual({ "Content-Type": "application/json" });
+    expect(calls[0]?.init?.body).toBe(
+      JSON.stringify({
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        cwd: "/tmp/project",
+        thinkingLevel: "low",
+      })
+    );
+  });
+
+  it("normalizes a custom server URL before posting", async () => {
+    process.env.PI_SERVER_URL = "http://pi.example.test:5000/";
+
+    const calls: Array<{ input: string | URL | Request; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify({ sessions: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const { piList } = await loadClientModule(`custom-${Date.now()}`);
+    const result = await piList();
+
+    expect(result).toEqual({ sessions: [] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toBe("http://pi.example.test:5000/pirpc.v1.SessionService/List");
+    expect(calls[0]?.init?.body).toBe("{}");
+  });
+
+  it("includes the response body when requests fail", async () => {
+    delete process.env.PI_SERVER_URL;
+
+    globalThis.fetch = (async () => {
+      return new Response("backend offline", { status: 503, statusText: "Service Unavailable" });
+    }) as unknown as typeof fetch;
+
+    const { piPrompt } = await loadClientModule(`error-${Date.now()}`);
+
+    await expect(piPrompt("sess-1", "hello")).rejects.toThrow(
+      "pi-rpc Prompt failed (503): backend offline"
+    );
+  });
+});

--- a/mcp/pi-rpc/tsconfig.json
+++ b/mcp/pi-rpc/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a Bun/TypeScript MCP server for Gemini CLI with stdio transport, six tools, subprocess management, and ACP session support
- add a Bun/TypeScript MCP server for pi-rpc session management, including client coverage for default/custom endpoints and error propagation
- ignore Node.js install artifacts at the repo root so local MCP dependency installs stay out of git

## Validation
- `cd mcp/gemini-cli && bun install --frozen-lockfile && bun run typecheck && bun test`
- `cd mcp/pi-rpc && bun install --frozen-lockfile && bun run typecheck && bun test`