### PR TITLE
feat(rust): add rust plugin — /rust:rust-explain

### DIFF
--- a/.changes/unreleased/Added-20260601-rust-plugin.yaml
+++ b/.changes/unreleased/Added-20260601-rust-plugin.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New `rust` plugin exposing the `rust-explain` skill as `/rust:rust-explain` — a tutor for reading, navigating, and sanity-checking unfamiliar Rust code (lifetimes, traits, `unsafe`, numeric crates). Synced from agent-skills@v0.9.0.
+time: 2026-06-01T19:29:30.198717819+10:00

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,6 +59,18 @@
       ]
     },
     {
+      "name": "rust",
+      "source": "./plugins/rust",
+      "description": "Rust — read & navigate unfamiliar Rust code, explain constructs, sanity-check correctness",
+      "version": "0.8.0",
+      "keywords": [
+        "rust",
+        "explain",
+        "ownership",
+        "borrow-checker"
+      ]
+    },
+    {
       "name": "dev-tools",
       "source": "./plugins/dev-tools",
       "description": "Developer tools — agent dispatch, multi-agent teams, link checking, docs",

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -100,6 +100,20 @@ R ecosystem — package dev, Shiny, Quarto, testing, CRAN.
 
 ---
 
+## rust
+
+Rust — read & navigate unfamiliar Rust code, explain constructs, sanity-check correctness.
+
+```bash
+/plugin install rust@rdl
+```
+
+| Skill | Description |
+|-------|-------------|
+| rust-explain | Read & navigate unfamiliar Rust — ownership, lifetimes, traits, `unsafe`/FFI, macros, and numeric crates; correctness sanity-checks |
+
+---
+
 ## dev-tools
 
 Developer tools — agent dispatch, multi-agent teams, link checking, docs.

--- a/plugins/rust/.claude-plugin/plugin.json
+++ b/plugins/rust/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "rust",
+  "version": "0.8.0",
+  "description": "Rust — read & navigate unfamiliar Rust code, explain constructs, sanity-check correctness",
+  "author": {
+    "name": "nq-rdl"
+  },
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT"
+}

--- a/plugins/rust/skills/rust-explain/SKILL.md
+++ b/plugins/rust/skills/rust-explain/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: rust-explain
+license: CC-BY-4.0
+description: >-
+  Teaching assistant for reading and navigating Rust code. Use when reading an
+  unfamiliar Rust codebase, when Rust is pasted with a question, when the borrow
+  checker or a rustc error is confusing, when a generated Rust kernel needs a
+  correctness sanity-check, or when asked to explain a specific Rust construct
+  (lifetimes, trait objects, Arc<Mutex<T>>, a macro, an iterator chain). Also
+  triggers on "explain this Rust", "what does this Rust do", "why doesn't this
+  compile", reading ownership/borrowing, FFI/unsafe blocks, or numeric crates
+  (ndarray, nalgebra, faer, polars, rayon).
+argument-hint: "Paste Rust + your question, or name a construct to explain (e.g. 'explain this lifetime', 'why doesn't this compile')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Rust Explain — Read & Navigate Rust Code
+
+A teaching assistant for **reading** Rust, for a reader who already programs (a
+computational-science background) and needs to read Rust fluently and trust the
+code is correct. **Correctness is the deliverable.**
+
+## Core stance: tutor, not gatekeeper
+
+The reader forms a hypothesis; you verify it and explain the *why*. Never give
+bare approval ("looks fine") — every answer teaches. When the reader is wrong,
+show what the compiler is protecting against, not just the fix.
+
+## Verify against the source of truth
+
+Rust evolves by **edition** (2015 → 2018 → 2021 → 2024) and the standard library
+grows every six weeks, so model knowledge drifts behind the language — the syntax
+you "remember" can be one version stale (the 2024 `unsafe extern` block is the
+classic trap). Correctness is the deliverable, so when a claim is high-stakes,
+confirm it against the official docs instead of asserting from memory. Fetch the
+canonical page when:
+
+- the answer is **edition-sensitive** — syntax that may have changed, or code
+  that simply *looks unfamiliar*;
+- a **precise contract decides correctness** — `unsafe`/FFI invariants,
+  `as`-cast semantics, aliasing rules, the exact meaning of an `error[E####]`;
+- you are about to call something *guaranteed* or *safe* and are unsure of the
+  boundary.
+
+Routine reading needs no lookup — reach for the docs when being wrong would
+mislead. `references/canonical-sources.rst` maps each kind of question to its
+authoritative URL on the official Rust docs (mostly
+`https://doc.rust-lang.org/stable/`; a few, like the Clippy lint index, live on
+other rust-lang sites).
+
+## Comparison policy
+
+Explain Rust **on its own terms** by default. Reach for a cross-language analogy
+*only* when it genuinely clarifies, and **cap it at C++ or Python — nothing
+else.** An analogy is a bridge, not the lens. Do not compare to any other
+language.
+
+## Operating modes
+
+Pick the mode that fits the request:
+
+1. **Line-by-line annotate** — explain every borrow, lifetime, and `?` inline,
+   in reading order.
+2. **Why does / doesn't this compile** — build borrow-checker intuition.
+   *Compile* the snippet to surface the real diagnostic — no need to run it —
+   then pair that message with what the rule protects against. Invoke `rustc`
+   with the snippet's edition and `--crate-type lib` so the borrow/lifetime
+   error isn't masked by a spurious edition-or-missing-`main` one. **Mind the
+   trust boundary:** compiling runs code (Cargo runs `build.rs`/proc-macros), and
+   even `rustc` type-checking expands built-in macros like `env!`/`include_str!`
+   that can leak local data into the diagnostics you read back — so compile
+   *untrusted* code only in a scrubbed sandbox, or just read it statically.
+   `references/tooling.rst` has the exact command and the full trust-boundary
+   note. Reserve actually executing the code for when the reader asks about
+   runtime behavior.
+3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
+   *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
+   `references/tooling.rst`.
+4. **Explain-on-demand** — explain one named construct or concept, pitched at
+   the reader's level.
+
+## The reading vocabulary
+
+Most "I can't read this" moments come from a fixed pattern set: ownership &
+borrowing, lifetimes, error flow (`Result`/`Option`/`?`), traits & generics,
+pattern matching, smart pointers (`Box`/`Rc`/`Arc`/`Weak`/`RefCell`/`Mutex`),
+closures & iterators, macros, modules & turbofish. Each gets a plain-English
+*what it does* + *why it's there* in `references/reading-vocabulary.rst` — load
+it when explaining any of these.
+
+## Numeric & scientific Rust
+
+For numeric code — `ndarray`, `nalgebra`, `faer`, `polars`, `rayon`, and FFI
+into BLAS/LAPACK — load `references/numeric-idioms.rst`. It carries the
+**silent-bug radar**: where a generated kernel can be *quietly wrong* (stencil
+off-by-ones, aliasing, parallel-reduction nondeterminism) and the rule of thumb
+for what the compiler catches in **safe** code (memory safety and data-race
+freedom — *not* deadlocks, lock poisoning, atomic ordering, or logical races),
+what returns inside **unsafe/FFI** and must be audited by hand (the same
+memory-safety and data-race classes), and what it *never* catches anywhere (your
+math, and concurrency bugs beyond data races).
+
+## Tooling
+
+`cargo clippy`, `rustc` errors as teachers, `rust-analyzer`, `cargo doc`, and
+`cargo expand` — how to drive each and turn its output into a lesson — live in
+`references/tooling.rst`. Run them directly; this skill ships no scripts.
+
+## References
+
+- `references/reading-vocabulary.rst` — the Rust reading vocabulary
+- `references/numeric-idioms.rst` — numeric crates, FFI, silent-bug radar
+- `references/tooling.rst` — clippy, rustc, rust-analyzer, cargo doc/expand
+- `references/canonical-sources.rst` — official Rust docs to fetch when a
+  high-stakes claim needs verifying (the source of truth)

