### PR TITLE
chore: bump all versions to v0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent extensions — curated skill bundles for Claude Code",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,49 +14,49 @@
       "name": "swe",
       "source": "./plugins/swe",
       "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["go", "tdd", "ci-cd", "security"]
     },
     {
       "name": "infra",
       "source": "./plugins/infra",
       "description": "Infrastructure — Ansible, git hooks, analytical databases",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["ansible", "git-hooks", "starrocks"]
     },
     {
       "name": "dataops",
       "source": "./plugins/dataops",
       "description": "Data operations — CSV, Excel, PDF, Word, design documents",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["csv", "excel", "pdf", "docx"]
     },
     {
       "name": "informatics",
       "source": "./plugins/informatics",
       "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["r", "shiny", "quarto", "cran", "tidyverse"]
     },
     {
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
       "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["agents", "dispatch", "claude-code", "jules", "lychee", "writerside"]
     },
     {
       "name": "meta",
       "source": "./plugins/meta",
       "description": "Meta — skill review and issue reporting for skill quality",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["skills", "review", "quality"]
     },
     {
       "name": "hooks",
       "source": "./plugins/hooks",
       "description": "Hooks — forced skill evaluation when prompts mention skills",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "keywords": ["hooks", "skills", "evaluation"]
     }
   ]

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "nq-rdl-agent-extensions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Curated agent skills — SWE, infrastructure, data ops, R/informatics, developer tools, and meta",
   "contextFileName": "GEMINI.md"
 }

--- a/mcp/gemini-cli/package.json
+++ b/mcp/gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-cli-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp/pi-rpc/package.json
+++ b/mcp/pi-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-rpc-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pidev/package.json
+++ b/pidev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nq-rdl/agent-extensions",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Curated agent skills — SWE, infrastructure, data ops, R/informatics, developer tools, and meta",
   "keywords": ["pi-package"],
   "license": "MIT",

--- a/plugins/dataops/.claude-plugin/plugin.json
+++ b/plugins/dataops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataops",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Data operations — CSV, Excel, PDF, Word, design documents",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/plugins/dev-tools/.claude-plugin/plugin.json
+++ b/plugins/dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/plugins/informatics/.claude-plugin/plugin.json
+++ b/plugins/informatics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "informatics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/plugins/infra/.claude-plugin/plugin.json
+++ b/plugins/infra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Infrastructure — Ansible, git hooks, analytical databases",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Meta — skill review and issue reporting for skill quality",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/plugins/swe/.claude-plugin/plugin.json
+++ b/plugins/swe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
   "author": { "name": "nq-rdl" },
   "repository": "https://github.com/nq-rdl/agent-extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = [{name = "Rudolf J", email = "r.schnetler@uq.edu.au"}]
 dependencies = []
 name = "agent-extensions"
 requires-python = ">= 3.11"
-version = "0.1.0"
+version = "0.1.1"
 
 [build-system]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0` to `0.1.1` across all 12 version-managed files

### Files updated
- `pyproject.toml`
- `.claude-plugin/marketplace.json` (metadata + all 7 plugin entries)
- `gemini-extension.json`
- `mcp/pi-rpc/package.json`
- `mcp/gemini-cli/package.json`
- `pidev/package.json`
- 6x `plugins/*/. claude-plugin/plugin.json`

## Test plan
- [x] No `0.1.0` version strings remain in any JSON or TOML file