### PR TITLE
Add Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,80 @@
+{
+  "name": "rdl",
+  "interface": {
+    "displayName": "RDL Agent Extensions"
+  },
+  "plugins": [
+    {
+      "name": "swe",
+      "source": {
+        "source": "local",
+        "path": "./plugins/swe"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "infra",
+      "source": {
+        "source": "local",
+        "path": "./plugins/infra"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "dataops",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dataops"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "informatics",
+      "source": {
+        "source": "local",
+        "path": "./plugins/informatics"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "dev-tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dev-tools"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "meta",
+      "source": {
+        "source": "local",
+        "path": "./plugins/meta"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.changes/unreleased/Added-20260422-codex-marketplace.yaml
+++ b/.changes/unreleased/Added-20260422-codex-marketplace.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add native Codex marketplace and plugin manifests for the `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta` bundles
+time: 2026-04-22T12:00:00+10:00

--- a/.changes/unreleased/Changed-20260422-codex-packaging-docs.yaml
+++ b/.changes/unreleased/Changed-20260422-codex-packaging-docs.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Document Codex packaging and install flow, and extend validation and release versioning to cover Codex plugin manifests
+time: 2026-04-22T12:00:01+10:00

--- a/.changes/unreleased/add-codex-support.md
+++ b/.changes/unreleased/add-codex-support.md
@@ -1,0 +1,7 @@
+### Added
+
+* Add native Codex marketplace and plugin manifests for the `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta` bundles
+
+### Changed
+
+* Document Codex packaging and install flow, and extend validation and release versioning to cover Codex plugin manifests

--- a/.changes/unreleased/add-codex-support.md
+++ b/.changes/unreleased/add-codex-support.md
@@ -1,7 +1,0 @@
-### Added
-
-* Add native Codex marketplace and plugin manifests for the `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta` bundles
-
-### Changed
-
-* Document Codex packaging and install flow, and extend validation and release versioning to cover Codex plugin manifests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
           set -euo pipefail
 
           # --- Claude marketplace: metadata.version and plugin entry versions ---
+          # The Codex marketplace at .agents/plugins/marketplace.json has no
+          # versioned fields today, so it's intentionally not touched here.
+          # Version stamping for Codex happens via plugins/*/.codex-plugin/plugin.json
+          # in the generic JSON loop below.
           if [ -f .claude-plugin/marketplace.json ]; then
             jq --arg v "$VERSION" '
               if .metadata?.version then .metadata.version = $v else . end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,22 +69,29 @@ jobs:
         run: |
           set -euo pipefail
 
-          # --- JSON files: update "version" fields via jq ---
+          # --- Claude marketplace: metadata.version and plugin entry versions ---
+          if [ -f .claude-plugin/marketplace.json ]; then
+            jq --arg v "$VERSION" '
+              if .metadata?.version then .metadata.version = $v else . end
+              | if .plugins then .plugins |= map(.version = $v) else . end
+            ' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
+            mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+            echo "  ✓ .claude-plugin/marketplace.json"
+          fi
+
+          # --- JSON files with a top-level version field ---
           json_files=(
-            .claude-plugin/marketplace.json
             gemini-extension.json
             pidev/package.json
           )
-          for f in plugins/*/.claude-plugin/plugin.json; do
-            json_files+=("$f")
+          for f in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json; do
+            [ -f "$f" ] && json_files+=("$f")
           done
 
           for f in "${json_files[@]}"; do
             if [ -f "$f" ]; then
               jq --arg v "$VERSION" '
                 if .version then .version = $v else . end
-                | if .metadata?.version then .metadata.version = $v else . end
-                | if .plugins then .plugins |= map(.version = $v) else . end
               ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
               echo "  ✓ $f"
             fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,7 +80,7 @@ jobs:
           exit $exit_code
 
   validate-plugins:
-    name: Validate Claude Code plugin structure
+    name: Validate plugin manifests and hooks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
   - repo: local
     hooks:
       - id: validate-plugins
-        name: Validate Claude Code plugins
+        name: Validate Claude and Codex plugins
         entry: scripts/validate-plugin-hooks.sh
         language: script
-        files: ^plugins/
+        files: ^(plugins/|\.agents/plugins/)
         pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Agent Extensions
 
+Curated reusable agent skills and integrations published in host-native formats. Shared skills live in the `skills/` submodule; host-specific packaging for Claude Code, Codex, Gemini CLI, `pi.dev`, and OpenCode lives in this repository.
+
 ## Installation
+
+### Codex
+
+Codex uses a native repo marketplace at `.agents/plugins/marketplace.json` plus bundle-local `.codex-plugin/plugin.json` manifests.
+
+```bash
+git clone git@github.com:nq-rdl/agent-extensions.git
+cd agent-extensions
+git submodule update --init
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+Install the bundles you want from the `RDL Agent Extensions` marketplace: `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta`.
+
+Codex hooks do not package the same way as Claude hooks. Codex discovers hooks from `<repo>/.codex/hooks.json` or `~/.codex/hooks.json`, so the Claude-only `hooks` bundle is not exposed in the Codex marketplace.
+
+See [`docs/codex.md`](docs/codex.md) for the Codex packaging model and bundle layout.
 
 ### Claude Code
 
@@ -20,6 +41,6 @@ gemini extensions add nq-rdl/agent-extensions
 
 See [`docs/local-testing.md`](docs/local-testing.md) for local/devcontainer install.
 
-3. `pi.dev` and OpenCode
+### `pi.dev` and OpenCode
 
-_TBA._ 
+_TBA._

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -4,7 +4,7 @@ icon: lucide/package
 
 # Bundles
 
-Available skill bundles distributed as Claude Code plugins and a Gemini CLI extension.
+Available skill bundles distributed as Claude Code plugins, Codex plugins, and a Gemini CLI extension.
 
 ## Install
 
@@ -19,6 +19,20 @@ Skills are distributed as 6 separate plugin bundles. Install the bundles you nee
 # Install a bundle
 /plugin install <bundle>@rdl
 ```
+
+### Codex
+
+Supported bundles are distributed as native Codex plugins:
+
+```bash
+# From a cloned copy of this repo
+git submodule update --init
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+The Codex marketplace currently exposes `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta`. The Claude-only `hooks` bundle is not listed because Codex hooks live in repo or user `.codex/hooks.json` files rather than inside plugins.
 
 ### Gemini CLI
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -41,6 +41,8 @@ plugins/
 
 4. **Bundled MCP** lives at the plugin root. `plugins/dev-tools/.mcp.json` exposes the prebuilt `pi-rpc` and `gemini-cli` MCP launchers through the same wrapper scripts already shipped for Claude.
 
+    Claude and Codex each read a different file — Claude uses `plugins/dev-tools/.claude-plugin/.mcp.json` with `${CLAUDE_PLUGIN_ROOT}/scripts/...` paths, Codex uses `plugins/dev-tools/.mcp.json` with `./scripts/...` paths. When adding or changing MCP servers for this bundle, update both files together.
+
 5. **Hooks are different in Codex.** Codex discovers hooks from `<repo>/.codex/hooks.json` or `~/.codex/hooks.json`, behind `features.codex_hooks = true`. Hooks are not packaged as plugin components, so the Claude-specific `hooks` bundle is intentionally not exposed in the Codex marketplace.
 
 Codex can also read a Claude-style marketplace at `.claude-plugin/marketplace.json`, but this repo ships a native Codex marketplace so the plugin directory only shows the bundles Codex can actually install.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,79 @@
+---
+icon: lucide/blocks
+---
+
+# Codex
+
+How agent-extensions packages skills and MCP integrations for Codex as native plugins.
+
+## Architecture
+
+Codex uses a **marketplace -> plugin -> skills** model that is close to Claude Code, but with native marketplace metadata at `.agents/plugins/marketplace.json`:
+
+```text
+.agents/
+  plugins/
+    marketplace.json        <- Codex marketplace manifest (repo root)
+
+plugins/
+  swe/
+    .codex-plugin/
+      plugin.json           <- plugin manifest
+    skills/
+      tdd -> ../../../skills/tdd
+      go-secure -> ../../../skills/go-secure
+  dev-tools/
+    .codex-plugin/
+      plugin.json
+    .mcp.json               <- bundled MCP server config
+    scripts/
+      run-pi-rpc-mcp.sh
+      run-gemini-cli-mcp.sh
+```
+
+## How it works
+
+1. **Marketplace manifest** (`.agents/plugins/marketplace.json`) defines the `rdl` marketplace and the six Codex-installable bundles: `swe`, `infra`, `dataops`, `informatics`, `dev-tools`, and `meta`.
+
+2. **Plugin manifests** (`plugins/<bundle>/.codex-plugin/plugin.json`) declare bundle metadata and point Codex at `./skills/`. The `dev-tools` bundle also points at `./.mcp.json`.
+
+3. **Skill symlinks** (`plugins/<bundle>/skills/<name>`) reuse the shared `skills/` submodule. Each entry is a relative symlink back to `../../../skills/<name>`.
+
+4. **Bundled MCP** lives at the plugin root. `plugins/dev-tools/.mcp.json` exposes the prebuilt `pi-rpc` and `gemini-cli` MCP launchers through the same wrapper scripts already shipped for Claude.
+
+5. **Hooks are different in Codex.** Codex discovers hooks from `<repo>/.codex/hooks.json` or `~/.codex/hooks.json`, behind `features.codex_hooks = true`. Hooks are not packaged as plugin components, so the Claude-specific `hooks` bundle is intentionally not exposed in the Codex marketplace.
+
+Codex can also read a Claude-style marketplace at `.claude-plugin/marketplace.json`, but this repo ships a native Codex marketplace so the plugin directory only shows the bundles Codex can actually install.
+
+## Install
+
+### Local development
+
+```bash
+git clone git@github.com:nq-rdl/agent-extensions.git
+cd agent-extensions
+git submodule update --init
+codex plugin marketplace add .
+codex
+/plugins
+```
+
+Install the bundles you want from the `RDL Agent Extensions` marketplace, then start a new thread and ask Codex to use them. You can also mention a plugin with `@` or a bundled skill with `$`.
+
+### Remote marketplace
+
+Codex also supports Git-backed marketplace sources:
+
+```bash
+codex plugin marketplace add owner/repo
+codex plugin marketplace add owner/repo --ref main
+```
+
+For this repository, a local checkout is the safest path while the shared `skills/` content continues to live in the git submodule.
+
+## Validation
+
+```bash
+# Validate Claude and Codex plugin manifests plus Claude hook configs
+bash scripts/validate-plugin-hooks.sh
+```

--- a/plugins/dataops/.codex-plugin/plugin.json
+++ b/plugins/dataops/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "dataops",
+  "version": "0.4.0",
+  "description": "Data operations workflows for CSV, Excel, PDF, Word, and design documents.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "dataops",
+    "csv",
+    "pdf"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "DataOps",
+    "shortDescription": "CSV, Excel, PDF, and DOCX",
+    "longDescription": "Reusable data operations workflows for extraction sheets, spreadsheets, PDFs, Word documents, and design artifacts.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use DataOps to update this CSV extraction sheet.",
+      "Use DataOps to extract tables from this PDF.",
+      "Use DataOps to fix this Excel workbook."
+    ]
+  }
+}

--- a/plugins/dev-tools/.codex-plugin/plugin.json
+++ b/plugins/dev-tools/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "dev-tools",
+  "version": "0.4.0",
+  "description": "Developer tool workflows plus bundled MCP servers for dispatch and cross-agent integrations.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "mcp",
+    "dispatch",
+    "tooling"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Dev Tools",
+    "shortDescription": "Dispatch, docs, and MCP servers",
+    "longDescription": "Reusable developer tooling workflows for agent dispatch, documentation, and bundled MCP-backed integrations.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Integrations"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use Dev Tools to fan this task out to another agent.",
+      "Use Dev Tools to run the bundled pi-rpc MCP server.",
+      "Use Dev Tools to update docs after this release."
+    ]
+  }
+}

--- a/plugins/dev-tools/.mcp.json
+++ b/plugins/dev-tools/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "pi-rpc": {
+      "command": "./scripts/run-pi-rpc-mcp.sh",
+      "env": {
+        "PI_SERVER_URL": "http://localhost:4097"
+      }
+    },
+    "gemini-cli": {
+      "command": "./scripts/run-gemini-cli-mcp.sh"
+    }
+  }
+}

--- a/plugins/informatics/.codex-plugin/plugin.json
+++ b/plugins/informatics/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "informatics",
+  "version": "0.4.0",
+  "description": "R ecosystem workflows for package development, Shiny, Quarto, testing, and CRAN.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "informatics",
+    "r",
+    "quarto"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Informatics",
+    "shortDescription": "R, Shiny, Quarto, and CRAN",
+    "longDescription": "Reusable R ecosystem workflows for package development, Shiny apps, Quarto authoring, testing, and CRAN preparation.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use Informatics to review this R package structure.",
+      "Use Informatics to improve this Shiny app.",
+      "Use Informatics to prepare this package for CRAN checks."
+    ]
+  }
+}

--- a/plugins/infra/.codex-plugin/plugin.json
+++ b/plugins/infra/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "infra",
+  "version": "0.4.0",
+  "description": "Infrastructure workflows for Ansible, git hooks, and analytical databases.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "infra",
+    "ansible",
+    "databases"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Infra",
+    "shortDescription": "Ansible, hooks, and databases",
+    "longDescription": "Reusable infrastructure workflows for Ansible, git hook tooling, and analytical database operations.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use Infra to debug this Ansible role.",
+      "Use Infra to set up git hooks for this repository.",
+      "Use Infra to review this StarRocks table design."
+    ]
+  }
+}

--- a/plugins/meta/.codex-plugin/plugin.json
+++ b/plugins/meta/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "meta",
+  "version": "0.4.0",
+  "description": "Meta workflows for reviewing skill quality and reporting problems back upstream.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "review",
+    "meta",
+    "quality"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Meta",
+    "shortDescription": "Skill review and issue reporting",
+    "longDescription": "Reusable workflows for reviewing skill quality, identifying gaps, and reporting issues back to the skills repository.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use Meta to review this skill before release.",
+      "Use Meta to write an upstream skill issue report.",
+      "Use Meta to audit this skill description for trigger quality."
+    ]
+  }
+}

--- a/plugins/swe/.codex-plugin/plugin.json
+++ b/plugins/swe/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "swe",
+  "version": "0.4.0",
+  "description": "Software engineering workflows for TDD, secure Go, naming, CI/CD, and changelogs.",
+  "author": {
+    "name": "nq-rdl",
+    "email": "r.schnetler@uq.edu.au",
+    "url": "https://github.com/nq-rdl"
+  },
+  "homepage": "https://github.com/nq-rdl/agent-extensions",
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT",
+  "keywords": [
+    "agents",
+    "skills",
+    "swe",
+    "go",
+    "tdd"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SWE",
+    "shortDescription": "TDD, Go, CI/CD, and changelogs",
+    "longDescription": "Reusable software engineering workflows for test-driven development, secure Go, naming, CI/CD, and changelog work.",
+    "developerName": "nq-rdl",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nq-rdl/agent-extensions",
+    "defaultPrompt": [
+      "Use SWE to drive a TDD change in this repo.",
+      "Use SWE to review this Go package for secure error handling.",
+      "Use SWE to add a changie entry for this change."
+    ]
+  }
+}

--- a/registry/bundles/dataops.yaml
+++ b/registry/bundles/dataops.yaml
@@ -20,6 +20,10 @@ targets:
     enabled: true
     pluginName: dataops
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: dataops
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/dev-tools.yaml
+++ b/registry/bundles/dev-tools.yaml
@@ -26,6 +26,10 @@ targets:
     enabled: true
     pluginName: dev-tools
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: dev-tools
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/hooks.yaml
+++ b/registry/bundles/hooks.yaml
@@ -16,6 +16,8 @@ targets:
     enabled: true
     pluginName: hooks
     marketplaceName: rdl
+  codex:
+    enabled: false
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/informatics.yaml
+++ b/registry/bundles/informatics.yaml
@@ -27,6 +27,10 @@ targets:
     enabled: true
     pluginName: informatics
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: informatics
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/infra.yaml
+++ b/registry/bundles/infra.yaml
@@ -19,6 +19,10 @@ targets:
     enabled: true
     pluginName: infra
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: infra
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/meta.yaml
+++ b/registry/bundles/meta.yaml
@@ -17,6 +17,10 @@ targets:
     enabled: true
     pluginName: meta
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: meta
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/registry/bundles/swe.yaml
+++ b/registry/bundles/swe.yaml
@@ -23,6 +23,10 @@ targets:
     enabled: true
     pluginName: swe
     marketplaceName: rdl
+  codex:
+    enabled: true
+    pluginName: swe
+    marketplaceName: rdl
   gemini:
     enabled: false
   pidev:

--- a/scripts/validate-plugin-hooks.sh
+++ b/scripts/validate-plugin-hooks.sh
@@ -170,6 +170,14 @@ else
 fi
 
 if [ ${#plugins[@]} -eq 0 ]; then
+  # Still validate the Codex marketplace even when no plugin dirs are in scope
+  # (e.g. targeted run against only .agents/plugins/marketplace.json).
+  validate_codex_marketplace
+  if [ $errors -gt 0 ]; then
+    echo ""
+    echo "Plugin validation failed with $errors error(s)"
+    exit 1
+  fi
   echo "No plugins to validate"
   exit 0
 fi
@@ -185,12 +193,23 @@ for plugin_rel in "${plugins[@]}"; do
   echo "Validating $plugin_rel"
 
   # ── plugin manifests ─────────────────────────────────────────────────────
-  if [ -f "$claude_plugin_json" ]; then
-    validate_manifest_json "$claude_plugin_json" "claude" "$plugin_dir"
+  # If the host subdirectory exists, its plugin.json must exist too — catches
+  # partial scaffolds where someone created .claude-plugin/ (or .codex-plugin/)
+  # without the manifest file inside it.
+  if [ -d "$plugin_dir/.claude-plugin" ]; then
+    if [ -f "$claude_plugin_json" ]; then
+      validate_manifest_json "$claude_plugin_json" "claude" "$plugin_dir"
+    else
+      error "$plugin_rel" "Missing .claude-plugin/plugin.json"
+    fi
   fi
 
-  if [ -f "$codex_plugin_json" ]; then
-    validate_manifest_json "$codex_plugin_json" "codex" "$plugin_dir"
+  if [ -d "$plugin_dir/.codex-plugin" ]; then
+    if [ -f "$codex_plugin_json" ]; then
+      validate_manifest_json "$codex_plugin_json" "codex" "$plugin_dir"
+    else
+      error "$plugin_rel" "Missing .codex-plugin/plugin.json"
+    fi
   fi
 
   # ── hooks.json (optional — only validate if present) ─────────────────────

--- a/scripts/validate-plugin-hooks.sh
+++ b/scripts/validate-plugin-hooks.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
-# Validate Claude Code plugin hooks.json files.
+# Validate Claude and Codex plugin manifests plus Claude hook configs.
 #
 # Checks:
-#   1. All hooks.json files are valid JSON
-#   2. Each event maps to an array of rule groups
-#   3. Each rule group has a "hooks" array (not bare hook objects)
-#   4. Each hook entry has required "type" and "command" fields
-#   5. Event names are from the known set
-#   6. Scripts referenced via ${CLAUDE_PLUGIN_ROOT} exist relative to plugin root
-#   7. plugin.json is valid JSON with required "name" and "description" fields
+#   1. Claude and Codex plugin manifests are valid JSON
+#   2. Each manifest has required "name" and "description" fields
+#   3. Codex manifest component paths are ./-prefixed and resolve within the plugin
+#   4. Codex marketplace metadata is valid JSON and points at existing plugin dirs
+#   5. Claude hooks.json files are valid JSON
+#   6. Each Claude hook event maps to an array of rule groups
+#   7. Each Claude rule group has a "hooks" array (not bare hook objects)
+#   8. Each Claude hook entry has required "type" and "command" fields
+#   9. Claude hook event names are from the known set
+#  10. Scripts referenced via ${CLAUDE_PLUGIN_ROOT} exist relative to plugin root
 #
 # Usage:
 #   validate-plugin-hooks.sh                   # validate all plugins
@@ -50,6 +53,99 @@ warn() {
   echo "::warning file=$1::$2" >&2
 }
 
+validate_manifest_json() {
+  local manifest_json="$1"
+  local manifest_kind="$2"
+  local plugin_dir="$3"
+
+  if ! jq empty "$manifest_json" 2>/dev/null; then
+    error "$manifest_json" "Invalid JSON in $(basename "$manifest_json")"
+    return
+  fi
+
+  local name desc
+  name=$(jq -r '.name // empty' "$manifest_json")
+  desc=$(jq -r '.description // empty' "$manifest_json")
+  [ -z "$name" ] && error "$manifest_json" "$(basename "$manifest_json") missing required 'name' field"
+  [ -z "$desc" ] && error "$manifest_json" "$(basename "$manifest_json") missing required 'description' field"
+
+  if [ "$manifest_kind" != "codex" ]; then
+    return
+  fi
+
+  local field rel_path prompt_count
+  for field in skills mcpServers apps; do
+    rel_path=$(jq -r --arg field "$field" '.[$field] // empty' "$manifest_json")
+    [ -z "$rel_path" ] && continue
+
+    if [[ "$rel_path" != ./* ]]; then
+      error "$manifest_json" "Field '$field' must be a relative path starting with './'"
+      continue
+    fi
+
+    if [ ! -e "$plugin_dir/${rel_path#./}" ]; then
+      error "$manifest_json" "Field '$field' points to a missing path: $rel_path"
+    fi
+  done
+
+  prompt_count=$(jq '(.interface.defaultPrompt // []) | length' "$manifest_json")
+  if [ "$prompt_count" -gt 3 ]; then
+    error "$manifest_json" "interface.defaultPrompt may contain at most 3 entries"
+  fi
+}
+
+validate_codex_marketplace() {
+  local marketplace_json="$REPO_ROOT/.agents/plugins/marketplace.json"
+  [ -f "$marketplace_json" ] || return
+
+  echo "Validating .agents/plugins/marketplace.json"
+
+  if ! jq empty "$marketplace_json" 2>/dev/null; then
+    error "$marketplace_json" "Invalid JSON in marketplace.json"
+    return
+  fi
+
+  local name is_array count entry_name source_path install_policy auth_policy category
+  name=$(jq -r '.name // empty' "$marketplace_json")
+  [ -z "$name" ] && error "$marketplace_json" "marketplace.json missing required 'name' field"
+
+  is_array=$(jq '.plugins | type == "array"' "$marketplace_json")
+  if [ "$is_array" != "true" ]; then
+    error "$marketplace_json" "marketplace.json field 'plugins' must be an array"
+    return
+  fi
+
+  count=$(jq '.plugins | length' "$marketplace_json")
+  for ((i = 0; i < count; i++)); do
+    entry_name=$(jq -r --argjson i "$i" '.plugins[$i].name // empty' "$marketplace_json")
+    source_path=$(jq -r --argjson i "$i" '
+      if (.plugins[$i].source | type) == "object" then
+        .plugins[$i].source.path // empty
+      else
+        .plugins[$i].source // empty
+      end
+    ' "$marketplace_json")
+    install_policy=$(jq -r --argjson i "$i" '.plugins[$i].policy.installation // empty' "$marketplace_json")
+    auth_policy=$(jq -r --argjson i "$i" '.plugins[$i].policy.authentication // empty' "$marketplace_json")
+    category=$(jq -r --argjson i "$i" '.plugins[$i].category // empty' "$marketplace_json")
+
+    [ -z "$entry_name" ] && error "$marketplace_json" "plugins[$i] missing required 'name' field"
+    [ -z "$source_path" ] && error "$marketplace_json" "plugins[$i] missing required source path"
+    [ -z "$install_policy" ] && error "$marketplace_json" "plugins[$i] missing policy.installation"
+    [ -z "$auth_policy" ] && error "$marketplace_json" "plugins[$i] missing policy.authentication"
+    [ -z "$category" ] && error "$marketplace_json" "plugins[$i] missing category"
+
+    if [[ -n "$source_path" && "$source_path" != ./* ]]; then
+      error "$marketplace_json" "plugins[$i] source.path must start with './': $source_path"
+      continue
+    fi
+
+    if [[ -n "$source_path" && ! -e "$REPO_ROOT/${source_path#./}" ]]; then
+      error "$marketplace_json" "plugins[$i] source.path does not exist: $source_path"
+    fi
+  done
+}
+
 # ── Determine which plugins to validate ─────────────────────────────────────
 if [ $# -gt 0 ]; then
   # Extract unique plugin dirs from changed file paths
@@ -67,7 +163,9 @@ else
   # Validate all plugins
   plugins=()
   for d in "$REPO_ROOT"/plugins/*/; do
-    [ -d "$d/.claude-plugin" ] && plugins+=("plugins/$(basename "$d")")
+    if [ -d "$d/.claude-plugin" ] || [ -d "$d/.codex-plugin" ]; then
+      plugins+=("plugins/$(basename "$d")")
+    fi
   done
 fi
 
@@ -79,120 +177,116 @@ fi
 # ── Validate each plugin ────────────────────────────────────────────────────
 for plugin_rel in "${plugins[@]}"; do
   plugin_dir="$REPO_ROOT/$plugin_rel"
-  plugin_json="$plugin_dir/.claude-plugin/plugin.json"
+  claude_plugin_json="$plugin_dir/.claude-plugin/plugin.json"
+  codex_plugin_json="$plugin_dir/.codex-plugin/plugin.json"
   hooks_json="$plugin_dir/hooks/hooks.json"
 
   plugin_errors=0
   echo "Validating $plugin_rel"
 
-  # ── plugin.json ──────────────────────────────────────────────────────────
-  if [ ! -f "$plugin_json" ]; then
-    error "$plugin_rel" "Missing .claude-plugin/plugin.json"
-    continue
+  # ── plugin manifests ─────────────────────────────────────────────────────
+  if [ -f "$claude_plugin_json" ]; then
+    validate_manifest_json "$claude_plugin_json" "claude" "$plugin_dir"
   fi
 
-  if ! jq empty "$plugin_json" 2>/dev/null; then
-    error "$plugin_json" "Invalid JSON in plugin.json"
-    continue
+  if [ -f "$codex_plugin_json" ]; then
+    validate_manifest_json "$codex_plugin_json" "codex" "$plugin_dir"
   fi
-
-  name=$(jq -r '.name // empty' "$plugin_json")
-  desc=$(jq -r '.description // empty' "$plugin_json")
-  [ -z "$name" ] && error "$plugin_json" "plugin.json missing required 'name' field"
-  [ -z "$desc" ] && error "$plugin_json" "plugin.json missing required 'description' field"
 
   # ── hooks.json (optional — only validate if present) ─────────────────────
-  [ -f "$hooks_json" ] || continue
-
-  if ! jq empty "$hooks_json" 2>/dev/null; then
-    error "$hooks_json" "Invalid JSON in hooks.json"
-    continue
-  fi
-
-  # Check top-level has "hooks" object
-  has_hooks=$(jq 'has("hooks")' "$hooks_json")
-  if [ "$has_hooks" != "true" ]; then
-    error "$hooks_json" "hooks.json must have a top-level 'hooks' object"
-    continue
-  fi
-
-  # Validate each event
-  events=$(jq -r '.hooks | keys[]' "$hooks_json")
-  for event in $events; do
-    # Check event name is known
-    known=false
-    for ke in "${KNOWN_EVENTS[@]}"; do
-      [ "$event" = "$ke" ] && known=true && break
-    done
-    $known || warn "$hooks_json" "Unknown hook event '$event' — check spelling"
-
-    # Each event must map to an array
-    is_array=$(jq --arg e "$event" '.hooks[$e] | type == "array"' "$hooks_json")
-    if [ "$is_array" != "true" ]; then
-      error "$hooks_json" "Event '$event' must map to an array of rule groups"
+  if [ -f "$hooks_json" ]; then
+    if ! jq empty "$hooks_json" 2>/dev/null; then
+      error "$hooks_json" "Invalid JSON in hooks.json"
       continue
     fi
 
-    # Each rule group must have a "hooks" array
-    group_count=$(jq --arg e "$event" '.hooks[$e] | length' "$hooks_json")
-    for ((i = 0; i < group_count; i++)); do
-      has_inner=$(jq --arg e "$event" --argjson i "$i" \
-        '.hooks[$e][$i] | has("hooks")' "$hooks_json")
+    # Check top-level has "hooks" object
+    has_hooks=$(jq 'has("hooks")' "$hooks_json")
+    if [ "$has_hooks" != "true" ]; then
+      error "$hooks_json" "hooks.json must have a top-level 'hooks' object"
+      continue
+    fi
 
-      if [ "$has_inner" != "true" ]; then
-        # Check if user accidentally put hook fields at rule-group level
-        has_type=$(jq --arg e "$event" --argjson i "$i" \
-          '.hooks[$e][$i] | has("type")' "$hooks_json")
-        if [ "$has_type" = "true" ]; then
-          error "$hooks_json" \
-            "Event '$event' group[$i]: hook definition placed directly in rule group. " \
-            "Wrap it: { \"hooks\": [{ \"type\": ..., \"command\": ... }] }"
-        else
-          error "$hooks_json" \
-            "Event '$event' group[$i]: missing required 'hooks' array"
-        fi
+    # Validate each event
+    events=$(jq -r '.hooks | keys[]' "$hooks_json")
+    for event in $events; do
+      # Check event name is known
+      known=false
+      for ke in "${KNOWN_EVENTS[@]}"; do
+        [ "$event" = "$ke" ] && known=true && break
+      done
+      $known || warn "$hooks_json" "Unknown hook event '$event' — check spelling"
+
+      # Each event must map to an array
+      is_array=$(jq --arg e "$event" '.hooks[$e] | type == "array"' "$hooks_json")
+      if [ "$is_array" != "true" ]; then
+        error "$hooks_json" "Event '$event' must map to an array of rule groups"
         continue
       fi
 
-      # Validate each hook entry inside the rule group
-      hook_count=$(jq --arg e "$event" --argjson i "$i" \
-        '.hooks[$e][$i].hooks | length' "$hooks_json")
-      for ((j = 0; j < hook_count; j++)); do
-        hook_type=$(jq -r --arg e "$event" --argjson i "$i" --argjson j "$j" \
-          '.hooks[$e][$i].hooks[$j].type // empty' "$hooks_json")
-        hook_cmd=$(jq -r --arg e "$event" --argjson i "$i" --argjson j "$j" \
-          '.hooks[$e][$i].hooks[$j].command // empty' "$hooks_json")
+      # Each rule group must have a "hooks" array
+      group_count=$(jq --arg e "$event" '.hooks[$e] | length' "$hooks_json")
+      for ((i = 0; i < group_count; i++)); do
+        has_inner=$(jq --arg e "$event" --argjson i "$i" \
+          '.hooks[$e][$i] | has("hooks")' "$hooks_json")
 
-        [ -z "$hook_type" ] && \
-          error "$hooks_json" "Event '$event' group[$i] hook[$j]: missing 'type' field"
-        [ -z "$hook_cmd" ] && \
-          error "$hooks_json" "Event '$event' group[$i] hook[$j]: missing 'command' field"
-
-        # If command references ${CLAUDE_PLUGIN_ROOT}, check the script exists
-        if [[ "$hook_cmd" == *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
-          rel_script="${hook_cmd/\$\{CLAUDE_PLUGIN_ROOT\}/}"
-          rel_script="${rel_script#/}"
-          # Strip any prefix command (e.g. "bash ", "python3 ")
-          rel_script="${rel_script#bash }"
-          rel_script="${rel_script#python3 }"
-          # Remove surrounding quotes
-          rel_script="${rel_script#\"}"
-          rel_script="${rel_script%\"}"
-          abs_script="$plugin_dir/$rel_script"
-          if [ ! -f "$abs_script" ]; then
+        if [ "$has_inner" != "true" ]; then
+          # Check if user accidentally put hook fields at rule-group level
+          has_type=$(jq --arg e "$event" --argjson i "$i" \
+            '.hooks[$e][$i] | has("type")' "$hooks_json")
+          if [ "$has_type" = "true" ]; then
             error "$hooks_json" \
-              "Event '$event' group[$i] hook[$j]: script not found: $rel_script"
-          elif [ ! -x "$abs_script" ] && [[ "$hook_cmd" != *python3* ]] && [[ "$hook_cmd" != *bash* ]]; then
-            warn "$hooks_json" \
-              "Event '$event' group[$i] hook[$j]: script not executable: $rel_script"
+              "Event '$event' group[$i]: hook definition placed directly in rule group. " \
+              "Wrap it: { \"hooks\": [{ \"type\": ..., \"command\": ... }] }"
+          else
+            error "$hooks_json" \
+              "Event '$event' group[$i]: missing required 'hooks' array"
           fi
+          continue
         fi
+
+        # Validate each hook entry inside the rule group
+        hook_count=$(jq --arg e "$event" --argjson i "$i" \
+          '.hooks[$e][$i].hooks | length' "$hooks_json")
+        for ((j = 0; j < hook_count; j++)); do
+          hook_type=$(jq -r --arg e "$event" --argjson i "$i" --argjson j "$j" \
+            '.hooks[$e][$i].hooks[$j].type // empty' "$hooks_json")
+          hook_cmd=$(jq -r --arg e "$event" --argjson i "$i" --argjson j "$j" \
+            '.hooks[$e][$i].hooks[$j].command // empty' "$hooks_json")
+
+          [ -z "$hook_type" ] && \
+            error "$hooks_json" "Event '$event' group[$i] hook[$j]: missing 'type' field"
+          [ -z "$hook_cmd" ] && \
+            error "$hooks_json" "Event '$event' group[$i] hook[$j]: missing 'command' field"
+
+          # If command references ${CLAUDE_PLUGIN_ROOT}, check the script exists
+          if [[ "$hook_cmd" == *'${CLAUDE_PLUGIN_ROOT}'* ]]; then
+            rel_script="${hook_cmd/\$\{CLAUDE_PLUGIN_ROOT\}/}"
+            rel_script="${rel_script#/}"
+            # Strip any prefix command (e.g. "bash ", "python3 ")
+            rel_script="${rel_script#bash }"
+            rel_script="${rel_script#python3 }"
+            # Remove surrounding quotes
+            rel_script="${rel_script#\"}"
+            rel_script="${rel_script%\"}"
+            abs_script="$plugin_dir/$rel_script"
+            if [ ! -f "$abs_script" ]; then
+              error "$hooks_json" \
+                "Event '$event' group[$i] hook[$j]: script not found: $rel_script"
+            elif [ ! -x "$abs_script" ] && [[ "$hook_cmd" != *python3* ]] && [[ "$hook_cmd" != *bash* ]]; then
+              warn "$hooks_json" \
+                "Event '$event' group[$i] hook[$j]: script not executable: $rel_script"
+            fi
+          fi
+        done
       done
     done
-  done
+  fi
 
   [ "$plugin_errors" -eq 0 ] && echo "  OK"
 done
+
+validate_codex_marketplace
 
 if [ $errors -gt 0 ]; then
   echo ""


### PR DESCRIPTION
## Summary
- add native Codex marketplace metadata at .agents/plugins/marketplace.json
- add .codex-plugin manifests for the installable bundles and bundle the dev-tools MCP config
- document the Codex install flow, mark Codex targets in the registry, and extend validation/release versioning for Codex manifests

## Testing
- bash scripts/validate-plugin-hooks.sh
- bash -n scripts/validate-plugin-hooks.sh
- jq empty .agents/plugins/marketplace.json plugins/{swe,infra,dataops,informatics,dev-tools,meta}/.codex-plugin/plugin.json plugins/dev-tools/.mcp.json