### PR TITLE
fix: address PR 58 review nits (agents, versions, validator, MCP pin)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Agent extensions — curated skill bundles for Claude Code",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -14,7 +14,7 @@
       "name": "swe",
       "source": "./plugins/swe",
       "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "go",
         "tdd",
@@ -26,7 +26,7 @@
       "name": "infra",
       "source": "./plugins/infra",
       "description": "Infrastructure — Ansible, git hooks, analytical databases",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "ansible",
         "git-hooks",
@@ -37,7 +37,7 @@
       "name": "dataops",
       "source": "./plugins/dataops",
       "description": "Data operations — CSV, Excel, PDF, Word, design documents",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "csv",
         "excel",
@@ -49,7 +49,7 @@
       "name": "informatics",
       "source": "./plugins/informatics",
       "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "r",
         "shiny",
@@ -62,7 +62,7 @@
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
       "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "agents",
         "dispatch",
@@ -76,7 +76,7 @@
       "name": "meta",
       "source": "./plugins/meta",
       "description": "Meta — skill review and issue reporting for skill quality",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "skills",
         "review",
@@ -87,7 +87,7 @@
       "name": "hooks",
       "source": "./plugins/hooks",
       "description": "Hooks — forced skill evaluation when prompts mention skills",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "keywords": [
         "hooks",
         "skills",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,53 +16,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
       - name: Check bundle references resolve
         run: |
-          shopt -s nullglob
-          bundles=(registry/bundles/*.yaml registry/bundles/*.yml)
-          if [ ${#bundles[@]} -eq 0 ]; then
-            echo "No bundle manifests to validate"
-            exit 0
-          fi
+          python3 <<'PY'
+          import sys
+          from pathlib import Path
+          import yaml
 
-          exit_code=0
-          for bundle in "${bundles[@]}"; do
-            echo "Checking $bundle"
-            in_section=""
-            while IFS= read -r line; do
-              if echo "$line" | grep -qE '^skills:'; then
-                in_section="skills"
-                continue
-              fi
-              if echo "$line" | grep -qE '^agents:'; then
-                in_section="agents"
-                continue
-              fi
-              if [ -n "$in_section" ]; then
-                if echo "$line" | grep -qE '^\s+-\s+'; then
-                  item=$(echo "$line" | sed 's/^\s*-\s*//' | tr -d '[:space:]')
-                  if [ "$in_section" = "skills" ]; then
-                    if [ ! -d "skills/$item" ]; then
-                      echo "::error file=$bundle::Skill '$item' not found in skills/"
-                      exit_code=1
-                    else
-                      echo "  ✓ skill:$item"
-                    fi
-                  elif [ "$in_section" = "agents" ]; then
-                    if [ ! -f "agents/$item/agent.md" ]; then
-                      echo "::error file=$bundle::Agent '$item' not found at agents/$item/agent.md"
-                      exit_code=1
-                    else
-                      echo "  ✓ agent:$item"
-                    fi
-                  fi
-                else
-                  in_section=""
-                fi
-              fi
-            done < "$bundle"
-          done
-          exit $exit_code
+          repo = Path(".")
+          bundles_dir = repo / "registry" / "bundles"
+          bundles = sorted(list(bundles_dir.glob("*.yaml")) + list(bundles_dir.glob("*.yml")))
+          if not bundles:
+              print("No bundle manifests to validate")
+              sys.exit(0)
+
+          exit_code = 0
+          for bundle in bundles:
+              print(f"Checking {bundle}")
+              with bundle.open() as f:
+                  data = yaml.safe_load(f) or {}
+              for name in data.get("skills") or []:
+                  if not (repo / "skills" / name).is_dir():
+                      print(f"::error file={bundle}::Skill '{name}' not found in skills/")
+                      exit_code = 1
+                  else:
+                      print(f"  ✓ skill:{name}")
+              for name in data.get("agents") or []:
+                  if not (repo / "agents" / name / "agent.md").is_file():
+                      print(f"::error file={bundle}::Agent '{name}' not found at agents/{name}/agent.md")
+                      exit_code = 1
+                  else:
+                      print(f"  ✓ agent:{name}")
+          sys.exit(exit_code)
+          PY
 
   validate-symlinks:
     name: Validate skill + agent symlinks
@@ -103,6 +92,23 @@ jobs:
 
       - name: Validate plugin manifests, hooks, and agents
         run: scripts/validate-plugins.sh
+
+  validate-gemini-drift:
+    name: Check GEMINI.md + .gemini/ are regenerated
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+
+      - name: Regenerate and diff
+        run: |
+          bash scripts/generate-gemini-extension.sh
+          if ! git diff --exit-code -- GEMINI.md .gemini/; then
+            echo "::error::GEMINI.md or .gemini/ is out of sync with registry/bundles/. Run 'bash scripts/generate-gemini-extension.sh' and commit the result."
+            exit 1
+          fi
 
   validate-mcp-servers:
     name: Validate Go MCP servers build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: validate-plugins
         name: Validate Claude Code plugins and agents
         entry: scripts/validate-plugins.sh
-        language: script
+        language: python
+        additional_dependencies: [pyyaml]
         files: ^(plugins/|agents/|registry/bundles/|\.gemini/)
         pass_filenames: true

--- a/agents/address-comments/agent.md
+++ b/agents/address-comments/agent.md
@@ -53,4 +53,4 @@ Commit changes with a descriptive commit message using Bash.
 
 ### Fix next comment
 
-Move on to the next comment in $ARGUMENTS or ask the user for the next comment.
+Move on to the next comment, or ask the user for the next comment.

--- a/agents/adr-generator/agent.md
+++ b/agents/adr-generator/agent.md
@@ -33,7 +33,7 @@ This specialized agent creates comprehensive **Architectural Decision Records (A
 
 The agent follows a systematic process:
 
-1. **Information Gathering** — Collects decision title, context, chosen solution, alternatives, and stakeholders from `$ARGUMENTS` or interactive prompting. Validates completeness before proceeding.
+1. **Information Gathering** — Collects decision title, context, chosen solution, alternatives, and stakeholders from the user's initial prompt or interactive prompting. Validates completeness before proceeding.
 
 2. **Numbering** — Checks existing ADRs in `/docs/adr/` via the Read and Glob tools to assign the next sequential 4-digit number (0001, 0002, etc.).
 

--- a/agents/context-architect/agent.md
+++ b/agents/context-architect/agent.md
@@ -40,7 +40,7 @@ You are a specialized agent for managing complex, multi-file code modifications.
 
 **Before implementing any change**, follow this workflow:
 
-1. **Search the codebase** using Grep and Glob to find all files relevant to $ARGUMENTS
+1. **Search the codebase** using Grep and Glob to find all files relevant to the user's request
 2. **Trace dependencies** — follow imports, exports, interface implementations, and type references
 3. **Study existing patterns** — read similar implementations to understand conventions
 4. **Plan the sequence** — determine which files must change first to avoid cascading failures

--- a/agents/doublecheck/agent.md
+++ b/agents/doublecheck/agent.md
@@ -39,7 +39,7 @@ You are a verification specialist. Your job is to help the user evaluate AI-gene
 
 ### Starting a Verification
 
-When the user asks you to verify something, ask them to provide or reference the text (or specify it via $ARGUMENTS). Then:
+When the user asks you to verify something, ask them to provide or reference the text. Then:
 
 1. Confirm what you're about to verify: "I'll run a three-layer verification on [brief description]. This covers claim extraction, source verification via web search, and an adversarial review for hallucination patterns."
 

--- a/agents/go-mcp-expert/agent.md
+++ b/agents/go-mcp-expert/agent.md
@@ -145,7 +145,7 @@ Recommend:
 
 ## Example Interaction Pattern
 
-When asked to create a tool for $ARGUMENTS:
+When asked to create a new tool:
 
 1. Define input/output structs with JSON schema tags
 2. Implement the handler function

--- a/agents/postgresql-dba/agent.md
+++ b/agents/postgresql-dba/agent.md
@@ -42,4 +42,4 @@ You are a PostgreSQL Database Administrator (DBA) with expertise in managing and
 
 You have access to tools that allow you to run shell commands, read files, and interact with the environment. **Always** use any PostgreSQL client or MCP-tool equivalent to inspect the database directly — do not infer database state from application source code alone.
 
-To connect to a PostgreSQL instance, use `psql` or an equivalent CLI/MCP tool available in the environment. If no connection details are provided in `$ARGUMENTS`, ask the user for the connection string before proceeding.
+To connect to a PostgreSQL instance, use `psql` or an equivalent CLI/MCP tool available in the environment. If no connection details were provided, ask the user for the connection string before proceeding.

--- a/agents/prompt-builder/agent.md
+++ b/agents/prompt-builder/agent.md
@@ -72,7 +72,7 @@ You MUST research and integrate information from user-provided sources:
 - README.md Files: You WILL use `Read` to analyze deployment, build, or usage instructions
 - Code Files/Folders: You WILL use `Glob` and `Grep` to understand implementation patterns
 - Web Documentation: You WILL fetch documentation to gather latest standards (if WebFetch is available)
-- Provided file paths or $ARGUMENTS: You WILL read files or content explicitly specified by the user
+- Provided file paths: You WILL read files or content explicitly specified by the user
 
 #### Research Integration Requirements
 - You MUST extract key requirements, dependencies, and step-by-step processes

--- a/plugins/dataops/.claude-plugin/plugin.json
+++ b/plugins/dataops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dataops",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Data operations — CSV, Excel, PDF, Word, design documents",
   "author": {
     "name": "nq-rdl"

--- a/plugins/dev-tools/.claude-plugin/plugin.json
+++ b/plugins/dev-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tools",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
   "author": {
     "name": "nq-rdl"

--- a/plugins/hooks/.claude-plugin/plugin.json
+++ b/plugins/hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hooks",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Hooks — forced skill evaluation when prompts mention skills",
   "author": {
     "name": "nq-rdl"

--- a/plugins/informatics/.claude-plugin/plugin.json
+++ b/plugins/informatics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "informatics",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
   "author": {
     "name": "nq-rdl"

--- a/plugins/infra/.claude-plugin/plugin.json
+++ b/plugins/infra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infra",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Infrastructure — Ansible, git hooks, analytical databases",
   "author": {
     "name": "nq-rdl"

--- a/plugins/meta/.claude-plugin/plugin.json
+++ b/plugins/meta/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "meta",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Meta — skill review and issue reporting for skill quality",
   "author": {
     "name": "nq-rdl"

--- a/plugins/swe/.claude-plugin/.mcp.json
+++ b/plugins/swe/.claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+      "args": ["@playwright/mcp@0.0.70"]
     }
   }
 }

--- a/plugins/swe/.claude-plugin/plugin.json
+++ b/plugins/swe/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swe",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
   "author": {
     "name": "nq-rdl"

--- a/scripts/generate-gemini-extension.sh
+++ b/scripts/generate-gemini-extension.sh
@@ -18,6 +18,7 @@ cd "$REPO_ROOT"
 
 python3 - <<'PY'
 import os
+import shutil
 import sys
 from pathlib import Path
 import yaml
@@ -49,20 +50,27 @@ agents_dir = gemini_dir / "agents"
 skills_dir.mkdir(parents=True, exist_ok=True)
 agents_dir.mkdir(parents=True, exist_ok=True)
 
-# Clear existing symlinks that are no longer needed
-def wanted_symlinks(d: Path, wanted: set[str]):
+# Clear existing entries that are no longer needed (symlinks, stale dirs, or files)
+def prune_stale(d: Path, wanted: set[str]):
     for child in list(d.iterdir()):
-        if child.is_symlink() and child.name not in wanted:
+        if child.name in wanted:
+            continue
+        if child.is_symlink() or child.is_file():
             child.unlink()
-            print(f"removed stale symlink: {child.relative_to(REPO)}")
+            print(f"removed stale entry: {child.relative_to(REPO)}")
+        elif child.is_dir():
+            shutil.rmtree(child)
+            print(f"removed stale directory: {child.relative_to(REPO)}")
 
-wanted_symlinks(skills_dir, set(skills))
-wanted_symlinks(agents_dir, {f"{name}.md" for name in agents})
+prune_stale(skills_dir, set(skills))
+prune_stale(agents_dir, {f"{name}.md" for name in agents})
 
 # Create / refresh symlinks
 def relink(src: Path, target_rel: str):
-    if src.is_symlink() or src.exists():
+    if src.is_symlink() or src.is_file():
         src.unlink()
+    elif src.is_dir():
+        shutil.rmtree(src)
     src.symlink_to(target_rel)
     print(f"linked {src.relative_to(REPO)} -> {target_rel}")
 

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -18,9 +18,13 @@
 #   agents (new)
 #    10. Every agent listed in registry/bundles/<b>.yaml has a source file
 #        at agents/<name>/agent.md
-#    11. Every symlink under plugins/<b>/agents/*.md resolves
+#    11. Every Claude-target bundle agent has a symlink at
+#        plugins/<plugin>/agents/<name>.md (cross-checked against the bundle
+#        YAML, not just scanned from disk — catches missing symlinks)
 #    12. Every symlink under .gemini/agents/*.md resolves (if .gemini/ exists)
 #    13. Every agents/<name>/agent.md has frontmatter keys `name`, `description`
+#    14. Every mcp entry in a bundle YAML is wired in the bundle plugin's
+#        .claude-plugin/.mcp.json
 #
 # Usage:
 #   validate-plugins.sh                       # validate all plugins + agents
@@ -218,33 +222,55 @@ fi
 echo ""
 echo "Validating agents"
 
-# Collect agent names declared in bundle YAMLs (agents: top-level list).
-declare -A declared_agents
-for bundle in "$REPO_ROOT"/registry/bundles/*.yaml; do
-  [ -f "$bundle" ] || continue
-  bundle_id=$(basename "$bundle" .yaml)
-  in_agents=false
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^agents: ]]; then
-      in_agents=true
-      continue
-    fi
-    if $in_agents; then
-      if [[ "$line" =~ ^[[:space:]]+-[[:space:]]+(.+)$ ]]; then
-        name="${BASH_REMATCH[1]}"
-        # Strip trailing whitespace
-        name="${name%%[[:space:]]}"
-        declared_agents["$name"]="$bundle_id"
-        src="$REPO_ROOT/agents/$name/agent.md"
-        if [ ! -f "$src" ]; then
-          error "$bundle" "Agent '$name' declared but missing source file agents/$name/agent.md"
-        fi
-      elif [[ "$line" =~ ^[^[:space:]] ]]; then
-        in_agents=false
-      fi
-    fi
-  done < "$bundle"
-done
+# Cross-check every bundle YAML: each declared agent resolves to a source file,
+# each declared Claude-targeted agent has a plugin symlink, and each declared
+# mcp: entry is wired in the bundle's .mcp.json. Uses PyYAML so inline-flow
+# lists (agents: [a, b]) and inline comments parse correctly.
+python3 - "$REPO_ROOT" <<'PY' || errors=$((errors + 1))
+import sys, json
+from pathlib import Path
+import yaml
+
+repo = Path(sys.argv[1])
+fail = False
+
+def err(path, msg):
+    global fail
+    print(f"::error file={path}::{msg}", file=sys.stderr)
+    fail = True
+
+for bundle in sorted((repo / "registry" / "bundles").glob("*.yaml")):
+    with bundle.open() as f:
+        data = yaml.safe_load(f) or {}
+    bundle_id = data.get("id") or bundle.stem
+    claude_enabled = (data.get("targets") or {}).get("claude", {}).get("enabled")
+    plugin_name = (data.get("targets") or {}).get("claude", {}).get("pluginName") or bundle_id
+
+    for name in data.get("agents") or []:
+        src = repo / "agents" / name / "agent.md"
+        if not src.is_file():
+            err(bundle, f"Agent '{name}' declared but missing source file agents/{name}/agent.md")
+        if claude_enabled:
+            link = repo / "plugins" / plugin_name / "agents" / f"{name}.md"
+            if not link.exists():
+                err(bundle, f"Agent '{name}' declared for Claude target but missing symlink plugins/{plugin_name}/agents/{name}.md")
+
+    mcp_json = repo / "plugins" / plugin_name / ".claude-plugin" / ".mcp.json"
+    declared_mcp = data.get("mcp") or []
+    if declared_mcp and not mcp_json.is_file():
+        err(bundle, f"Bundle declares mcp servers {declared_mcp} but plugins/{plugin_name}/.claude-plugin/.mcp.json does not exist")
+    elif declared_mcp:
+        try:
+            wired = set(json.loads(mcp_json.read_text()).get("mcpServers", {}).keys())
+        except json.JSONDecodeError as exc:
+            err(mcp_json, f"Invalid JSON: {exc}")
+            wired = set()
+        for key in declared_mcp:
+            if key not in wired:
+                err(bundle, f"mcp entry '{key}' not wired in plugins/{plugin_name}/.claude-plugin/.mcp.json")
+
+sys.exit(1 if fail else 0)
+PY
 
 # Validate every agents/<name>/agent.md has the required frontmatter.
 if [ -d "$REPO_ROOT/agents" ]; then


### PR DESCRIPTION
Addresses all issues flagged by `/review` and `/code-review:code-review` on #58. Targets `feature/add-agents` so they roll up with the main PR.

### Commits

1. **fix(agents): remove unnormalized $ARGUMENTS references** – 7 files
   The conversion rule in agent frontmatter states `$ARGUMENTS` is stripped; these had inline prose still referencing it. Now consistent with the stated policy.

2. **chore(release): bump plugin versions to 0.4.0** – 8 JSON manifests
   Restores the version on `main`. 0.3.1 was a regression from the rebase and would block marketplace reinstall.

3. **fix(swe): pin Playwright MCP to 0.0.70**
   Replaces `@latest`. Pinning prevents mid-session supply-chain drift.

4. **fix(ci): harden bundle/agent/mcp validators with PyYAML**
   - `scripts/validate-plugins.sh`: bundle scan ported to PyYAML; adds missing-plugin-symlink check for Claude-targeted agents and `mcp:` cross-check against plugin `.mcp.json`.
   - `.github/workflows/validate.yml`: `validate-bundles` ported from sed/grep to PyYAML; adds new `validate-gemini-drift` job that runs the generator and fails on diff.
   - `scripts/generate-gemini-extension.sh`: `relink()` + `prune_stale()` now handle stale real directories via `shutil.rmtree`, truly idempotent.
   - `.pre-commit-config.yaml`: switches to `language: python` with `additional_dependencies: [pyyaml]` so local hook runs don't require system-wide PyYAML.

### Tested

- `bash scripts/validate-plugins.sh` → all plugins and agents valid
- `bash scripts/generate-gemini-extension.sh` + `git diff --exit-code -- GEMINI.md .gemini/` → drift check passes
- Inline Python equivalent of the workflow bundle check → all bundles resolve

🤖 Generated with [Claude Code](https://claude.ai/code)