### PR TITLE
feat: add changie-fragment-lint PreToolUse hook (closes #40)

### DIFF
--- a/.changes/unreleased/Added-20260419-changie-fragment-lint-hook.yaml
+++ b/.changes/unreleased/Added-20260419-changie-fragment-lint-hook.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Adds changie-fragment-lint PreToolUse hook — blocks fusion and missing flag, warns on word count (#40)
+time: 2026-04-19T08:16:45.257126828+10:00

--- a/hooks/changie-fragment-lint.json
+++ b/hooks/changie-fragment-lint.json
@@ -1,0 +1,17 @@
+{
+  "description": "Lint changie new commands — blocks fusion (Rule #1), missing --interactive=false, and word-count violations (Rule #2). Warns on trailing period (Rule #7) and invalid --kind. Set CHANGIE_LINT_STRICT=1 to promote word-count warnings to blocks.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash hooks/changie-fragment-lint.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/changie-fragment-lint.sh
+++ b/hooks/changie-fragment-lint.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# changie-fragment-lint.sh — PreToolUse hook for Bash tool calls.
+#
+# Lints `changie new` commands before execution.
+# Rules enforced:
+#   BLOCK  — Rule #1 fusion:   body contains fusion markers (also fixes, and also, additionally, , also)
+#   BLOCK  — Missing --interactive=false flag
+#   BLOCK  — Word count >20 when CHANGIE_LINT_STRICT=1
+#   WARN   — Word count >20 (default — warns but allows)
+#   WARN   — Rule #7 trailing single period
+#   WARN   — --kind not in the six capitalised values
+#
+# Skips:
+#   - Commands that are not `changie new`
+#   - changie batch, changie merge, changie --help
+#   - Repo root has .changie/.no-lint
+
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+[[ -z "$COMMAND" ]] && exit 0
+
+# Skip if not a changie new invocation
+if ! printf '%s' "$COMMAND" | grep -qE '(^|[;|&]\s*)changie\s+new\b'; then
+  exit 0
+fi
+
+# Skip changie batch, merge, --help explicitly
+if printf '%s' "$COMMAND" | grep -qE 'changie\s+(batch|merge)\b|changie\s+--help'; then
+  exit 0
+fi
+
+# Per-repo opt-out
+if [[ -f ".changie/.no-lint" ]]; then
+  exit 0
+fi
+
+# ── Extract --body value ────────────────────────────────────────────────────
+# Handles double-quoted, single-quoted, and $'...' body values
+# || true guards prevent set -e from exiting on no-match grep returns
+BODY=""
+if printf '%s' "$COMMAND" | grep -qP -- "--body\s+['\"]"; then
+  BODY=$(printf '%s' "$COMMAND" | grep -oP "(?<=--body\s')[^']*(?=')" | head -1 || true)
+  if [[ -z "$BODY" ]]; then
+    BODY=$(printf '%s' "$COMMAND" | grep -oP '(?<=--body\s")[^"]*(?=")' | head -1 || true)
+  fi
+fi
+
+# ── Extract --kind value ────────────────────────────────────────────────────
+KIND=$(printf '%s' "$COMMAND" | grep -oP '(?<=--kind\s)\S+' | head -1 || true)
+
+VALID_KINDS="Added Changed Deprecated Removed Fixed Security"
+WARNINGS=""
+BLOCK_REASON=""
+
+# ── Rule: missing --interactive=false ──────────────────────────────────────
+if ! printf '%s' "$COMMAND" | grep -q -- '--interactive=false'; then
+  BLOCK_REASON="changie-fragment-lint: missing --interactive=false — changie opens a TUI that agents cannot interact with"
+fi
+
+# ── Rule #1: fusion markers ─────────────────────────────────────────────────
+if [[ -z "$BLOCK_REASON" && -n "$BODY" ]]; then
+  BODY_LOWER=$(printf '%s' "$BODY" | tr '[:upper:]' '[:lower:]')
+  if printf '%s' "$BODY_LOWER" | grep -qE '\balso fixes\b|\band also\b|\badditionally\b|,\s*also\s'; then
+    BLOCK_REASON="changie-fragment-lint: Rule #1 — body contains a fusion marker ('also fixes', 'and also', 'additionally', or ', also'). Split into two separate changie new calls."
+  fi
+fi
+
+if [[ -n "$BLOCK_REASON" ]]; then
+  printf '{"decision":"block","reason":"%s"}' \
+    "$(printf '%s' "$BLOCK_REASON" | sed 's/"/\\"/g')"
+  exit 0
+fi
+
+# ── Rule #2: word count ─────────────────────────────────────────────────────
+if [[ -n "$BODY" ]]; then
+  BODY_NO_REF=$(printf '%s' "$BODY" | sed 's/(#[0-9]\+)[[:space:]]*$//')
+  WORD_COUNT=$(printf '%s' "$BODY_NO_REF" | wc -w)
+  if [[ "$WORD_COUNT" -gt 20 ]]; then
+    if [[ "${CHANGIE_LINT_STRICT:-0}" == "1" ]]; then
+      printf '{"decision":"block","reason":"changie-fragment-lint: Rule #2 — body is %d words (limit 20, excluding issue ref). Count words and trim before continuing."}' \
+        "$WORD_COUNT"
+      exit 0
+    else
+      WARNINGS="${WARNINGS}[WARN] changie-fragment-lint: body is ${WORD_COUNT} words — Rule #2 limit is 20 (excluding issue ref); consider trimming\\n"
+    fi
+  fi
+fi
+
+# ── Rule #7: trailing period ────────────────────────────────────────────────
+if [[ -n "$BODY" ]]; then
+  # Allow ellipsis (..) but not a single trailing period
+  if printf '%s' "$BODY" | grep -qP '\.[^.]\s*$' || \
+     { printf '%s' "$BODY" | grep -qP '\.$' && ! printf '%s' "$BODY" | grep -qP '\.\.\s*$'; }; then
+    WARNINGS="${WARNINGS}[WARN] changie-fragment-lint: Rule #7 — body ends with a period; entries render as bullet items, not sentences\\n"
+  fi
+fi
+
+# ── Kind validation ─────────────────────────────────────────────────────────
+if [[ -n "$KIND" ]]; then
+  if ! printf '%s' "$VALID_KINDS" | grep -qw "$KIND"; then
+    WARNINGS="${WARNINGS}[WARN] changie-fragment-lint: --kind '${KIND}' is not one of the six capitalised values (Added, Changed, Deprecated, Removed, Fixed, Security)\\n"
+  fi
+fi
+
+# ── Emit warnings ──────────────────────────────────────────────────────────
+if [[ -n "$WARNINGS" ]]; then
+  printf '{"context":"%s"}' \
+    "$(printf '%s' "$WARNINGS" | sed 's/"/\\"/g' | tr -d '\n')"
+fi
+
+exit 0

--- a/hooks/changie-fragment-lint.sh
+++ b/hooks/changie-fragment-lint.sh
@@ -41,15 +41,15 @@ fi
 # Handles double-quoted, single-quoted, and $'...' body values
 # || true guards prevent set -e from exiting on no-match grep returns
 BODY=""
-if printf '%s' "$COMMAND" | grep -qP -- "--body\s+['\"]"; then
-  BODY=$(printf '%s' "$COMMAND" | grep -oP "(?<=--body\s')[^']*(?=')" | head -1 || true)
+if printf '%s' "$COMMAND" | grep -qP -- "--body[= ]['\"]"; then
+  BODY=$(printf '%s' "$COMMAND" | grep -oP "(?<=--body[= ]')[^']*(?=')" | head -1 || true)
   if [[ -z "$BODY" ]]; then
-    BODY=$(printf '%s' "$COMMAND" | grep -oP '(?<=--body\s")[^"]*(?=")' | head -1 || true)
+    BODY=$(printf '%s' "$COMMAND" | grep -oP '(?<=--body[= ]")[^"]*(?=")' | head -1 || true)
   fi
 fi
 
 # ── Extract --kind value ────────────────────────────────────────────────────
-KIND=$(printf '%s' "$COMMAND" | grep -oP '(?<=--kind\s)\S+' | head -1 || true)
+KIND=$(printf '%s' "$COMMAND" | grep -oP '(?<=--kind[= ])\S+' | head -1 || true)
 
 VALID_KINDS="Added Changed Deprecated Removed Fixed Security"
 WARNINGS=""
@@ -63,14 +63,13 @@ fi
 # ── Rule #1: fusion markers ─────────────────────────────────────────────────
 if [[ -z "$BLOCK_REASON" && -n "$BODY" ]]; then
   BODY_LOWER=$(printf '%s' "$BODY" | tr '[:upper:]' '[:lower:]')
-  if printf '%s' "$BODY_LOWER" | grep -qE '\balso fixes\b|\band also\b|\badditionally\b|,\s*also\s'; then
+  if printf '%s' "$BODY_LOWER" | grep -qE '\balso fixes\b|\band also\b|\badditionally\b|,\s*also\b'; then
     BLOCK_REASON="changie-fragment-lint: Rule #1 — body contains a fusion marker ('also fixes', 'and also', 'additionally', or ', also'). Split into two separate changie new calls."
   fi
 fi
 
 if [[ -n "$BLOCK_REASON" ]]; then
-  printf '{"decision":"block","reason":"%s"}' \
-    "$(printf '%s' "$BLOCK_REASON" | sed 's/"/\\"/g')"
+  jq -n --arg reason "$BLOCK_REASON" '{decision: "block", reason: $reason}'
   exit 0
 fi
 
@@ -91,9 +90,8 @@ fi
 
 # ── Rule #7: trailing period ────────────────────────────────────────────────
 if [[ -n "$BODY" ]]; then
-  # Allow ellipsis (..) but not a single trailing period
-  if printf '%s' "$BODY" | grep -qP '\.[^.]\s*$' || \
-     { printf '%s' "$BODY" | grep -qP '\.$' && ! printf '%s' "$BODY" | grep -qP '\.\.\s*$'; }; then
+  # Allow ellipsis but not a single trailing period (negative lookbehind for prior dot)
+  if printf '%s' "$BODY" | grep -qP '(?<!\.)\.\s*$'; then
     WARNINGS="${WARNINGS}[WARN] changie-fragment-lint: Rule #7 — body ends with a period; entries render as bullet items, not sentences\\n"
   fi
 fi
@@ -107,8 +105,7 @@ fi
 
 # ── Emit warnings ──────────────────────────────────────────────────────────
 if [[ -n "$WARNINGS" ]]; then
-  printf '{"context":"%s"}' \
-    "$(printf '%s' "$WARNINGS" | sed 's/"/\\"/g' | tr -d '\n')"
+  jq -n --arg context "$(printf '%s' "$WARNINGS" | tr -d '\n')" '{context: $context}'
 fi
 
 exit 0


### PR DESCRIPTION
Companion hook to `nq-rdl/agent-skills#64` — enforces changie writing rules at execution time before the Bash tool runs `changie new`.

## What it does

A `PreToolUse` hook that intercepts every `Bash` tool call, detects `changie new` invocations, and lints the command against the changie skill's rules.

### Rules enforced

| Severity | Rule | Trigger |
|----------|------|---------|
| **BLOCK** | Rule #1 fusion | body contains `also fixes`, `and also`, `additionally`, or `, also` |
| **BLOCK** | Missing `--interactive=false` | flag absent — changie opens a TUI agents cannot interact with |
| **BLOCK** (strict) | Rule #2 word count | body >20 words with `CHANGIE_LINT_STRICT=1` |
| WARN | Rule #2 word count | body >20 words (default mode) |
| WARN | Rule #7 trailing period | body ends with single `.` (not `..` or `...`) |
| WARN | Invalid `--kind` | value not in `Added/Changed/Deprecated/Removed/Fixed/Security` |

### Skips
- `changie batch`, `changie merge`, `changie --help`
- Any repo with `.changie/.no-lint` in its root

## New files

- `hooks/changie-fragment-lint.sh` — bash hook script (reads stdin JSON, emits `decision` or `context`)
- `hooks/changie-fragment-lint.json` — hook definition for `.claude/settings.json`

## Configuration

```json
// Merge into .claude/settings.json:
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash",
        "hooks": [{ "type": "command", "command": "bash hooks/changie-fragment-lint.sh", "timeout": 5 }]
      }
    ]
  }
}
```

Set `CHANGIE_LINT_STRICT=1` in your environment to promote word-count warnings to hard blocks.

Closes #40