### PR TITLE
chore: add changie fragment for v0.3.1 skills sync

### DIFF
--- a/.changes/unreleased/Changed-20260417-sync-skills-v031.yaml
+++ b/.changes/unreleased/Changed-20260417-sync-skills-v031.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Sync skills from agent-skills@v0.3.1 — audit-driven fixes across 26 skills for RST link rot, hook events, and metadata
+time: 2026-04-17T10:59:36.77048068+10:00

--- a/.changes/unreleased/Fixed-20260417-sync-skills-v031.yaml
+++ b/.changes/unreleased/Fixed-20260417-sync-skills-v031.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Sync skills from `agent-skills@v0.3.1` — audit-driven fixes across 26 skills for RST link rot, hook events, and metadata
+time: 2026-04-17T10:59:36.77048068+10:00

--- a/.changes/unreleased/Fixed-20260417-sync-skills-v031.yaml
+++ b/.changes/unreleased/Fixed-20260417-sync-skills-v031.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Sync skills from `agent-skills@v0.3.1` — audit-driven fixes across 26 skills for RST link rot, hook events, and metadata
-time: 2026-04-17T10:59:36.77048068+10:00


### PR DESCRIPTION
The `v0.3.1` tag was already pushed but the [Release workflow failed](https://github.com/nq-rdl/agent-extensions/actions/runs/24542069527) at the "Check for unreleased changes" step:

```
No unreleased changelog entries found. Nothing to release.
```

Root cause: the `sync-skills` workflow in #38 merged the upstream `agent-skills@v0.3.1` skills but did not add a changie fragment, so `.changes/unreleased/` was empty when the tag triggered the release job.

This PR adds the missing fragment. After merge, the plan is:
1. Delete the failed `v0.3.1` tag locally + remotely
2. Re-tag the new merge commit as `v0.3.1` and push
3. Release workflow picks it up, batches the fragment, bumps manifests to `0.3.1`, commits `chore: release v0.3.1`, moves the tag to include that commit, and creates the GitHub release

Fragment content mirrors the [upstream `agent-skills@v0.3.1` release notes](https://github.com/nq-rdl/agent-skills/releases/tag/v0.3.1).