### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.changes/unreleased/Changed-20260416-sync-skills-v030.yaml
+++ b/.changes/unreleased/Changed-20260416-sync-skills-v030.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: "Sync skills from agent-skills@v0.3.0 — adds argo-cd, conventional-commits, stitch-design-md, sops, zod, obsidian, and pre-commit skills; completes RST migration for all references"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent extensions — curated skill bundles for Claude Code",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "swe",
       "source": "./plugins/swe",
       "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "go",
         "tdd",
@@ -26,7 +26,7 @@
       "name": "infra",
       "source": "./plugins/infra",
       "description": "Infrastructure — Ansible, git hooks, analytical databases",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "ansible",
         "git-hooks",
@@ -37,7 +37,7 @@
       "name": "dataops",
       "source": "./plugins/dataops",
       "description": "Data operations — CSV, Excel, PDF, Word, design documents",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "csv",
         "excel",
@@ -49,7 +49,7 @@
       "name": "informatics",
       "source": "./plugins/informatics",
       "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "r",
         "shiny",
@@ -62,7 +62,7 @@
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
       "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "agents",
         "dispatch",
@@ -76,7 +76,7 @@
       "name": "meta",
       "source": "./plugins/meta",
       "description": "Meta — skill review and issue reporting for skill quality",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "skills",
         "review",
@@ -87,7 +87,7 @@
       "name": "hooks",
       "source": "./plugins/hooks",
       "description": "Hooks — forced skill evaluation when prompts mention skills",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "keywords": [
         "hooks",
         "skills",

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to sync from (e.g. v0.2.1). Leave empty for latest."
+        description: "Release tag to sync from (e.g. v0.3.0). Leave empty for latest."
         required: false
 
 permissions:

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "rdl",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Curated agent skills — SWE, infrastructure, data ops, R/informatics, developer tools, and meta",
   "contextFileName": "GEMINI.md"
 }

--- a/mcp/gemini-cli/package.json
+++ b/mcp/gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-cli-mcp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/mcp/pi-rpc/package.json
+++ b/mcp/pi-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-rpc-mcp",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pidev/package.json
+++ b/pidev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nq-rdl/agent-extensions",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Curated agent skills — SWE, infrastructure, data ops, R/informatics, developer tools, and meta",
   "keywords": [
     "pi-package"

--- a/plugins/dataops/.claude-plugin/plugin.json
+++ b/plugins/dataops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataops",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Data operations — CSV, Excel, PDF, Word, design documents",
   "author": {
     "name": "nq-rdl"

--- a/plugins/dev-tools/.claude-plugin/plugin.json
+++ b/plugins/dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tools",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
   "author": {
     "name": "nq-rdl"

--- a/plugins/hooks/.claude-plugin/plugin.json
+++ b/plugins/hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Hooks — forced skill evaluation when prompts mention skills",
   "author": {
     "name": "nq-rdl"

--- a/plugins/informatics/.claude-plugin/plugin.json
+++ b/plugins/informatics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "informatics",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
   "author": {
     "name": "nq-rdl"

--- a/plugins/infra/.claude-plugin/plugin.json
+++ b/plugins/infra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infra",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Infrastructure — Ansible, git hooks, analytical databases",
   "author": {
     "name": "nq-rdl"

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Meta — skill review and issue reporting for skill quality",
   "author": {
     "name": "nq-rdl"

--- a/plugins/swe/.claude-plugin/plugin.json
+++ b/plugins/swe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swe",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
   "author": {
     "name": "nq-rdl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ authors = [{name = "Rudolf J", email = "r.schnetler@uq.edu.au"}]
 dependencies = []
 name = "agent-extensions"
 requires-python = ">= 3.11"
-version = "0.2.1"
+version = "0.3.0"
 
 [build-system]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Release v0.3.0

Bumps agent-extensions to v0.3.0 to align with agent-skills@v0.3.0.

### Changes

- Bump version from `0.2.1` to `0.3.0` across all manifests (pyproject.toml, plugin.json, package.json, marketplace.json, gemini-extension.json)
- Add changie fragment for skills sync from agent-skills@v0.3.0
- Update sync-skills workflow example tag

### Skills synced from agent-skills@v0.3.0

- New `argo-cd` skill
- New `conventional-commits` skill
- New `stitch-design-md` skill
- New `sops` skill
- New `zod` skill
- New `obsidian` skills (defuddle, json-canvas, obsidian-bases, obsidian-cli, obsidian-markdown)
- New `pre-commit` skill
- RST migration completed for all skill references
- Speckit integration scaffolding for Claude, Gemini, and OpenCode
