### PR TITLE
feat(marketplace): add worktrunk plugin (external)

### DIFF
--- a/.changes/unreleased/Added-20260419-102256.yaml
+++ b/.changes/unreleased/Added-20260419-102256.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add worktrunk plugin — external reference to max-sixty/worktrunk (git worktree CLI for parallel AI agent workflows)
+time: 2026-04-19T10:22:56.577448236+10:00

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,6 +93,21 @@
         "skills",
         "evaluation"
       ]
+    },
+    {
+      "name": "worktrunk",
+      "source": {
+        "source": "github",
+        "repo": "max-sixty/worktrunk"
+      },
+      "description": "Git worktree CLI for parallel AI agent workflows — config guidance and automatic Claude session tracking",
+      "version": "1.0.0",
+      "keywords": [
+        "git",
+        "worktree",
+        "agents",
+        "workflow"
+      ]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,7 +100,7 @@
         "source": "github",
         "repo": "max-sixty/worktrunk"
       },
-      "description": "Git worktree CLI for parallel AI agent workflows — config guidance and automatic Claude session tracking",
+      "description": "Developer tools — Git worktree CLI for parallel AI agent workflows, config guidance, and automatic Claude session tracking",
       "version": "1.0.0",
       "keywords": [
         "git",


### PR DESCRIPTION
## Summary

Registers [**worktrunk**](https://github.com/max-sixty/worktrunk) (`max-sixty/worktrunk`) as an external plugin in the `rdl` marketplace. Worktrunk is a CLI for Git worktree management designed for parallel AI agent workflows, offering config guidance (LLM commit messages, project hooks, worktree paths) and automatic activity tracking (🤖/💬 indicators in `wt list` showing active Claude sessions).

## Changes

- **`.claude-plugin/marketplace.json`** — new plugin entry with `source: { source: "github", repo: "max-sixty/worktrunk" }`, version `1.0.0`
- **`.changes/unreleased/Added-*.yaml`** — changie fragment (kind: Added)

## Notes

This is the **first external-source plugin** in this marketplace; every existing entry ships locally via `./plugins/`. The Claude Code marketplace schema supports both forms — local path string or a provider object — so the installer fetches worktrunk from its upstream repo on install while other rdl plugins continue to be served inline.

No changes to `plugins/`, so `scripts/validate-plugin-hooks.sh` pre-commit does not trigger. Downstream users install via:

```
/plugin install worktrunk@rdl
```

## References

- Upstream: https://github.com/max-sixty/worktrunk
- Landing: https://worktrunk.dev/claude-code/