### PR TITLE
chore(changelog): add fragment for pi-server binary sync v0.6.1

### DIFF
--- a/.changes/unreleased/Fixed-20260426-121012.yaml
+++ b/.changes/unreleased/Fixed-20260426-121012.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Sync pi-server binaries from agent-skills@v0.6.1.
+time: 2026-04-26T12:10:12.436677581+10:00


### PR DESCRIPTION
Adds a `Fixed` changie fragment for the pi-server binary sync that landed in #75 (`chore/sync-binaries-v0.6.1`).

Once merged, ready to release as **v0.5.2**.

### Fragment

\`\`\`yaml
kind: Fixed
body: Sync pi-server binaries from agent-skills@v0.6.1.
\`\`\`

`Fixed` auto-bumps to patch under `changie batch auto`, matching the intended v0.5.2 release.