### PR TITLE
fix(marketplace): point plugin sources at release branch via git-subdir (#83)

### DIFF
--- a/.changes/unreleased/Fixed-20260502-153500.yaml
+++ b/.changes/unreleased/Fixed-20260502-153500.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Point local plugin sources in `.claude-plugin/marketplace.json` at the materialized `release` branch via `git-subdir` so installed plugins resolve to real files instead of dangling symlinks (#83, follow-up to #79). `worktrunk` keeps its third-party `github` source.
+time: 2026-05-02T15:35:00.000000000+10:00

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,12 @@
   "plugins": [
     {
       "name": "swe",
-      "source": "./plugins/swe",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/swe",
+        "ref": "release"
+      },
       "description": "Software engineering — TDD, secure Go, naming, CI/CD, changelogs",
       "version": "0.5.3",
       "keywords": [
@@ -24,7 +29,12 @@
     },
     {
       "name": "infra",
-      "source": "./plugins/infra",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/infra",
+        "ref": "release"
+      },
       "description": "Infrastructure — Ansible, git hooks, analytical databases",
       "version": "0.5.3",
       "keywords": [
@@ -35,7 +45,12 @@
     },
     {
       "name": "dataops",
-      "source": "./plugins/dataops",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/dataops",
+        "ref": "release"
+      },
       "description": "Data operations — CSV, Excel, PDF, Word, design documents",
       "version": "0.5.3",
       "keywords": [
@@ -47,7 +62,12 @@
     },
     {
       "name": "informatics",
-      "source": "./plugins/informatics",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/informatics",
+        "ref": "release"
+      },
       "description": "R ecosystem — package dev, Shiny, Quarto, testing, CRAN",
       "version": "0.5.3",
       "keywords": [
@@ -60,7 +80,12 @@
     },
     {
       "name": "dev-tools",
-      "source": "./plugins/dev-tools",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/dev-tools",
+        "ref": "release"
+      },
       "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",
       "version": "0.5.3",
       "keywords": [
@@ -74,7 +99,12 @@
     },
     {
       "name": "meta",
-      "source": "./plugins/meta",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/meta",
+        "ref": "release"
+      },
       "description": "Meta — skill review and issue reporting for skill quality",
       "version": "0.5.3",
       "keywords": [
@@ -85,7 +115,12 @@
     },
     {
       "name": "hooks",
-      "source": "./plugins/hooks",
+      "source": {
+        "source": "git-subdir",
+        "url": "nq-rdl/agent-extensions",
+        "path": "plugins/hooks",
+        "ref": "release"
+      },
       "description": "Hooks — forced skill evaluation when prompts mention skills",
       "version": "0.5.3",
       "keywords": [


### PR DESCRIPTION
## Summary

- Switch the seven local plugin entries in `.claude-plugin/marketplace.json` (`swe`, `infra`, `dataops`, `informatics`, `dev-tools`, `meta`, `hooks`) from relative-path sources to `git-subdir` sources pinned to the `release` branch.
- This is the deferred follow-up to #82 that issue #83 calls out: PR #82 added materialization but explicitly left the marketplace switchover for a later PR once the first materialized release existed (v0.5.3 is already published, so the `release` branch is populated).
- `worktrunk` keeps its third-party `"source": "github"` entry — only locally-hosted plugins move.

Closes #83. Refs #79, #82.

## Why this fixes the bug

`/plugin install <name>@rdl` copies a plugin subtree out of the marketplace clone into a per-user cache via `cp -R`. The marketplace clone is taken from `main` (the default branch), where `plugins/<bundle>/skills/<name>` and `plugins/<bundle>/agents/<name>.md` are symlinks pointing at `../../../skills/<name>` / `../../../agents/<name>/agent.md`. Those targets sit *outside* the plugin subtree, so every link dangles after the cache copy, producing empty `skills/` and `agents/` directories — the symptom in #83 (`ls ~/.claude/plugins/cache/rdl/swe/0.5.3/skills/sops/` → ENOENT).

The `release` branch is regenerated from `dist/release/` on every tag (`scripts/materialize.sh` + `.github/workflows/release.yml` lines 125-150). It contains the same plugin tree but with every symlink dereferenced via `rsync -aL` into real files. With `git-subdir` pointing at `release`, each plugin install sparse-checks the materialized subtree directly — symlinks never enter the picture.

## Why `git-subdir` per plugin and not `extraKnownMarketplaces` / `@release` shorthand

The `release` branch contains only `plugins/`, `.gemini/`, `opencode/`, `pidev/` (`materialize.sh` does not copy `.claude-plugin/`). That means the marketplace manifest itself must keep living on `main`, so users can keep typing `claude plugin marketplace add nq-rdl/agent-extensions` without an `@release` suffix. Putting the branch pin on each plugin entry redirects the install step transparently.

## Test plan

- [x] `jq empty .claude-plugin/marketplace.json` — valid JSON.
- [x] `bash scripts/validate-plugins.sh` — all plugins + agents valid (validator covers the Codex marketplace JSON; the Claude marketplace JSON is plain, but the plugin manifests it points at are checked).
- [x] `bash scripts/materialize.sh dist/release` — produces a 1289-file tree with zero symlinks; `dist/release/plugins/swe/skills/sops/SKILL.md` resolves to a real file.
- [ ] Post-merge: tag a follow-up patch release (e.g. v0.5.4) so the new marketplace.json reaches users via the marketplace's normal cache-update path. Then re-test the workflow from a fresh devcontainer:
  - `claude plugin marketplace add nq-rdl/agent-extensions`
  - `claude plugin install swe@rdl`
  - `ls ~/.claude/plugins/cache/rdl/swe/<version>/skills/sops/SKILL.md` should resolve.

## Notes

- `metadata.version` and per-plugin `version` are intentionally **not** bumped here; `release.yml` jq-edits both fields when CI runs on the next `v*` tag.
- The `release` branch is regenerated from `main` on every tag, so the next release will publish a marketplace.json that *also* contains git-subdir refs back to `release`. That's idempotent — both paths converge on the same tree.