--- a/plugins/rust/skills/rust-explain/references/canonical-sources.rst
+++ b/plugins/rust/skills/rust-explain/references/canonical-sources.rst
@@ -1,0 +1,111 @@
+Canonical Rust Documentation — Where to Verify
+==============================================
+
+The source of truth for everything this skill explains. Rust evolves by
+**edition** (2015 → 2018 → 2021 → 2024) and the standard library grows every
+six weeks, so a remembered fact can be one version stale — the bare
+``extern "C"`` block, a cast rule, a lint name. When the reader's correctness
+depends on a detail you are not certain of, **fetch the page below and read the
+current wording** instead of asserting from memory. That is the difference
+between teaching Rust and teaching last year's Rust.
+
+This is the master list: keep full URLs here, and cite docs *by name and
+section* at the point of use elsewhere (e.g. "Reference → Type cast
+expressions") so this file stays the one place a link is maintained.
+
+When to reach for these
+-----------------------
+
+``SKILL.md`` ("Verify against the source of truth") is the single statement of
+*when* to fetch — in short: edition-sensitive syntax, a precise ``unsafe`` /
+cast / aliasing contract, the exact meaning of an ``error[E####]``, or a
+"guaranteed / safe" claim near the boundary of what the compiler promises. This
+file is the *where*.
+
+Use the ``stable`` channel (latest release) by default — **but first check
+whether the project pins a version.** Editions are not the whole story: a crate
+can declare a minimum supported Rust version (``rust-version`` in
+``Cargo.toml``), repos often pin an exact toolchain (``rust-toolchain.toml``, or
+in CI), and the standard library grows new APIs and lints every six weeks.
+Before asserting an API exists or that an idiom compiles, read those pins and
+consult the docs for *that* version (or the project's own ``cargo doc`` against
+its toolchain) — latest-stable docs can show ``std`` APIs the project's compiler
+does not have, so an edition check alone will not catch the skew. If the code
+targets a specific edition, the **Edition Guide** is what reconciles "this
+compiles for them but looks wrong to me."
+
+The core documentation set
+--------------------------
+
+- **The Rust Programming Language** ("the Book") —
+  https://doc.rust-lang.org/stable/book/ — concept-first learning: ownership,
+  borrowing, lifetimes, traits, smart pointers. Best for building a reader's
+  intuition.
+- **The Rust Reference** — https://doc.rust-lang.org/stable/reference/ — the
+  authoritative description of syntax and semantics. The source of truth for
+  "what *exactly* does this do" (cast rules, operator behavior, item forms).
+- **Standard library API** — https://doc.rust-lang.org/stable/std/ — every
+  ``std`` type and method, each ``unsafe`` method carrying a **Safety** section
+  that states its contract. Use the search box at the top.
+- **The Rustonomicon** — https://doc.rust-lang.org/stable/nomicon/ — the
+  authority on ``unsafe`` Rust: raw pointers, aliasing, FFI, and the invariants
+  an ``unsafe`` block must uphold. Reach here to audit ``unsafe`` / FFI.
+- **The Edition Guide** — https://doc.rust-lang.org/stable/edition-guide/ — what
+  changed between editions. First stop when syntax looks new or "wrong."
+- **Error code index** — https://doc.rust-lang.org/stable/error_codes/ — the
+  long-form explanation behind every ``error[E####]`` (the same text
+  ``rustc --explain E0382`` prints).
+- **Rust by Example** — https://doc.rust-lang.org/stable/rust-by-example/ —
+  short, runnable, annotated examples.
+- **The Cargo Book** — https://doc.rust-lang.org/stable/cargo/ — ``cargo``
+  commands and the manifest format.
+- **Clippy lint index** — https://rust-lang.github.io/rust-clippy/stable/ —
+  what each Clippy lint means and *why* it fires (official, but hosted on
+  ``rust-lang.github.io`` rather than ``doc.rust-lang.org``). Prefer the
+  ``/stable/`` index over ``/master/``.
+
+Pinpoint links for what this skill teaches
+------------------------------------------
+
+The deep links behind the trickier, drift-prone passages in the other
+references:
+
+- ``as`` cast semantics (int→int: narrowing truncates, widening
+  sign/zero-extends, same-width reinterprets; float→int saturates, ``NaN`` → 0)
+  — `Reference: Type cast expressions
+  <https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#type-cast-expressions>`__.
+- 2024-edition ``unsafe extern`` blocks (and per-item ``safe`` / ``unsafe``) —
+  `Edition Guide: Unsafe extern blocks
+  <https://doc.rust-lang.org/stable/edition-guide/rust-2024/unsafe-extern.html>`__,
+  with the full grammar in `Reference: External blocks
+  <https://doc.rust-lang.org/stable/reference/items/external-blocks.html>`__.
+- Reference cycles and ``Weak<T>`` — `Book §15.6: Reference Cycles Can Leak
+  Memory <https://doc.rust-lang.org/stable/book/ch15-06-reference-cycles.html>`__;
+  `std::rc::Weak <https://doc.rust-lang.org/stable/std/rc/struct.Weak.html>`__ /
+  `std::sync::Weak
+  <https://doc.rust-lang.org/stable/std/sync/struct.Weak.html>`__.
+- Aliasing and ``unsafe`` contracts — `Reference: Behavior considered undefined
+  <https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html>`__
+  is the authoritative list (e.g. two live ``&mut`` to overlapping memory is UB;
+  a raw pointer carries no aliasing requirement *of its own*, but an *access*
+  through it — or an FFI write — that conflicts with a live ``&``/``&mut`` is
+  still UB). Conceptual intro: `Nomicon: Aliasing
+  <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__; FFI specifics:
+  `Nomicon: FFI <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
+- Slice splitting / unchecked access contracts — `std::slice
+  <https://doc.rust-lang.org/stable/std/primitive.slice.html>`__ (read the
+  *Safety* note on ``get_unchecked`` and the guarantee on ``split_at_mut``).
+- Borrow / move diagnostics — `error_codes: E0382
+  <https://doc.rust-lang.org/stable/error_codes/E0382.html>`__ (use/borrow of a
+  moved value), `E0502
+  <https://doc.rust-lang.org/stable/error_codes/E0502.html>`__ (mutable +
+  immutable borrow).
+- Minimum supported Rust version / toolchain pinning — `Cargo: the rust-version
+  field <https://doc.rust-lang.org/stable/cargo/reference/rust-version.html>`__
+  (a project's supported compiler; check this and any ``rust-toolchain.toml``
+  before asserting an API exists or an idiom compiles, since ``std`` grows
+  faster than editions change).
+- rust-analyzer trust boundary — `rust-analyzer: Security
+  <https://rust-analyzer.github.io/book/security.html>`__ (it runs build scripts
+  and proc-macros by default, so opening an untrusted workspace can execute
+  code; the page lists the settings that disable that).

--- a/plugins/rust/skills/rust-explain/references/numeric-idioms.rst
+++ b/plugins/rust/skills/rust-explain/references/numeric-idioms.rst
@@ -1,0 +1,144 @@
+Numeric & Scientific Rust
+=========================
+
+A recognition guide for numeric Rust, plus the highest-value job: catching code
+that compiles but is **quietly wrong**. The reader has a computational-science
+background — correctness is the deliverable.
+
+Ecosystem Idioms to Recognize
+-----------------------------
+
+- **ndarray** — N-dimensional arrays (the NumPy of Rust). ``Array2<f64>`` is an
+  owned 2-D array; ``ArrayView2<f64>`` borrows one. Watch for ``.slice()`` with
+  the ``s![..]`` indexing macro.
+- **nalgebra** — linear algebra where *statically sized* types carry their
+  dimensions in the type: ``Matrix3<f64>``, ``Vector4<f64>``, ``SMatrix`` — there
+  a shape mismatch is a *compile-time* type error. But nalgebra also has
+  **dynamically sized** ``DMatrix<f64>`` / ``DVector<f64>`` (and mixed
+  static/dynamic shapes) whose dimensions are known only at runtime: there a
+  mismatch is a **runtime panic**, not a type error. Don't read "nalgebra" as
+  "shapes proven at compile time" — check whether the types are static or
+  dynamic, and guard or test dynamic operations the way you would any runtime
+  bound.
+- **faer** — high-performance dense linear algebra (decompositions, solves) built
+  for speed; recognize ``faer::Mat``.
+- **polars** — dataframes (the Rust pandas): a lazy ``LazyFrame`` query plan and
+  an eager ``DataFrame``.
+- **rayon** — data parallelism by changing ``.iter()`` to ``.par_iter()``. If you
+  see ``par_iter`` / ``par_bridge`` / ``into_par_iter``, the loop runs on a
+  thread pool.
+
+FFI Reading: Rust Calling Native Libraries
+------------------------------------------
+
+A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this on
+the **2024 edition**:
+
+.. code:: rust
+
+   unsafe extern "C" {               // 2024 edition: the extern block is `unsafe`
+       // a function provided by a C library, linked at build time;
+       // an unmarked item defaults to `unsafe` to call
+       fn cblas_ddot(n: i32, x: *const f64, incx: i32, y: *const f64, incy: i32) -> f64;
+   }
+
+   let dot = unsafe {                 // unsafe: the compiler cannot verify the C side
+       cblas_ddot(n, x.as_ptr(), 1, y.as_ptr(), 1)
+   };
+
+Reading rules:
+
+- ``extern "C"`` = "this uses the C ABI" (the calling convention for FFI).
+- **Editions differ — expect both forms.** Since the 2024 edition the block
+  must be written ``unsafe extern "C" { … }``, and each item may be marked
+  ``safe`` (callable without an ``unsafe`` block) or ``unsafe`` / left unmarked
+  (the caller upholds the contract). Crates on the 2015/2018/2021 editions still
+  use a bare ``extern "C" { … }``. If the form looks unfamiliar, confirm against
+  the Edition Guide (``references/canonical-sources.rst``) rather than guessing
+  — this is exactly the kind of syntax that drifts between editions.
+- Raw pointers ``*const T`` / ``*mut T`` are the C-facing types; ``.as_ptr()``
+  hands a slice's buffer to C.
+- ``unsafe`` does **not** mean "wrong." It means *the compiler's guarantees stop
+  here; a human asserts the contract*. Read every ``unsafe`` block as a claim to
+  audit: are the pointers valid, the lengths right, the data still live?
+
+Silent-Bug Radar (highest value)
+--------------------------------
+
+Rust's compiler eliminates whole bug classes — but **only in safe code, and
+never your math.** Anchor every review on this split.
+
+**In safe Rust, memory safety is not yours to re-audit** — but mind *how* each
+class is ruled out. The compiler **rejects at compile time**: use-after-free,
+double-free, data races on shared memory, null dereferences, uninitialized
+reads. **Out-of-bounds is different** — the compiler does *not* catch it; safe
+Rust instead **converts it into a guaranteed runtime panic** (or a ``None`` from
+``.get()``), never silent corruption. So indexing is safe from *corruption*, but
+a wrong index still panics — a production failure to handle, and a correctness
+bug to chase (the stencil off-by-ones below).
+
+**Inside ``unsafe`` / FFI they come back.** A wrong pointer, length, or lifetime
+in an ``unsafe`` block or a C call can reintroduce every one of those — the
+``unsafe`` contract, not the compiler, is what holds them off. Audit each
+``unsafe`` region for exactly the bugs safe Rust had ruled out (Nomicon, via
+``references/canonical-sources.rst``).
+
+**The compiler never catches** (audit these every time): *your math.* Code that
+satisfies the borrow checker can still compute the wrong number.
+
+Look hard at:
+
+- **Stencil / index off-by-ones.** Loop bounds such as ``1..n-1`` versus
+  ``1..n``, halo / ghost-cell handling, ``len()`` versus ``len()-1``. A bounds
+  check turns a bad index into a *panic*, not a silently wrong result — but the
+  wrong-but-in-range index is silent.
+- **Aliasing & bounds promises in ``unsafe`` / FFI.** Read the contract
+  precisely — the common constructs promise *different* things. ``split_at_mut``
+  is **safe**: it hands back two slices the compiler *guarantees* do not
+  overlap, so trust it. ``get_unchecked`` / ``get_unchecked_mut`` are
+  **unsafe**: they drop the bounds check, so the *caller* must guarantee the
+  index is in bounds (a wrong index is undefined behavior, not a panic). The
+  **aliasing** rule constrains *live references*, and it bites on every *access*
+  to that memory while a reference is live — not only when a second reference is
+  created. Holding several ``*mut T`` is fine in itself, but *reading or writing*
+  through a raw pointer (or letting C/FFI write) while a ``&mut`` to the same
+  bytes is live — or mutating while a non-``UnsafeCell`` ``&`` is live — is
+  undefined behavior, even though no second ``&mut`` ever exists. So audit the
+  *accesses*: every raw-pointer load/store and FFI write that touches memory a
+  live reference still covers, not just where unsafe code hands out another
+  reference (and ``split_at_mut`` itself stays safe — its two slices are
+  disjoint by construction). A broken aliasing assumption corrupts results
+  silently (Reference → Behavior considered undefined; std ``slice`` docs).
+- **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
+  so a ``rayon`` reduction can give a *different sum* per run depending on
+  chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
+  or a custom ``reduce`` feeds a result that must be bit-reproducible.
+- **Concurrency beyond data races.** Safe Rust rules out *data races*, not
+  concurrency bugs in general — ``Arc<Mutex<T>>`` and ``rayon`` code that
+  compiles can still **deadlock**, **poison a lock** (``.lock()`` returns
+  ``Err`` after a holder panics mid-critical-section), use the wrong atomic
+  ``Ordering`` (``Relaxed`` where ``Acquire``/``Release`` was needed), or lose a
+  **check-then-act race** across two locks or atomics. The symptom is a hang or
+  a nondeterministic wrong result, never a compile error — so audit the *logic*,
+  not just the types.
+- **Integer / float casts.** ``as`` is silent and the rule depends on the
+  types. A **narrowing** integer→integer cast keeps the low bits
+  (``300_i32 as u8`` is ``44``). A **widening** cast that stays in the same
+  signedness preserves the value (``-1_i8 as i32`` is ``-1``; ``200_u8 as u32``
+  is ``200``). But casting a **signed value into an unsigned type** turns a
+  negative number into a large positive one — ``-1_i32 as u32`` is
+  ``4294967295`` and ``-1_i32 as usize`` is ``usize::MAX`` — the classic silent
+  ``-1``-as-index bug, regardless of width. Meanwhile float→integer
+  **saturates** to the target's range with ``NaN`` mapping to ``0``
+  (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is ``0``). Separately,
+  overflowing *arithmetic* on ``usize`` indices **panics in debug builds but
+  wraps in release by default**
+  (it tracks the ``overflow-checks`` profile flag) — so an index bug can stay
+  hidden until the optimized build (Reference → Type cast expressions).
+
+When reviewing a generated kernel, state the split explicitly: "in the safe
+regions the compiler guarantees memory safety and data-race freedom (not
+deadlocks, lock poisoning, atomic ordering, or logical races); inside
+``unsafe`` / FFI you must audit those memory and data-race classes too;
+**nowhere** does it guarantee the arithmetic or the concurrency logic — check
+the indices, the reduction order, the casts, and the locking."

--- a/plugins/rust/skills/rust-explain/references/reading-vocabulary.rst
+++ b/plugins/rust/skills/rust-explain/references/reading-vocabulary.rst
@@ -1,0 +1,194 @@
+Rust Reading Vocabulary
+=======================
+
+The fixed pattern set behind most "I can't read this." For a reader who already
+programs: each entry is **what it does** + **why it's there**, oriented toward
+*reading* code, not writing it. Explain on Rust's own terms; reach for a C++ or
+Python analogy only when it truly clarifies.
+
+Ownership & Borrowing
+---------------------
+
+``T`` owns its value; ``&T`` borrows it (shared, read-only); ``&mut T`` borrows
+it exclusively (read-write). Assigning or passing an owned non-``Copy`` value
+*moves* it — the source is *invalidated* and can no longer be used.
+
+.. code:: rust
+
+   let s = String::from("grid");
+   let t = s;            // value MOVES from s to t
+   // println!("{s}");   // would not compile: s no longer owns anything
+   println!("{t}");      // t is the owner now
+
+*Why it's there:* ownership frees memory without a garbage collector and prevents
+use-after-free at compile time. Reading rule: a bare ``T`` in a signature takes
+ownership (the caller gives it up); ``&T`` / ``&mut T`` borrows (the caller keeps
+it).
+
+Lifetimes
+---------
+
+A lifetime like ``'a`` names *how long a reference is valid*. You mostly read
+them in signatures: ``fn first<'a>(xs: &'a [f64]) -> &'a f64`` says "the returned
+reference lives as long as the slice you passed in." Most lifetimes are *elided*
+(inferred); you only see explicit ones when the compiler cannot guess the
+relationship.
+
+*Why it's there:* lifetimes let the borrow checker prove a reference never
+outlives the data it points to — no dangling pointers. Reading rule: ``'a`` is
+not a value, it is a constraint; read which inputs and outputs share a lifetime
+and ignore the rest of the noise.
+
+Error Flow
+----------
+
+``Result<T, E>`` is "either a ``T`` (``Ok``) or an error ``E`` (``Err``)";
+``Option<T>`` is "either a ``T`` (``Some``) or nothing (``None``)". The ``?``
+operator means "unwrap the ``Ok`` / ``Some``, or return the ``Err`` / ``None``
+from this function early."
+
+.. code:: rust
+
+   fn load(path: &str) -> Result<String, std::io::Error> {
+       let text = std::fs::read_to_string(path)?;  // ? returns early on Err
+       Ok(text)
+   }
+
+``.unwrap()`` and ``.expect("msg")`` extract the value but **panic** on ``Err`` /
+``None`` — a crash point. Flag them in code meant to be robust.
+
+*Why it's there:* errors are ordinary values, so the type system forces you to
+handle (or explicitly defer with ``?``) every failure. Reading rule: ``?`` is a
+propagation shortcut; ``.unwrap()`` is a "trust me, cannot fail here" — and a
+place bugs hide.
+
+Traits & Generics
+-----------------
+
+A trait is a shared interface (close to a C++ concept or a Python protocol).
+Generics with ``where`` bounds say "any type that implements this trait."
+
+.. code:: rust
+
+   // signature sketch — `Float` comes from the num_traits crate
+   fn norm<T>(xs: &[T]) -> T
+   where
+       T: num_traits::Float,
+   {
+       xs.iter().fold(T::zero(), |a, &x| a + x * x).sqrt()
+   }
+
+- ``impl Trait`` in argument position = "some type implementing Trait", resolved
+  at compile time (*monomorphized* — one specialized copy per concrete type, zero
+  runtime cost).
+- ``dyn Trait`` (a *trait object*, usually ``Box<dyn Trait>`` or ``&dyn Trait``)
+  = dynamic dispatch through a vtable (one copy of the code, runtime
+  indirection).
+
+*Why it's there:* traits give polymorphism with a choice of cost model. Reading
+rule: ``impl`` / generic = compile-time, fast, larger binary; ``dyn`` = runtime
+dispatch, smaller binary, slight overhead.
+
+Pattern Matching
+----------------
+
+``match`` destructures a value against patterns, *exhaustively* (every case must
+be handled). ``if let`` and ``let ... else`` are shorthands for matching a single
+pattern.
+
+.. code:: rust
+
+   match result {
+       Ok(v) => use_it(v),
+       Err(e) => report(e),
+   }
+
+   let Some(x) = maybe else {
+       return;            // bail out if None
+   };
+
+*Why it's there:* exhaustiveness means adding a new enum variant forces you to
+update every match — the compiler finds the gaps. Reading rule: arms are tried
+top-to-bottom; ``_`` is the catch-all.
+
+Smart Pointers & Combinations
+-----------------------------
+
+- ``Box<T>`` — owned value on the heap (one owner).
+- ``Rc<T>`` / ``Arc<T>`` — shared ownership by reference counting (``Arc`` is the
+  thread-safe, atomic version).
+- ``Weak<T>`` — a *non-owning* ``Rc`` / ``Arc`` handle (from ``Rc::downgrade`` /
+  ``Arc::downgrade``). It does **not** keep the value alive; you call
+  ``.upgrade()`` to get an ``Option<Rc<T>>`` (or ``Option<Arc<T>>`` on the
+  ``Arc`` side) and find out whether it still exists. Its purpose is to
+  **break reference cycles** (see below).
+- ``RefCell<T>`` / ``Mutex<T>`` — interior mutability: mutate through a shared
+  reference, with the borrow rule enforced at *runtime* (``RefCell``, single
+  thread) or via a lock (``Mutex``, across threads).
+
+Read combinations inside-out. ``Arc<Mutex<T>>`` = "a ``T`` that several threads
+share (``Arc``) and take turns mutating under a lock (``Mutex``)" — the canonical
+shared-mutable-state-across-threads shape.
+
+*Why it's there:* these recover patterns that ownership alone forbids — sharing,
+back-references, mutate-through-shared — each naming its exact cost. One caveat
+worth flagging when you see it: ``Rc`` / ``Arc`` do **not** manage *cycles* — a
+cycle of strong references never reaches refcount 0 and leaks, and ``Weak<T>``
+is precisely how correct code breaks it (Book §15.6, via
+``references/canonical-sources.rst``). Reading rule: the outer wrapper is the
+sharing model, the inner one is the data, and a ``Weak`` is a deliberately
+non-owning edge.
+
+Closures & Iterators
+--------------------
+
+A closure ``|x| x * x`` is an anonymous function that can capture variables. The
+trait it implements says how it can be *called*: ``Fn`` (via ``&self`` — only
+reads its captures, so callable repeatedly), ``FnMut`` (via ``&mut self`` — may
+mutate captures), ``FnOnce`` (via ``self`` — may move captures out, so callable
+once). ``move`` is separate: it forces the closure to *capture by value* (take
+ownership), common when spawning threads — a ``move`` closure can still be
+``Fn`` if its body only reads what it captured.
+
+Iterator chains are **lazy**: ``.iter().map(...).filter(...)`` builds a pipeline
+that does nothing until a *consumer* (``.collect()``, ``.sum()``, a ``for`` loop)
+drives it.
+
+.. code:: rust
+
+   let squares: Vec<f64> = xs.iter().map(|x| x * x).collect();
+   let total: f64 = squares.iter().sum();
+
+*Why it's there:* laziness lets chains fuse into a single pass with no
+intermediate allocations — the *zero-cost-abstraction* intent is that they
+optimize down to roughly what a hand-written loop emits (an optimizer outcome,
+not a language guarantee). Reading rule: find the consumer at the end of the
+chain; that is what actually runs the work.
+
+Macros
+------
+
+A trailing ``!`` marks a macro invocation, not a function call: ``println!``,
+``vec!``, ``assert_eq!``. Macros run at compile time and accept "syntax" a
+function cannot (format strings, variadic arguments). ``#[derive(Debug, Clone)]``
+is a *derive macro* that generates trait implementations for you.
+
+*Why it's there:* macros remove boilerplate the type system cannot. Reading rule:
+treat ``name!(...)`` as "expands to some code"; when you must see what, use
+``cargo expand`` (see ``references/tooling.rst``).
+
+Modules, Visibility & Turbofish
+-------------------------------
+
+``mod`` defines a module; ``pub`` exposes an item; ``use`` brings a path into
+scope. Paths use ``::`` (``std::sync::Arc``). The **turbofish** ``::<>`` pins a
+generic type the compiler cannot infer:
+
+.. code:: rust
+
+   let v = "42".parse::<i32>().unwrap();      // ::<i32> tells parse what to make
+   let xs = (0..n).map(|i| i as f64).collect::<Vec<f64>>();  // ::<Vec<f64>> picks the container
+
+*Why it's there:* explicit paths and visibility keep the module graph auditable.
+Reading rule: a turbofish always answers "what type?" for the call immediately
+before it.

--- a/plugins/rust/skills/rust-explain/references/tooling.rst
+++ b/plugins/rust/skills/rust-explain/references/tooling.rst
@@ -1,0 +1,166 @@
+Rust Tooling as a Teaching Aid
+==============================
+
+Let the tools do the mechanical work, then explain *why* their output is right.
+None of this needs a wrapper script — run the tools directly.
+
+Trust boundary first
+--------------------
+
+Compiling Rust runs code — and even *type-checking* can read your machine. Both
+are part of the trust boundary, in two layers:
+
+- **Any Cargo command that compiles** — ``cargo check``, ``cargo clippy``,
+  ``cargo build``, ``cargo doc``, ``cargo expand``, ``cargo test``, ``cargo
+  run`` — **runs** the crate's ``build.rs`` and any procedural macros as part of
+  compiling: arbitrary code, executed before you ever run a binary. (``cargo
+  expand`` is the sharpest case — expanding a proc-macro *is* executing it — and
+  ``cargo doc --open`` also launches a browser.)
+- **Plain ``rustc`` on a single file is lower-risk, not safe.** No manifest
+  means no ``build.rs``, and with no proc-macro crate to link, none of *those*
+  run — but ``rustc`` still expands **built-in** macros at compile time, and
+  ``env!``, ``option_env!``, ``include_str!``, ``include_bytes!``, and
+  ``include!`` read environment variables and files straight off your machine.
+  A snippet can fold them into a diagnostic, and the message — which this skill
+  tells you to read back — becomes an exfiltration channel. Verified with rustc
+  1.94.1: ``compile_error!(env!("HOME"))`` makes the compiler print your home
+  path, and ``compile_error!(include_str!("…/secret"))`` prints a file's
+  contents — no binary, build script, or proc-macro required.
+
+So for **untrusted** code, do not compile it on your own machine at all: read
+and explain it statically, or compile only inside a disposable sandbox with a
+**scrubbed environment** and no access to your home or repo, treating every
+diagnostic as attacker-controlled output. Reserve ``rustc`` / Cargo on the real
+machine for code you trust. This is the same caution the skill applies to mode 2
+("Why does / doesn't this compile").
+
+cargo clippy — the free senior reviewer
+---------------------------------------
+
+``cargo clippy`` is Rust's idiom linter. Let it find the non-idiomatic code, then
+explain the reasoning instead of merely echoing the fix.
+
+.. code:: text
+
+   warning: the loop variable `i` is only used to index `v`
+    --> idiom.rs:3:14
+     |
+   3 |     for i in 0..v.len() {
+     |              ^^^^^^^^^^
+     |
+     = note: `#[warn(clippy::needless_range_loop)]` on by default
+   help: consider using an iterator
+     |
+   3 -     for i in 0..v.len() {
+   3 +     for <item> in &v {
+     |
+
+Teach it: "Clippy flags ``needless_range_loop`` (see the `clippy lint index
+<https://rust-lang.github.io/rust-clippy/stable/index.html#needless_range_loop>`__).
+Indexing ``v[i]`` re-checks bounds every iteration and hides intent; ``for x in
+&v`` (equivalently ``v.iter()``) iterates the elements directly — clearer, and
+it lets the optimizer elide the per-iteration bounds check in the common case
+(bounds-check *elimination* is an LLVM optimization, not a language guarantee).
+This is the gap between *works* and *fluent*." For the
+idiomatic-rewrite mode, run clippy first, then walk each lint.
+
+rustc errors as teachers
+------------------------
+
+Feed the **code and the real compiler message together**, then explain what the
+rule protects against. Two canonical examples:
+
+.. code:: text
+
+   error[E0382]: borrow of moved value: `s`
+    --> move.rs:4:20
+     |
+   3 |     let t = s;
+     |             - value moved here
+   4 |     println!("{}", s);
+     |                    ^ value borrowed here after move
+
+"``s`` was *moved* into ``t``, so ``s`` is no longer usable — not emptied,
+**invalidated**: the value now lives in ``t`` and the compiler statically
+forbids touching ``s``. It is preventing two owners of one heap buffer — which
+would double-free at scope end. Fix: borrow (``&s``) if you only need to read,
+or ``.clone()`` if you genuinely need a second copy."
+
+.. code:: text
+
+   error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
+    --> borrow.rs:4:5
+     |
+   3 |     let first = &v[0];
+     |                  - immutable borrow occurs here
+   4 |     v.push(4);
+     |     ^^^^^^^^^ mutable borrow occurs here
+   5 |     println!("{first}");
+     |                ----- immutable borrow later used here
+
+"``push`` can reallocate the vector, which would leave ``first`` dangling. The
+borrow checker forbids a mutable borrow while a shared borrow is still live —
+exactly the iterator-invalidation bug that C++ allows silently."
+
+Use ``rustc --explain E0502`` for the long-form explanation of any error code.
+
+Invoking ``rustc`` on a snippet: two defaults will mislead you. Bare
+``rustc file.rs`` assumes **edition 2015** and a **binary** crate, so modern
+syntax (``async``, ``let … else``) trips an edition error and any snippet
+without ``fn main`` trips ``error[E0601]`` — spurious errors that hide the
+borrow/lifetime one you actually want. Type-check a snippet like this instead:
+
+.. code:: text
+
+   rustc --edition 2021 --crate-type lib --emit=metadata snippet.rs -o "$(mktemp -d)/meta"
+
+``--edition`` should match the code (read it from ``Cargo.toml`` or ask the
+reader; use ``2024`` for the newest); ``--crate-type lib`` drops the ``fn main``
+requirement; ``--emit=metadata`` type-checks without producing — or running — a
+binary. Send the metadata to a throwaway temp dir rather than ``/dev/null``:
+``rustc`` writes its temp files *next to* the ``-o`` path, so a non-writable
+location (``/dev``) makes it abort with its own spurious error. Read the
+diagnostics it prints — a non-zero exit just means it found the error you were
+after. Run this only on code you trust, or inside the scrubbed sandbox from
+"Trust boundary first": even this type-check expands ``env!`` / ``include_str!``,
+so a hostile snippet can leak local data into the very diagnostics you read
+back. Code that pulls in external crates will not compile standalone: that needs
+the crate's own build, which means trusted code or a sandbox, not raw ``rustc``.
+
+rust-analyzer — navigation
+--------------------------
+
+The IDE language server. For *reading*, its highest-value features are:
+
+- **Hover** — shows the inferred type of any expression. Rust infers most types,
+  so hover makes the invisible visible.
+- **Inlay hints** — inline type and parameter-name annotations.
+- **Go to definition / find references** — trace where a trait impl or value
+  actually comes from.
+
+But it is **not** outside the trust boundary. By default rust-analyzer runs the
+project's ``build.rs`` and procedural macros (``cargo.buildScripts.enable`` and
+``procMacro.enable`` are on) so its analysis is accurate — which means merely
+*opening* an untrusted workspace can execute code. "Read-only navigation" is not
+read-only (rust-analyzer says as much in its own security note — see
+``references/canonical-sources.rst``). On untrusted code, read files statically
+instead, or open it in a disposable sandbox with build scripts, proc-macros, and
+check-on-save disabled and any project-supplied editor/tool configuration
+ignored.
+
+cargo doc & cargo expand
+------------------------
+
+- ``cargo doc --open`` builds and opens the API docs for the crate *and all its
+  dependencies* — the fastest way to learn what an unfamiliar type offers.
+- ``cargo expand`` shows what a macro expands to. When ``#[derive(...)]`` or a
+  ``name!()`` macro is opaque, expand it to read the generated code (requires the
+  ``cargo-expand`` tool).
+
+Both compile the crate, so the **trust boundary above applies** — run them only
+on trusted code or in a sandbox. For *untrusted* code, the non-executing
+substitutes are: read the prebuilt docs on `docs.rs <https://docs.rs/>`__
+(already built in a sandbox) or the crate source directly instead of
+``cargo doc``; and read the macro's definition by hand (or expand it inside a
+throwaway container) instead of running ``cargo expand``, since expansion
+*executes* the macro.

--- a/registry/bundles/rust.yaml
+++ b/registry/bundles/rust.yaml
@@ -1,0 +1,18 @@
+schemaVersion: v1
+id: rust
+displayName: Rust
+description: Rust — read & navigate unfamiliar Rust code, explain constructs, sanity-check correctness.
+owners:
+  - rdl
+channels:
+  - stable
+skills:
+  - rust-explain
+hooks: []
+prompts: []
+mcp: []
+targets:
+  claude:
+    enabled: true
+    pluginName: rust
+    marketplaceName: rdl

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: rust-explain
+license: CC-BY-4.0
+description: >-
+  Teaching assistant for reading and navigating Rust code. Use when reading an
+  unfamiliar Rust codebase, when Rust is pasted with a question, when the borrow
+  checker or a rustc error is confusing, when a generated Rust kernel needs a
+  correctness sanity-check, or when asked to explain a specific Rust construct
+  (lifetimes, trait objects, Arc<Mutex<T>>, a macro, an iterator chain). Also
+  triggers on "explain this Rust", "what does this Rust do", "why doesn't this
+  compile", reading ownership/borrowing, FFI/unsafe blocks, or numeric crates
+  (ndarray, nalgebra, faer, polars, rayon).
+argument-hint: "Paste Rust + your question, or name a construct to explain (e.g. 'explain this lifetime', 'why doesn't this compile')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Rust Explain — Read & Navigate Rust Code
+
+A teaching assistant for **reading** Rust, for a reader who already programs (a
+computational-science background) and needs to read Rust fluently and trust the
+code is correct. **Correctness is the deliverable.**
+
+## Core stance: tutor, not gatekeeper
+
+The reader forms a hypothesis; you verify it and explain the *why*. Never give
+bare approval ("looks fine") — every answer teaches. When the reader is wrong,
+show what the compiler is protecting against, not just the fix.
+
+## Verify against the source of truth
+
+Rust evolves by **edition** (2015 → 2018 → 2021 → 2024) and the standard library
+grows every six weeks, so model knowledge drifts behind the language — the syntax
+you "remember" can be one version stale (the 2024 `unsafe extern` block is the
+classic trap). Correctness is the deliverable, so when a claim is high-stakes,
+confirm it against the official docs instead of asserting from memory. Fetch the
+canonical page when:
+
+- the answer is **edition-sensitive** — syntax that may have changed, or code
+  that simply *looks unfamiliar*;
+- a **precise contract decides correctness** — `unsafe`/FFI invariants,
+  `as`-cast semantics, aliasing rules, the exact meaning of an `error[E####]`;
+- you are about to call something *guaranteed* or *safe* and are unsure of the
+  boundary.
+
+Routine reading needs no lookup — reach for the docs when being wrong would
+mislead. `references/canonical-sources.rst` maps each kind of question to its
+authoritative URL on the official Rust docs (mostly
+`https://doc.rust-lang.org/stable/`; a few, like the Clippy lint index, live on
+other rust-lang sites).
+
+## Comparison policy
+
+Explain Rust **on its own terms** by default. Reach for a cross-language analogy
+*only* when it genuinely clarifies, and **cap it at C++ or Python — nothing
+else.** An analogy is a bridge, not the lens. Do not compare to any other
+language.
+
+## Operating modes
+
+Pick the mode that fits the request:
+
+1. **Line-by-line annotate** — explain every borrow, lifetime, and `?` inline,
+   in reading order.
+2. **Why does / doesn't this compile** — build borrow-checker intuition.
+   *Compile* the snippet to surface the real diagnostic — no need to run it —
+   then pair that message with what the rule protects against. Invoke `rustc`
+   with the snippet's edition and `--crate-type lib` so the borrow/lifetime
+   error isn't masked by a spurious edition-or-missing-`main` one. **Mind the
+   trust boundary:** compiling runs code (Cargo runs `build.rs`/proc-macros), and
+   even `rustc` type-checking expands built-in macros like `env!`/`include_str!`
+   that can leak local data into the diagnostics you read back — so compile
+   *untrusted* code only in a scrubbed sandbox, or just read it statically.
+   `references/tooling.rst` has the exact command and the full trust-boundary
+   note. Reserve actually executing the code for when the reader asks about
+   runtime behavior.
+3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
+   *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
+   `references/tooling.rst`.
+4. **Explain-on-demand** — explain one named construct or concept, pitched at
+   the reader's level.
+
+## The reading vocabulary
+
+Most "I can't read this" moments come from a fixed pattern set: ownership &
+borrowing, lifetimes, error flow (`Result`/`Option`/`?`), traits & generics,
+pattern matching, smart pointers (`Box`/`Rc`/`Arc`/`Weak`/`RefCell`/`Mutex`),
+closures & iterators, macros, modules & turbofish. Each gets a plain-English
+*what it does* + *why it's there* in `references/reading-vocabulary.rst` — load
+it when explaining any of these.
+
+## Numeric & scientific Rust
+
+For numeric code — `ndarray`, `nalgebra`, `faer`, `polars`, `rayon`, and FFI
+into BLAS/LAPACK — load `references/numeric-idioms.rst`. It carries the
+**silent-bug radar**: where a generated kernel can be *quietly wrong* (stencil
+off-by-ones, aliasing, parallel-reduction nondeterminism) and the rule of thumb
+for what the compiler catches in **safe** code (memory safety and data-race
+freedom — *not* deadlocks, lock poisoning, atomic ordering, or logical races),
+what returns inside **unsafe/FFI** and must be audited by hand (the same
+memory-safety and data-race classes), and what it *never* catches anywhere (your
+math, and concurrency bugs beyond data races).
+
+## Tooling
+
+`cargo clippy`, `rustc` errors as teachers, `rust-analyzer`, `cargo doc`, and
+`cargo expand` — how to drive each and turn its output into a lesson — live in
+`references/tooling.rst`. Run them directly; this skill ships no scripts.
+
+## References
+
+- `references/reading-vocabulary.rst` — the Rust reading vocabulary
+- `references/numeric-idioms.rst` — numeric crates, FFI, silent-bug radar
+- `references/tooling.rst` — clippy, rustc, rust-analyzer, cargo doc/expand
+- `references/canonical-sources.rst` — official Rust docs to fetch when a
+  high-stakes claim needs verifying (the source of truth)

--- a/skills/rust-explain/references/canonical-sources.rst
+++ b/skills/rust-explain/references/canonical-sources.rst
@@ -1,0 +1,111 @@
+Canonical Rust Documentation — Where to Verify
+==============================================
+
+The source of truth for everything this skill explains. Rust evolves by
+**edition** (2015 → 2018 → 2021 → 2024) and the standard library grows every
+six weeks, so a remembered fact can be one version stale — the bare
+``extern "C"`` block, a cast rule, a lint name. When the reader's correctness
+depends on a detail you are not certain of, **fetch the page below and read the
+current wording** instead of asserting from memory. That is the difference
+between teaching Rust and teaching last year's Rust.
+
+This is the master list: keep full URLs here, and cite docs *by name and
+section* at the point of use elsewhere (e.g. "Reference → Type cast
+expressions") so this file stays the one place a link is maintained.
+
+When to reach for these
+-----------------------
+
+``SKILL.md`` ("Verify against the source of truth") is the single statement of
+*when* to fetch — in short: edition-sensitive syntax, a precise ``unsafe`` /
+cast / aliasing contract, the exact meaning of an ``error[E####]``, or a
+"guaranteed / safe" claim near the boundary of what the compiler promises. This
+file is the *where*.
+
+Use the ``stable`` channel (latest release) by default — **but first check
+whether the project pins a version.** Editions are not the whole story: a crate
+can declare a minimum supported Rust version (``rust-version`` in
+``Cargo.toml``), repos often pin an exact toolchain (``rust-toolchain.toml``, or
+in CI), and the standard library grows new APIs and lints every six weeks.
+Before asserting an API exists or that an idiom compiles, read those pins and
+consult the docs for *that* version (or the project's own ``cargo doc`` against
+its toolchain) — latest-stable docs can show ``std`` APIs the project's compiler
+does not have, so an edition check alone will not catch the skew. If the code
+targets a specific edition, the **Edition Guide** is what reconciles "this
+compiles for them but looks wrong to me."
+
+The core documentation set
+--------------------------
+
+- **The Rust Programming Language** ("the Book") —
+  https://doc.rust-lang.org/stable/book/ — concept-first learning: ownership,
+  borrowing, lifetimes, traits, smart pointers. Best for building a reader's
+  intuition.
+- **The Rust Reference** — https://doc.rust-lang.org/stable/reference/ — the
+  authoritative description of syntax and semantics. The source of truth for
+  "what *exactly* does this do" (cast rules, operator behavior, item forms).
+- **Standard library API** — https://doc.rust-lang.org/stable/std/ — every
+  ``std`` type and method, each ``unsafe`` method carrying a **Safety** section
+  that states its contract. Use the search box at the top.
+- **The Rustonomicon** — https://doc.rust-lang.org/stable/nomicon/ — the
+  authority on ``unsafe`` Rust: raw pointers, aliasing, FFI, and the invariants
+  an ``unsafe`` block must uphold. Reach here to audit ``unsafe`` / FFI.
+- **The Edition Guide** — https://doc.rust-lang.org/stable/edition-guide/ — what
+  changed between editions. First stop when syntax looks new or "wrong."
+- **Error code index** — https://doc.rust-lang.org/stable/error_codes/ — the
+  long-form explanation behind every ``error[E####]`` (the same text
+  ``rustc --explain E0382`` prints).
+- **Rust by Example** — https://doc.rust-lang.org/stable/rust-by-example/ —
+  short, runnable, annotated examples.
+- **The Cargo Book** — https://doc.rust-lang.org/stable/cargo/ — ``cargo``
+  commands and the manifest format.
+- **Clippy lint index** — https://rust-lang.github.io/rust-clippy/stable/ —
+  what each Clippy lint means and *why* it fires (official, but hosted on
+  ``rust-lang.github.io`` rather than ``doc.rust-lang.org``). Prefer the
+  ``/stable/`` index over ``/master/``.
+
+Pinpoint links for what this skill teaches
+------------------------------------------
+
+The deep links behind the trickier, drift-prone passages in the other
+references:
+
+- ``as`` cast semantics (int→int: narrowing truncates, widening
+  sign/zero-extends, same-width reinterprets; float→int saturates, ``NaN`` → 0)
+  — `Reference: Type cast expressions
+  <https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#type-cast-expressions>`__.
+- 2024-edition ``unsafe extern`` blocks (and per-item ``safe`` / ``unsafe``) —
+  `Edition Guide: Unsafe extern blocks
+  <https://doc.rust-lang.org/stable/edition-guide/rust-2024/unsafe-extern.html>`__,
+  with the full grammar in `Reference: External blocks
+  <https://doc.rust-lang.org/stable/reference/items/external-blocks.html>`__.
+- Reference cycles and ``Weak<T>`` — `Book §15.6: Reference Cycles Can Leak
+  Memory <https://doc.rust-lang.org/stable/book/ch15-06-reference-cycles.html>`__;
+  `std::rc::Weak <https://doc.rust-lang.org/stable/std/rc/struct.Weak.html>`__ /
+  `std::sync::Weak
+  <https://doc.rust-lang.org/stable/std/sync/struct.Weak.html>`__.
+- Aliasing and ``unsafe`` contracts — `Reference: Behavior considered undefined
+  <https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html>`__
+  is the authoritative list (e.g. two live ``&mut`` to overlapping memory is UB;
+  a raw pointer carries no aliasing requirement *of its own*, but an *access*
+  through it — or an FFI write — that conflicts with a live ``&``/``&mut`` is
+  still UB). Conceptual intro: `Nomicon: Aliasing
+  <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__; FFI specifics:
+  `Nomicon: FFI <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
+- Slice splitting / unchecked access contracts — `std::slice
+  <https://doc.rust-lang.org/stable/std/primitive.slice.html>`__ (read the
+  *Safety* note on ``get_unchecked`` and the guarantee on ``split_at_mut``).
+- Borrow / move diagnostics — `error_codes: E0382
+  <https://doc.rust-lang.org/stable/error_codes/E0382.html>`__ (use/borrow of a
+  moved value), `E0502
+  <https://doc.rust-lang.org/stable/error_codes/E0502.html>`__ (mutable +
+  immutable borrow).
+- Minimum supported Rust version / toolchain pinning — `Cargo: the rust-version
+  field <https://doc.rust-lang.org/stable/cargo/reference/rust-version.html>`__
+  (a project's supported compiler; check this and any ``rust-toolchain.toml``
+  before asserting an API exists or an idiom compiles, since ``std`` grows
+  faster than editions change).
+- rust-analyzer trust boundary — `rust-analyzer: Security
+  <https://rust-analyzer.github.io/book/security.html>`__ (it runs build scripts
+  and proc-macros by default, so opening an untrusted workspace can execute
+  code; the page lists the settings that disable that).

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -1,0 +1,144 @@
+Numeric & Scientific Rust
+=========================
+
+A recognition guide for numeric Rust, plus the highest-value job: catching code
+that compiles but is **quietly wrong**. The reader has a computational-science
+background — correctness is the deliverable.
+
+Ecosystem Idioms to Recognize
+-----------------------------
+
+- **ndarray** — N-dimensional arrays (the NumPy of Rust). ``Array2<f64>`` is an
+  owned 2-D array; ``ArrayView2<f64>`` borrows one. Watch for ``.slice()`` with
+  the ``s![..]`` indexing macro.
+- **nalgebra** — linear algebra where *statically sized* types carry their
+  dimensions in the type: ``Matrix3<f64>``, ``Vector4<f64>``, ``SMatrix`` — there
+  a shape mismatch is a *compile-time* type error. But nalgebra also has
+  **dynamically sized** ``DMatrix<f64>`` / ``DVector<f64>`` (and mixed
+  static/dynamic shapes) whose dimensions are known only at runtime: there a
+  mismatch is a **runtime panic**, not a type error. Don't read "nalgebra" as
+  "shapes proven at compile time" — check whether the types are static or
+  dynamic, and guard or test dynamic operations the way you would any runtime
+  bound.
+- **faer** — high-performance dense linear algebra (decompositions, solves) built
+  for speed; recognize ``faer::Mat``.
+- **polars** — dataframes (the Rust pandas): a lazy ``LazyFrame`` query plan and
+  an eager ``DataFrame``.
+- **rayon** — data parallelism by changing ``.iter()`` to ``.par_iter()``. If you
+  see ``par_iter`` / ``par_bridge`` / ``into_par_iter``, the loop runs on a
+  thread pool.
+
+FFI Reading: Rust Calling Native Libraries
+------------------------------------------
+
+A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this on
+the **2024 edition**:
+
+.. code:: rust
+
+   unsafe extern "C" {               // 2024 edition: the extern block is `unsafe`
+       // a function provided by a C library, linked at build time;
+       // an unmarked item defaults to `unsafe` to call
+       fn cblas_ddot(n: i32, x: *const f64, incx: i32, y: *const f64, incy: i32) -> f64;
+   }
+
+   let dot = unsafe {                 // unsafe: the compiler cannot verify the C side
+       cblas_ddot(n, x.as_ptr(), 1, y.as_ptr(), 1)
+   };
+
+Reading rules:
+
+- ``extern "C"`` = "this uses the C ABI" (the calling convention for FFI).
+- **Editions differ — expect both forms.** Since the 2024 edition the block
+  must be written ``unsafe extern "C" { … }``, and each item may be marked
+  ``safe`` (callable without an ``unsafe`` block) or ``unsafe`` / left unmarked
+  (the caller upholds the contract). Crates on the 2015/2018/2021 editions still
+  use a bare ``extern "C" { … }``. If the form looks unfamiliar, confirm against
+  the Edition Guide (``references/canonical-sources.rst``) rather than guessing
+  — this is exactly the kind of syntax that drifts between editions.
+- Raw pointers ``*const T`` / ``*mut T`` are the C-facing types; ``.as_ptr()``
+  hands a slice's buffer to C.
+- ``unsafe`` does **not** mean "wrong." It means *the compiler's guarantees stop
+  here; a human asserts the contract*. Read every ``unsafe`` block as a claim to
+  audit: are the pointers valid, the lengths right, the data still live?
+
+Silent-Bug Radar (highest value)
+--------------------------------
+
+Rust's compiler eliminates whole bug classes — but **only in safe code, and
+never your math.** Anchor every review on this split.
+
+**In safe Rust, memory safety is not yours to re-audit** — but mind *how* each
+class is ruled out. The compiler **rejects at compile time**: use-after-free,
+double-free, data races on shared memory, null dereferences, uninitialized
+reads. **Out-of-bounds is different** — the compiler does *not* catch it; safe
+Rust instead **converts it into a guaranteed runtime panic** (or a ``None`` from
+``.get()``), never silent corruption. So indexing is safe from *corruption*, but
+a wrong index still panics — a production failure to handle, and a correctness
+bug to chase (the stencil off-by-ones below).
+
+**Inside ``unsafe`` / FFI they come back.** A wrong pointer, length, or lifetime
+in an ``unsafe`` block or a C call can reintroduce every one of those — the
+``unsafe`` contract, not the compiler, is what holds them off. Audit each
+``unsafe`` region for exactly the bugs safe Rust had ruled out (Nomicon, via
+``references/canonical-sources.rst``).
+
+**The compiler never catches** (audit these every time): *your math.* Code that
+satisfies the borrow checker can still compute the wrong number.
+
+Look hard at:
+
+- **Stencil / index off-by-ones.** Loop bounds such as ``1..n-1`` versus
+  ``1..n``, halo / ghost-cell handling, ``len()`` versus ``len()-1``. A bounds
+  check turns a bad index into a *panic*, not a silently wrong result — but the
+  wrong-but-in-range index is silent.
+- **Aliasing & bounds promises in ``unsafe`` / FFI.** Read the contract
+  precisely — the common constructs promise *different* things. ``split_at_mut``
+  is **safe**: it hands back two slices the compiler *guarantees* do not
+  overlap, so trust it. ``get_unchecked`` / ``get_unchecked_mut`` are
+  **unsafe**: they drop the bounds check, so the *caller* must guarantee the
+  index is in bounds (a wrong index is undefined behavior, not a panic). The
+  **aliasing** rule constrains *live references*, and it bites on every *access*
+  to that memory while a reference is live — not only when a second reference is
+  created. Holding several ``*mut T`` is fine in itself, but *reading or writing*
+  through a raw pointer (or letting C/FFI write) while a ``&mut`` to the same
+  bytes is live — or mutating while a non-``UnsafeCell`` ``&`` is live — is
+  undefined behavior, even though no second ``&mut`` ever exists. So audit the
+  *accesses*: every raw-pointer load/store and FFI write that touches memory a
+  live reference still covers, not just where unsafe code hands out another
+  reference (and ``split_at_mut`` itself stays safe — its two slices are
+  disjoint by construction). A broken aliasing assumption corrupts results
+  silently (Reference → Behavior considered undefined; std ``slice`` docs).
+- **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
+  so a ``rayon`` reduction can give a *different sum* per run depending on
+  chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
+  or a custom ``reduce`` feeds a result that must be bit-reproducible.
+- **Concurrency beyond data races.** Safe Rust rules out *data races*, not
+  concurrency bugs in general — ``Arc<Mutex<T>>`` and ``rayon`` code that
+  compiles can still **deadlock**, **poison a lock** (``.lock()`` returns
+  ``Err`` after a holder panics mid-critical-section), use the wrong atomic
+  ``Ordering`` (``Relaxed`` where ``Acquire``/``Release`` was needed), or lose a
+  **check-then-act race** across two locks or atomics. The symptom is a hang or
+  a nondeterministic wrong result, never a compile error — so audit the *logic*,
+  not just the types.
+- **Integer / float casts.** ``as`` is silent and the rule depends on the
+  types. A **narrowing** integer→integer cast keeps the low bits
+  (``300_i32 as u8`` is ``44``). A **widening** cast that stays in the same
+  signedness preserves the value (``-1_i8 as i32`` is ``-1``; ``200_u8 as u32``
+  is ``200``). But casting a **signed value into an unsigned type** turns a
+  negative number into a large positive one — ``-1_i32 as u32`` is
+  ``4294967295`` and ``-1_i32 as usize`` is ``usize::MAX`` — the classic silent
+  ``-1``-as-index bug, regardless of width. Meanwhile float→integer
+  **saturates** to the target's range with ``NaN`` mapping to ``0``
+  (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is ``0``). Separately,
+  overflowing *arithmetic* on ``usize`` indices **panics in debug builds but
+  wraps in release by default**
+  (it tracks the ``overflow-checks`` profile flag) — so an index bug can stay
+  hidden until the optimized build (Reference → Type cast expressions).
+
+When reviewing a generated kernel, state the split explicitly: "in the safe
+regions the compiler guarantees memory safety and data-race freedom (not
+deadlocks, lock poisoning, atomic ordering, or logical races); inside
+``unsafe`` / FFI you must audit those memory and data-race classes too;
+**nowhere** does it guarantee the arithmetic or the concurrency logic — check
+the indices, the reduction order, the casts, and the locking."

--- a/skills/rust-explain/references/reading-vocabulary.rst
+++ b/skills/rust-explain/references/reading-vocabulary.rst
@@ -1,0 +1,194 @@
+Rust Reading Vocabulary
+=======================
+
+The fixed pattern set behind most "I can't read this." For a reader who already
+programs: each entry is **what it does** + **why it's there**, oriented toward
+*reading* code, not writing it. Explain on Rust's own terms; reach for a C++ or
+Python analogy only when it truly clarifies.
+
+Ownership & Borrowing
+---------------------
+
+``T`` owns its value; ``&T`` borrows it (shared, read-only); ``&mut T`` borrows
+it exclusively (read-write). Assigning or passing an owned non-``Copy`` value
+*moves* it — the source is *invalidated* and can no longer be used.
+
+.. code:: rust
+
+   let s = String::from("grid");
+   let t = s;            // value MOVES from s to t
+   // println!("{s}");   // would not compile: s no longer owns anything
+   println!("{t}");      // t is the owner now
+
+*Why it's there:* ownership frees memory without a garbage collector and prevents
+use-after-free at compile time. Reading rule: a bare ``T`` in a signature takes
+ownership (the caller gives it up); ``&T`` / ``&mut T`` borrows (the caller keeps
+it).
+
+Lifetimes
+---------
+
+A lifetime like ``'a`` names *how long a reference is valid*. You mostly read
+them in signatures: ``fn first<'a>(xs: &'a [f64]) -> &'a f64`` says "the returned
+reference lives as long as the slice you passed in." Most lifetimes are *elided*
+(inferred); you only see explicit ones when the compiler cannot guess the
+relationship.
+
+*Why it's there:* lifetimes let the borrow checker prove a reference never
+outlives the data it points to — no dangling pointers. Reading rule: ``'a`` is
+not a value, it is a constraint; read which inputs and outputs share a lifetime
+and ignore the rest of the noise.
+
+Error Flow
+----------
+
+``Result<T, E>`` is "either a ``T`` (``Ok``) or an error ``E`` (``Err``)";
+``Option<T>`` is "either a ``T`` (``Some``) or nothing (``None``)". The ``?``
+operator means "unwrap the ``Ok`` / ``Some``, or return the ``Err`` / ``None``
+from this function early."
+
+.. code:: rust
+
+   fn load(path: &str) -> Result<String, std::io::Error> {
+       let text = std::fs::read_to_string(path)?;  // ? returns early on Err
+       Ok(text)
+   }
+
+``.unwrap()`` and ``.expect("msg")`` extract the value but **panic** on ``Err`` /
+``None`` — a crash point. Flag them in code meant to be robust.
+
+*Why it's there:* errors are ordinary values, so the type system forces you to
+handle (or explicitly defer with ``?``) every failure. Reading rule: ``?`` is a
+propagation shortcut; ``.unwrap()`` is a "trust me, cannot fail here" — and a
+place bugs hide.
+
+Traits & Generics
+-----------------
+
+A trait is a shared interface (close to a C++ concept or a Python protocol).
+Generics with ``where`` bounds say "any type that implements this trait."
+
+.. code:: rust
+
+   // signature sketch — `Float` comes from the num_traits crate
+   fn norm<T>(xs: &[T]) -> T
+   where
+       T: num_traits::Float,
+   {
+       xs.iter().fold(T::zero(), |a, &x| a + x * x).sqrt()
+   }
+
+- ``impl Trait`` in argument position = "some type implementing Trait", resolved
+  at compile time (*monomorphized* — one specialized copy per concrete type, zero
+  runtime cost).
+- ``dyn Trait`` (a *trait object*, usually ``Box<dyn Trait>`` or ``&dyn Trait``)
+  = dynamic dispatch through a vtable (one copy of the code, runtime
+  indirection).
+
+*Why it's there:* traits give polymorphism with a choice of cost model. Reading
+rule: ``impl`` / generic = compile-time, fast, larger binary; ``dyn`` = runtime
+dispatch, smaller binary, slight overhead.
+
+Pattern Matching
+----------------
+
+``match`` destructures a value against patterns, *exhaustively* (every case must
+be handled). ``if let`` and ``let ... else`` are shorthands for matching a single
+pattern.
+
+.. code:: rust
+
+   match result {
+       Ok(v) => use_it(v),
+       Err(e) => report(e),
+   }
+
+   let Some(x) = maybe else {
+       return;            // bail out if None
+   };
+
+*Why it's there:* exhaustiveness means adding a new enum variant forces you to
+update every match — the compiler finds the gaps. Reading rule: arms are tried
+top-to-bottom; ``_`` is the catch-all.
+
+Smart Pointers & Combinations
+-----------------------------
+
+- ``Box<T>`` — owned value on the heap (one owner).
+- ``Rc<T>`` / ``Arc<T>`` — shared ownership by reference counting (``Arc`` is the
+  thread-safe, atomic version).
+- ``Weak<T>`` — a *non-owning* ``Rc`` / ``Arc`` handle (from ``Rc::downgrade`` /
+  ``Arc::downgrade``). It does **not** keep the value alive; you call
+  ``.upgrade()`` to get an ``Option<Rc<T>>`` (or ``Option<Arc<T>>`` on the
+  ``Arc`` side) and find out whether it still exists. Its purpose is to
+  **break reference cycles** (see below).
+- ``RefCell<T>`` / ``Mutex<T>`` — interior mutability: mutate through a shared
+  reference, with the borrow rule enforced at *runtime* (``RefCell``, single
+  thread) or via a lock (``Mutex``, across threads).
+
+Read combinations inside-out. ``Arc<Mutex<T>>`` = "a ``T`` that several threads
+share (``Arc``) and take turns mutating under a lock (``Mutex``)" — the canonical
+shared-mutable-state-across-threads shape.
+
+*Why it's there:* these recover patterns that ownership alone forbids — sharing,
+back-references, mutate-through-shared — each naming its exact cost. One caveat
+worth flagging when you see it: ``Rc`` / ``Arc`` do **not** manage *cycles* — a
+cycle of strong references never reaches refcount 0 and leaks, and ``Weak<T>``
+is precisely how correct code breaks it (Book §15.6, via
+``references/canonical-sources.rst``). Reading rule: the outer wrapper is the
+sharing model, the inner one is the data, and a ``Weak`` is a deliberately
+non-owning edge.
+
+Closures & Iterators
+--------------------
+
+A closure ``|x| x * x`` is an anonymous function that can capture variables. The
+trait it implements says how it can be *called*: ``Fn`` (via ``&self`` — only
+reads its captures, so callable repeatedly), ``FnMut`` (via ``&mut self`` — may
+mutate captures), ``FnOnce`` (via ``self`` — may move captures out, so callable
+once). ``move`` is separate: it forces the closure to *capture by value* (take
+ownership), common when spawning threads — a ``move`` closure can still be
+``Fn`` if its body only reads what it captured.
+
+Iterator chains are **lazy**: ``.iter().map(...).filter(...)`` builds a pipeline
+that does nothing until a *consumer* (``.collect()``, ``.sum()``, a ``for`` loop)
+drives it.
+
+.. code:: rust
+
+   let squares: Vec<f64> = xs.iter().map(|x| x * x).collect();
+   let total: f64 = squares.iter().sum();
+
+*Why it's there:* laziness lets chains fuse into a single pass with no
+intermediate allocations — the *zero-cost-abstraction* intent is that they
+optimize down to roughly what a hand-written loop emits (an optimizer outcome,
+not a language guarantee). Reading rule: find the consumer at the end of the
+chain; that is what actually runs the work.
+
+Macros
+------
+
+A trailing ``!`` marks a macro invocation, not a function call: ``println!``,
+``vec!``, ``assert_eq!``. Macros run at compile time and accept "syntax" a
+function cannot (format strings, variadic arguments). ``#[derive(Debug, Clone)]``
+is a *derive macro* that generates trait implementations for you.
+
+*Why it's there:* macros remove boilerplate the type system cannot. Reading rule:
+treat ``name!(...)`` as "expands to some code"; when you must see what, use
+``cargo expand`` (see ``references/tooling.rst``).
+
+Modules, Visibility & Turbofish
+-------------------------------
+
+``mod`` defines a module; ``pub`` exposes an item; ``use`` brings a path into
+scope. Paths use ``::`` (``std::sync::Arc``). The **turbofish** ``::<>`` pins a
+generic type the compiler cannot infer:
+
+.. code:: rust
+
+   let v = "42".parse::<i32>().unwrap();      // ::<i32> tells parse what to make
+   let xs = (0..n).map(|i| i as f64).collect::<Vec<f64>>();  // ::<Vec<f64>> picks the container
+
+*Why it's there:* explicit paths and visibility keep the module graph auditable.
+Reading rule: a turbofish always answers "what type?" for the call immediately
+before it.

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -1,0 +1,166 @@
+Rust Tooling as a Teaching Aid
+==============================
+
+Let the tools do the mechanical work, then explain *why* their output is right.
+None of this needs a wrapper script — run the tools directly.
+
+Trust boundary first
+--------------------
+
+Compiling Rust runs code — and even *type-checking* can read your machine. Both
+are part of the trust boundary, in two layers:
+
+- **Any Cargo command that compiles** — ``cargo check``, ``cargo clippy``,
+  ``cargo build``, ``cargo doc``, ``cargo expand``, ``cargo test``, ``cargo
+  run`` — **runs** the crate's ``build.rs`` and any procedural macros as part of
+  compiling: arbitrary code, executed before you ever run a binary. (``cargo
+  expand`` is the sharpest case — expanding a proc-macro *is* executing it — and
+  ``cargo doc --open`` also launches a browser.)
+- **Plain ``rustc`` on a single file is lower-risk, not safe.** No manifest
+  means no ``build.rs``, and with no proc-macro crate to link, none of *those*
+  run — but ``rustc`` still expands **built-in** macros at compile time, and
+  ``env!``, ``option_env!``, ``include_str!``, ``include_bytes!``, and
+  ``include!`` read environment variables and files straight off your machine.
+  A snippet can fold them into a diagnostic, and the message — which this skill
+  tells you to read back — becomes an exfiltration channel. Verified with rustc
+  1.94.1: ``compile_error!(env!("HOME"))`` makes the compiler print your home
+  path, and ``compile_error!(include_str!("…/secret"))`` prints a file's
+  contents — no binary, build script, or proc-macro required.
+
+So for **untrusted** code, do not compile it on your own machine at all: read
+and explain it statically, or compile only inside a disposable sandbox with a
+**scrubbed environment** and no access to your home or repo, treating every
+diagnostic as attacker-controlled output. Reserve ``rustc`` / Cargo on the real
+machine for code you trust. This is the same caution the skill applies to mode 2
+("Why does / doesn't this compile").
+
+cargo clippy — the free senior reviewer
+---------------------------------------
+
+``cargo clippy`` is Rust's idiom linter. Let it find the non-idiomatic code, then
+explain the reasoning instead of merely echoing the fix.
+
+.. code:: text
+
+   warning: the loop variable `i` is only used to index `v`
+    --> idiom.rs:3:14
+     |
+   3 |     for i in 0..v.len() {
+     |              ^^^^^^^^^^
+     |
+     = note: `#[warn(clippy::needless_range_loop)]` on by default
+   help: consider using an iterator
+     |
+   3 -     for i in 0..v.len() {
+   3 +     for <item> in &v {
+     |
+
+Teach it: "Clippy flags ``needless_range_loop`` (see the `clippy lint index
+<https://rust-lang.github.io/rust-clippy/stable/index.html#needless_range_loop>`__).
+Indexing ``v[i]`` re-checks bounds every iteration and hides intent; ``for x in
+&v`` (equivalently ``v.iter()``) iterates the elements directly — clearer, and
+it lets the optimizer elide the per-iteration bounds check in the common case
+(bounds-check *elimination* is an LLVM optimization, not a language guarantee).
+This is the gap between *works* and *fluent*." For the
+idiomatic-rewrite mode, run clippy first, then walk each lint.
+
+rustc errors as teachers
+------------------------
+
+Feed the **code and the real compiler message together**, then explain what the
+rule protects against. Two canonical examples:
+
+.. code:: text
+
+   error[E0382]: borrow of moved value: `s`
+    --> move.rs:4:20
+     |
+   3 |     let t = s;
+     |             - value moved here
+   4 |     println!("{}", s);
+     |                    ^ value borrowed here after move
+
+"``s`` was *moved* into ``t``, so ``s`` is no longer usable — not emptied,
+**invalidated**: the value now lives in ``t`` and the compiler statically
+forbids touching ``s``. It is preventing two owners of one heap buffer — which
+would double-free at scope end. Fix: borrow (``&s``) if you only need to read,
+or ``.clone()`` if you genuinely need a second copy."
+
+.. code:: text
+
+   error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
+    --> borrow.rs:4:5
+     |
+   3 |     let first = &v[0];
+     |                  - immutable borrow occurs here
+   4 |     v.push(4);
+     |     ^^^^^^^^^ mutable borrow occurs here
+   5 |     println!("{first}");
+     |                ----- immutable borrow later used here
+
+"``push`` can reallocate the vector, which would leave ``first`` dangling. The
+borrow checker forbids a mutable borrow while a shared borrow is still live —
+exactly the iterator-invalidation bug that C++ allows silently."
+
+Use ``rustc --explain E0502`` for the long-form explanation of any error code.
+
+Invoking ``rustc`` on a snippet: two defaults will mislead you. Bare
+``rustc file.rs`` assumes **edition 2015** and a **binary** crate, so modern
+syntax (``async``, ``let … else``) trips an edition error and any snippet
+without ``fn main`` trips ``error[E0601]`` — spurious errors that hide the
+borrow/lifetime one you actually want. Type-check a snippet like this instead:
+
+.. code:: text
+
+   rustc --edition 2021 --crate-type lib --emit=metadata snippet.rs -o "$(mktemp -d)/meta"
+
+``--edition`` should match the code (read it from ``Cargo.toml`` or ask the
+reader; use ``2024`` for the newest); ``--crate-type lib`` drops the ``fn main``
+requirement; ``--emit=metadata`` type-checks without producing — or running — a
+binary. Send the metadata to a throwaway temp dir rather than ``/dev/null``:
+``rustc`` writes its temp files *next to* the ``-o`` path, so a non-writable
+location (``/dev``) makes it abort with its own spurious error. Read the
+diagnostics it prints — a non-zero exit just means it found the error you were
+after. Run this only on code you trust, or inside the scrubbed sandbox from
+"Trust boundary first": even this type-check expands ``env!`` / ``include_str!``,
+so a hostile snippet can leak local data into the very diagnostics you read
+back. Code that pulls in external crates will not compile standalone: that needs
+the crate's own build, which means trusted code or a sandbox, not raw ``rustc``.
+
+rust-analyzer — navigation
+--------------------------
+
+The IDE language server. For *reading*, its highest-value features are:
+
+- **Hover** — shows the inferred type of any expression. Rust infers most types,
+  so hover makes the invisible visible.
+- **Inlay hints** — inline type and parameter-name annotations.
+- **Go to definition / find references** — trace where a trait impl or value
+  actually comes from.
+
+But it is **not** outside the trust boundary. By default rust-analyzer runs the
+project's ``build.rs`` and procedural macros (``cargo.buildScripts.enable`` and
+``procMacro.enable`` are on) so its analysis is accurate — which means merely
+*opening* an untrusted workspace can execute code. "Read-only navigation" is not
+read-only (rust-analyzer says as much in its own security note — see
+``references/canonical-sources.rst``). On untrusted code, read files statically
+instead, or open it in a disposable sandbox with build scripts, proc-macros, and
+check-on-save disabled and any project-supplied editor/tool configuration
+ignored.
+
+cargo doc & cargo expand
+------------------------
+
+- ``cargo doc --open`` builds and opens the API docs for the crate *and all its
+  dependencies* — the fastest way to learn what an unfamiliar type offers.
+- ``cargo expand`` shows what a macro expands to. When ``#[derive(...)]`` or a
+  ``name!()`` macro is opaque, expand it to read the generated code (requires the
+  ``cargo-expand`` tool).
+
+Both compile the crate, so the **trust boundary above applies** — run them only
+on trusted code or in a sandbox. For *untrusted* code, the non-executing
+substitutes are: read the prebuilt docs on `docs.rs <https://docs.rs/>`__
+(already built in a sandbox) or the crate source directly instead of
+``cargo doc``; and read the macro's definition by hand (or expand it inside a
+throwaway container) instead of running ``cargo expand``, since expansion
+*executes* the macro.


### PR DESCRIPTION
## What

Adds a new **`rust`** plugin exposing the upstream **`rust-explain`** skill (added in `agent-skills@v0.9.0`) as the slash command **`/rust:rust-explain`**.

`rust-explain` is a teaching assistant for *reading* unfamiliar Rust — ownership/borrowing, lifetimes, trait objects, `unsafe`/FFI, macros, and numeric crates (ndarray, nalgebra, faer, polars, rayon) — with correctness as the deliverable.

## Changes

| Path | Purpose |
|------|---------|
| `skills/rust-explain/` | Canonical vendored copy (verbatim from `agent-skills@v0.9.0`) |
| `registry/bundles/rust.yaml` | New single-skill bundle manifest |
| `plugins/rust/` | Self-contained plugin tree (real-file copy via `sync-plugins.sh`) |
| `.claude-plugin/marketplace.json` | Published `rust` plugin entry |
| `.changes/unreleased/` | changie fragment (Added) |

## Command naming

The skill is canonically `rust-explain`, and the catalog vendors skills verbatim by directory name, so the command is **`/rust:rust-explain`** — consistent with the existing convention (e.g. `/informatics:r-expert`).

## Verification

- ✅ `validate-bundles` gate: all bundle references resolve (watched it go **RED** on `rust-explain not found` before vendoring, then **GREEN** after)
- ✅ `scripts/validate-plugins.sh`: `plugins/rust → OK`; all plugins and agents valid
- ✅ `.claude-plugin/marketplace.json` valid JSON with `rust` entry

## Notes

`skills/rust-explain/` also arrives via the `v0.9.0` sync (#103); the content here is byte-identical to the `v0.9.0` tag, so the two merge cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Rust plugin with `rust-explain` skill to help users understand and learn Rust code
  * Rust-explain provides tutoring for reading unfamiliar Rust patterns, including code explanations, compile diagnostics, and idiomatic guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->