### PR TITLE
fix: make forced-eval-hook advisory instead of injection-shaped (#78)

### DIFF
--- a/.changes/unreleased/Fixed-20260528-forced-eval-advisory.yaml
+++ b/.changes/unreleased/Fixed-20260528-forced-eval-advisory.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Rewrite forced-eval-hook to emit an advisory skill catalogue via additionalContext instead of coercive prompt-injection-shaped prose, gated on use intent (#78)
+time: 2026-05-28T12:00:00.000000+10:00

--- a/hooks/forced-eval-hook.sh
+++ b/hooks/forced-eval-hook.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# UserPromptSubmit hook that forces explicit skill evaluation
+# UserPromptSubmit hook that surfaces available skills as advisory context.
 #
 # Dynamically discovers available skills from:
 #   1. Standalone skills:     ~/.claude/skills/*/SKILL.md
@@ -21,10 +21,33 @@
 #   3. Ensure this script is executable: chmod +x forced-eval-hook.sh
 #
 # How it works:
-#   - On every UserPromptSubmit event, this script emits a structured prompt
-#     that Claude sees as additional context.
-#   - The prompt forces a 3-step sequence: Evaluate → Activate → Implement.
-#   - Claude must call Skill() for every skill or command it marks YES.
+#   - Fires only when the prompt expresses intent to use a skill (an action
+#     verb appears near "skill"/"skills"); silent no-op otherwise.
+#   - Emits the discovered skill/command catalogue as advisory context via the
+#     UserPromptSubmit additionalContext channel (plain stdout when jq absent).
+#   - The framing is descriptive: it invites the model to consider the skills,
+#     it does not coerce a fixed activation sequence.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Intent gate — fire only when an action verb sits near "skill"/"skills",
+# signalling intent to use one. Metalinguistic mentions ("skills should
+# always be reviewed") no longer trigger a catalogue dump. Silent no-op
+# otherwise.
+# ---------------------------------------------------------------------------
+input=$(cat)
+
+if command -v jq >/dev/null 2>&1; then
+  prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+else
+  prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
+fi
+
+intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering|consider|considering|check|checking'
+if ! printf '%s' "$prompt" | grep -qiE "\b(${intent})\b.{0,40}\bskills?\b|\bskills?\b.{0,40}\b(${intent})\b"; then
+  exit 0
+fi
 
 SKILLS_DIR="${HOME}/.claude/skills"
 PLUGINS_JSON="${HOME}/.claude/plugins/installed_plugins.json"
@@ -227,15 +250,21 @@ scan_plugin_commands() {
 }
 
 # ---------------------------------------------------------------------------
-# Build the forced evaluation prompt
+# Build the advisory skill catalogue
+#
+# Descriptive, non-coercive framing wrapped in a stable <skill-catalog> fence
+# so downstream agents can recognise it as hook-provided context rather than
+# an injected instruction. The <available_skills> / <available_commands>
+# blocks are the useful payload.
 # ---------------------------------------------------------------------------
 build_prompt() {
   local skills_block="$1"
   local commands_block="$2"
 
-  printf 'INSTRUCTION: MANDATORY SKILL ACTIVATION SEQUENCE\n'
-  printf '\n'
-  printf 'Before proceeding with ANY implementation, you MUST complete all three steps below.\n'
+  printf '<skill-catalog>\n'
+  printf 'Skills and commands available for this prompt are listed below, discovered\n'
+  printf 'from your local Claude configuration by a UserPromptSubmit hook. Consider\n'
+  printf 'whether any fit the task; if one does, load it with the Skill tool. Advisory only.\n'
   printf '\n'
   printf '<available_skills>\n%s</available_skills>\n' "$skills_block"
 
@@ -243,39 +272,26 @@ build_prompt() {
     printf '\n<available_commands>\n%s</available_commands>\n' "$commands_block"
   fi
 
-  printf '\n'
-  printf 'Step 1 — EVALUATE (print this table in your response):\n'
-  printf 'For EACH skill and command listed above, state:\n'
-  printf '  [name] — YES/NO — [one-line reason]\n'
-  printf '\n'
-  printf 'Step 2 — ACTIVATE (immediately after Step 1):\n'
-  printf '  IF any skills or commands are marked YES → Call Skill(name) for EACH one NOW.\n'
-  printf '  IF none are YES                          → State "No skills apply" and proceed to Step 3.\n'
-  printf '\n'
-  printf 'Step 3 — IMPLEMENT:\n'
-  printf '  Only after ALL Skill() calls from Step 2 have returned, proceed with implementation.\n'
-  printf '\n'
-  printf 'CRITICAL RULES:\n'
-  printf '• You MUST call the Skill() tool in Step 2. Do NOT skip to implementation.\n'
-  printf '• The evaluation table (Step 1) is WORTHLESS unless you ACTIVATE (Step 2).\n'
-  printf '• If you skip Step 2, you have violated this instruction — stop and redo.\n'
-  printf '\n'
-  printf 'Example of a correct sequence:\n'
-  printf '\n'
-  printf '  Step 1 — Evaluate:\n'
-  printf '    academic-super                  — NO  — not an academic task\n'
-  printf '    charm-tui                       — YES — building a terminal UI\n'
-  printf '    use-modern-go                   — YES — writing Go code\n'
-  printf '    frontend-design:frontend-design — NO  — not a web UI task\n'
-  printf '    commit-commands:commit          — NO  — not committing code\n'
-  printf '    (... remaining skills and commands ...)\n'
-  printf '\n'
-  printf '  Step 2 — Activate:\n'
-  printf '    > Skill(charm-tui)\n'
-  printf '    > Skill(use-modern-go)\n'
-  printf '\n'
-  printf '  Step 3 — Implement:\n'
-  printf '    (only now begin writing code)\n'
+  printf '</skill-catalog>\n'
+}
+
+# ---------------------------------------------------------------------------
+# Emit the catalogue. Preferred channel is the UserPromptSubmit
+# additionalContext field (added discreetly as system context); falls back to
+# plain stdout when jq is unavailable.
+# ---------------------------------------------------------------------------
+emit() {
+  local payload="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$payload" '{
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $ctx
+      }
+    }'
+  else
+    printf '%s\n' "$payload"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -284,7 +300,7 @@ build_prompt() {
 main() {
   # Return cached output if still fresh
   if check_cache; then
-    cat "$CACHE_FILE"
+    emit "$(cat "$CACHE_FILE")"
     return 0
   fi
 
@@ -325,7 +341,7 @@ main() {
   local output
   output=$(build_prompt "$skills_block" "$commands_block")
   write_cache "$output"
-  printf '%s\n' "$output"
+  emit "$output"
 }
 
 main

--- a/hooks/forced-eval-hook.sh
+++ b/hooks/forced-eval-hook.sh
@@ -40,11 +40,16 @@ input=$(cat)
 
 if command -v jq >/dev/null 2>&1; then
   prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+elif command -v python3 >/dev/null 2>&1; then
+  # JSON-aware fallback: correctly unescapes quotes, newlines, and unicode.
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt", ""))' 2>/dev/null || true)
 else
+  # Last-resort best-effort: truncates on embedded escaped quotes, but only
+  # the advisory intent gate depends on it, so a degraded match is acceptable.
   prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
 fi
 
-intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering|consider|considering|check|checking'
+intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering'
 if ! printf '%s' "$prompt" | grep -qiE "\b(${intent})\b.{0,40}\bskills?\b|\bskills?\b.{0,40}\b(${intent})\b"; then
   exit 0
 fi

--- a/hooks/forced-eval-hook.sh
+++ b/hooks/forced-eval-hook.sh
@@ -42,7 +42,9 @@ if command -v jq >/dev/null 2>&1; then
   prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
 elif command -v python3 >/dev/null 2>&1; then
   # JSON-aware fallback: correctly unescapes quotes, newlines, and unicode.
-  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt", ""))' 2>/dev/null || true)
+  # `or ""` coerces a missing or explicitly-null prompt to "", matching the
+  # jq path's `.prompt // empty`.
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt") or "")' 2>/dev/null || true)
 else
   # Last-resort best-effort: truncates on embedded escaped quotes, but only
   # the advisory intent gate depends on it, so a degraded match is acceptable.

--- a/plugins/hooks/scripts/forced-eval-hook.sh
+++ b/plugins/hooks/scripts/forced-eval-hook.sh
@@ -31,7 +31,9 @@ if command -v jq >/dev/null 2>&1; then
   prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
 elif command -v python3 >/dev/null 2>&1; then
   # JSON-aware fallback: correctly unescapes quotes, newlines, and unicode.
-  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt", ""))' 2>/dev/null || true)
+  # `or ""` coerces a missing or explicitly-null prompt to "", matching the
+  # jq path's `.prompt // empty`.
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt") or "")' 2>/dev/null || true)
 else
   # Last-resort best-effort: truncates on embedded escaped quotes, but only
   # the advisory intent gate depends on it, so a degraded match is acceptable.

--- a/plugins/hooks/scripts/forced-eval-hook.sh
+++ b/plugins/hooks/scripts/forced-eval-hook.sh
@@ -29,11 +29,16 @@ input=$(cat)
 
 if command -v jq >/dev/null 2>&1; then
   prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+elif command -v python3 >/dev/null 2>&1; then
+  # JSON-aware fallback: correctly unescapes quotes, newlines, and unicode.
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt", ""))' 2>/dev/null || true)
 else
+  # Last-resort best-effort: truncates on embedded escaped quotes, but only
+  # the advisory intent gate depends on it, so a degraded match is acceptable.
   prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
 fi
 
-intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering|consider|considering|check|checking'
+intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering'
 if ! printf '%s' "$prompt" | grep -qiE "\b(${intent})\b.{0,40}\bskills?\b|\bskills?\b.{0,40}\b(${intent})\b"; then
   exit 0
 fi

--- a/plugins/hooks/scripts/forced-eval-hook.sh
+++ b/plugins/hooks/scripts/forced-eval-hook.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# UserPromptSubmit hook that forces explicit skill evaluation
+# UserPromptSubmit hook that surfaces available skills as advisory context.
 #
-# Triggers ONLY when the user's prompt contains "skill" or "skills"
-# (case-insensitive, word-boundary match). Silent no-op otherwise.
+# Triggers only when the prompt expresses intent to use a skill — an action
+# verb (use, invoke, run, apply, ...) appears near "skill"/"skills". Silent
+# no-op otherwise. Output is the skill catalogue, emitted via the
+# UserPromptSubmit additionalContext channel as advisory (not coercive) text.
 #
 # Dynamically discovers available skills from:
 #   1. Standalone skills:     ~/.claude/skills/*/SKILL.md
@@ -18,7 +20,10 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# Keyword gate — only fire when the prompt mentions "skill" or "skills"
+# Intent gate — fire only when an action verb sits near "skill"/"skills",
+# signalling intent to use one. Metalinguistic mentions ("skills should
+# always be reviewed") no longer trigger a catalogue dump. Silent no-op
+# otherwise.
 # ---------------------------------------------------------------------------
 input=$(cat)
 
@@ -28,7 +33,8 @@ else
   prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
 fi
 
-if ! printf '%s' "$prompt" | grep -qiE '\bskills?\b'; then
+intent='use|using|invoke|invoking|run|running|apply|applying|activate|activating|load|loading|call|calling|trigger|triggering|consider|considering|check|checking'
+if ! printf '%s' "$prompt" | grep -qiE "\b(${intent})\b.{0,40}\bskills?\b|\bskills?\b.{0,40}\b(${intent})\b"; then
   exit 0
 fi
 
@@ -218,15 +224,21 @@ scan_plugin_commands() {
 }
 
 # ---------------------------------------------------------------------------
-# Build the forced evaluation prompt
+# Build the advisory skill catalogue
+#
+# Descriptive, non-coercive framing wrapped in a stable <skill-catalog> fence
+# so downstream agents can recognise it as hook-provided context rather than
+# an injected instruction. The <available_skills> / <available_commands>
+# blocks are the useful payload.
 # ---------------------------------------------------------------------------
 build_prompt() {
   local skills_block="$1"
   local commands_block="$2"
 
-  printf 'INSTRUCTION: MANDATORY SKILL ACTIVATION SEQUENCE\n'
-  printf '\n'
-  printf 'Before proceeding with ANY implementation, you MUST complete all three steps below.\n'
+  printf '<skill-catalog>\n'
+  printf 'Skills and commands available for this prompt are listed below, discovered\n'
+  printf 'from your local Claude configuration by a UserPromptSubmit hook. Consider\n'
+  printf 'whether any fit the task; if one does, load it with the Skill tool. Advisory only.\n'
   printf '\n'
   printf '<available_skills>\n%s</available_skills>\n' "$skills_block"
 
@@ -234,39 +246,26 @@ build_prompt() {
     printf '\n<available_commands>\n%s</available_commands>\n' "$commands_block"
   fi
 
-  printf '\n'
-  printf 'Step 1 — EVALUATE (print this table in your response):\n'
-  printf 'For EACH skill and command listed above, state:\n'
-  printf '  [name] — YES/NO — [one-line reason]\n'
-  printf '\n'
-  printf 'Step 2 — ACTIVATE (immediately after Step 1):\n'
-  printf '  IF any skills or commands are marked YES → Call Skill(name) for EACH one NOW.\n'
-  printf '  IF none are YES                          → State "No skills apply" and proceed to Step 3.\n'
-  printf '\n'
-  printf 'Step 3 — IMPLEMENT:\n'
-  printf '  Only after ALL Skill() calls from Step 2 have returned, proceed with implementation.\n'
-  printf '\n'
-  printf 'CRITICAL RULES:\n'
-  printf '• You MUST call the Skill() tool in Step 2. Do NOT skip to implementation.\n'
-  printf '• The evaluation table (Step 1) is WORTHLESS unless you ACTIVATE (Step 2).\n'
-  printf '• If you skip Step 2, you have violated this instruction — stop and redo.\n'
-  printf '\n'
-  printf 'Example of a correct sequence:\n'
-  printf '\n'
-  printf '  Step 1 — Evaluate:\n'
-  printf '    academic-super                  — NO  — not an academic task\n'
-  printf '    charm-tui                       — YES — building a terminal UI\n'
-  printf '    use-modern-go                   — YES — writing Go code\n'
-  printf '    frontend-design:frontend-design — NO  — not a web UI task\n'
-  printf '    commit-commands:commit          — NO  — not committing code\n'
-  printf '    (... remaining skills and commands ...)\n'
-  printf '\n'
-  printf '  Step 2 — Activate:\n'
-  printf '    > Skill(charm-tui)\n'
-  printf '    > Skill(use-modern-go)\n'
-  printf '\n'
-  printf '  Step 3 — Implement:\n'
-  printf '    (only now begin writing code)\n'
+  printf '</skill-catalog>\n'
+}
+
+# ---------------------------------------------------------------------------
+# Emit the catalogue. Preferred channel is the UserPromptSubmit
+# additionalContext field (added discreetly as system context); falls back to
+# plain stdout when jq is unavailable.
+# ---------------------------------------------------------------------------
+emit() {
+  local payload="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$payload" '{
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: $ctx
+      }
+    }'
+  else
+    printf '%s\n' "$payload"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -274,7 +273,7 @@ build_prompt() {
 # ---------------------------------------------------------------------------
 main() {
   if check_cache; then
-    cat "$CACHE_FILE"
+    emit "$(cat "$CACHE_FILE")"
     return 0
   fi
 
@@ -309,7 +308,7 @@ main() {
   local output
   output=$(build_prompt "$skills_block" "$commands_block")
   write_cache "$output"
-  printf '%s\n' "$output"
+  emit "$output"
 }
 
 main


### PR DESCRIPTION
## Summary

Fixes #78. The `UserPromptSubmit` forced-eval-hook surfaced a useful skill
catalogue but wrapped it in coercive, prompt-injection-shaped prose
(`MANDATORY` header, `you MUST`, `CRITICAL RULES`, a fake `Skill()`
transcript) emitted on plain stdout. Safety-aware agents correctly flagged
that shape and ignored the payload — defeating the catalogue it was meant to
surface.

Three orthogonal changes, applied to both the canonical `hooks/` source and
the shipped `plugins/hooks/scripts/` copy:

1. **Advisory `build_prompt`.** Replaced the imperative scaffolding and the
   3-step worked example with a ≤3-line descriptive preamble, wrapped in a
   stable `<skill-catalog>` fence so downstream agents can recognise
   hook-provided context. The `<available_skills>` / `<available_commands>`
   payload is unchanged. No occurrences of `MANDATORY`, `you MUST`,
   `CRITICAL RULES`, or `violated this instruction` remain.
2. **`additionalContext` channel.** Output now goes through the
   `hookSpecificOutput.additionalContext` JSON field (added discreetly as
   system context) instead of plain stdout. Falls back to plain stdout when
   `jq` is unavailable, matching the script's existing graceful-degradation
   posture.
3. **Intent-aware gate.** Replaced the bare `\bskills?\b` match with one that
   requires an action verb (use/invoke/run/apply/load/...) near
   "skill"/"skills". Metalinguistic mentions like "skills should always be
   reviewed" no longer trigger a catalogue dump.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] `scripts/validate-plugins.sh plugins/hooks/hooks/hooks.json` passes
- [x] No `MANDATORY` / `you MUST` / `CRITICAL RULES` / `violated this instruction` in emitted text
- [x] Positive gate ("use the tdd skill") emits valid JSON `additionalContext` with the fenced catalogue
- [x] Negative gate ("skills should always be reviewed", "what is a skill") produces no output, exit 0
- [x] Catalogue intact: standalone skills, plugin skills, and plugin commands all present
- [x] No-`jq` fallback emits the plain fenced catalogue (not JSON)

https://claude.ai/code/session_01NdbASJfJKKwDWTS3no13p8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdbASJfJKKwDWTS3no13p8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skill output is now advisory and non-coercive: the system emits a structured skill/command catalogue only when the user’s prompt expresses clear intent to use skills.
  * Cached and live catalogue emissions are unified into a consistent additional-context format, preventing unsolicited or intrusive catalogue dumps.
  * Emission is gated to ignore metalinguistic mentions and only respond to actionable intent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nq-rdl/agent-extensions/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->