### PR TITLE
feat: add Codex CC plugin via openai-codex marketplace

### DIFF
--- a/.changes/unreleased/Added-20260531-codex-plugin.yaml
+++ b/.changes/unreleased/Added-20260531-codex-plugin.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New `openai-codex` marketplace auto-installs the `codex` plugin — Codex delegation and code review from Claude Code (#90)
+time: 2026-05-31T12:42:11.639328534+10:00

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "source": "github",
         "repo": "openai/codex-plugin-cc"
       },
-      "autoUpdate": true
+      "autoUpdate": false
     }
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the request in #90 — wires the [Codex CC plugin](https://github.com/openai/codex-plugin-cc) into this repo's Claude Code configuration.

Adds **`.claude/settings.json`** (committed project scope, so the whole team gets it):

- **`extraKnownMarketplaces`** → registers `openai-codex` pointing at `github:openai/codex-plugin-cc`
- **`enabledPlugins`** → auto-installs `codex@openai-codex`
- **`autoUpdate: true`** → keeps the marketplace + installed plugin current on startup

## Verification

- Marketplace + plugin names taken from the upstream `marketplace.json` (marketplace `openai-codex`, plugin `codex`) — not guessed.
- `jq`-validated: valid JSON, source resolves to `github:openai/codex-plugin-cc`, both booleans `true`, and the `@openai-codex` suffix matches the marketplace key.

## Notes

- Takes effect on the next Claude Code session start in this repo (expect a one-time trust prompt for the new marketplace before `codex` installs).
- No changie fragment added: this is dev-environment config rather than a published-catalog change, and the changie hook/CI don't gate it. Happy to add one if you'd prefer it tracked in the changelog.

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex plugin is now automatically installed and configured, enabling code review and delegation features powered by Claude Code integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->