### PR TITLE
feat(lucid): add standalone plugin for hosted Lucid MCP server

### DIFF
--- a/.changes/unreleased/Added-20260602-lucid-mcp.yaml
+++ b/.changes/unreleased/Added-20260602-lucid-mcp.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add `lucid` plugin wiring the hosted Lucid MCP server (Lucidchart / Lucidspark) over Streamable HTTP — installable standalone via `/plugin`, authenticated with OAuth (no API key)
+time: 2026-06-02T10:00:00+10:00

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,6 +95,19 @@
       ]
     },
     {
+      "name": "lucid",
+      "source": "./plugins/lucid",
+      "description": "Lucid — visual collaboration (Lucidchart / Lucidspark) via the hosted Lucid MCP server",
+      "version": "0.6.0",
+      "keywords": [
+        "lucid",
+        "lucidchart",
+        "lucidspark",
+        "diagrams",
+        "mcp"
+      ]
+    },
+    {
       "name": "worktrunk",
       "source": {
         "source": "github",

--- a/plugins/lucid/.claude-plugin/plugin.json
+++ b/plugins/lucid/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "lucid",
+  "version": "0.6.0",
+  "description": "Lucid visual collaboration (Lucidchart / Lucidspark) via the hosted Lucid MCP server",
+  "author": {
+    "name": "nq-rdl"
+  },
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT"
+}

--- a/plugins/lucid/.mcp.json
+++ b/plugins/lucid/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lucid": {
+      "type": "http",
+      "url": "https://mcp.lucid.app/mcp"
+    }
+  }
+}

--- a/plugins/lucid/README.md
+++ b/plugins/lucid/README.md
@@ -1,0 +1,28 @@
+# Lucid
+
+Wires the hosted **Lucid** MCP server into Claude Code, exposing Lucid's
+visual-collaboration tools (Lucidchart / Lucidspark) as MCP tools. This plugin
+ships only the server declaration — no skills or agents — so it can be enabled
+on its own.
+
+## Install
+
+```bash
+/plugin marketplace add nq-rdl/agent-extensions   # once per machine
+/plugin                                            # enable "lucid"
+```
+
+## Authenticate
+
+Lucid is a hosted service that uses OAuth — there is no API key to configure.
+After enabling the plugin, open `/mcp`, select **lucid**, and choose
+**Authenticate**. A browser window completes the Lucid sign-in; tokens are then
+managed by Claude Code. Until that is done, `/mcp` reports the server as
+`Needs authentication` (expected — it means the endpoint is reachable).
+
+Tools surface under the `plugin:lucid:lucid` server, i.e.
+`mcp__plugin_lucid_lucid__<tool-name>`.
+
+## Transport
+
+Streamable HTTP (`type: http`) at `https://mcp.lucid.app/mcp`.

--- a/registry/bundles/lucid.yaml
+++ b/registry/bundles/lucid.yaml
@@ -1,0 +1,21 @@
+schemaVersion: v1
+id: lucid
+displayName: Lucid
+description: Lucid — visual collaboration boards and diagrams (Lucidchart / Lucidspark) via the hosted Lucid MCP server.
+owners:
+  - rdl
+channels:
+  - stable
+skills: []
+agents: []
+hooks: []
+prompts: []
+mcp:
+  - lucid
+targets:
+  claude:
+    enabled: true
+    pluginName: lucid
+    marketplaceName: rdl
+  gemini:
+    enabled: false


### PR DESCRIPTION
## What

Adds a dedicated **`lucid`** plugin that wires the hosted [Lucid](https://lucid.app) MCP server (`https://mcp.lucid.app/mcp`) into the marketplace, exposing Lucid's visual-collaboration tools (Lucidchart / Lucidspark) to Claude Code.

## Why a standalone plugin

Lucid is the repo's first **remote, hosted** MCP server — unlike `pi-rpc`/`gemini-cli`, which are Go binaries built from `mcp/*-go/`. There's no source to build and no binary to ship; it's just a URL + OAuth. Packaging it as its own MCP-only plugin lets teammates enable **exactly Lucid** via `/plugin` without pulling in a broad bundle like `dev-tools`.

## Changes

| File | Purpose |
|------|---------|
| `plugins/lucid/.mcp.json` | Declares the `lucid` server (`type: http`) |
| `plugins/lucid/.claude-plugin/plugin.json` | MCP-only manifest (no skills/agents) |
| `plugins/lucid/README.md` | Install + OAuth instructions |
| `registry/bundles/lucid.yaml` | Bundle source of truth: `mcp: [lucid]`, Claude-only |
| `.claude-plugin/marketplace.json` | Marketplace entry |
| `.changes/unreleased/Added-20260602-lucid-mcp.yaml` | Changelog fragment (`Added` → minor bump) |

## Design notes

- **No secrets committed.** Lucid uses OAuth; the config holds only the public endpoint. Auth happens per-user at runtime via `/mcp` → `lucid` → Authenticate.
- **Claude-only, matching precedent.** Every MCP server in this repo is Claude-side; `gemini-extension.json` declares none. The bundle sets `gemini.enabled: false`, so `GEMINI.md` is unaffected (its generator reads only `skills`/`agents`/`targets.gemini`).
- **Follows the `swe` pattern**, not the `dev-tools` gap: the bundle *declares* `mcp: [lucid]`, and `validate-plugins.sh` cross-checks that against `.mcp.json`.

## How teammates use it

```bash
/plugin marketplace add nq-rdl/agent-extensions   # once
/plugin                                            # enable "lucid"
/mcp                                               # select lucid → Authenticate
```

Tools surface as `plugin:lucid:lucid` (`mcp__plugin_lucid_lucid__*`).

## Validation

`bash scripts/validate-plugins.sh` → **All plugins and agents valid** (run with PyYAML; includes the registry↔`.mcp.json` MCP cross-check and `.gemini` symlink resolution).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Lucid plugin enabling visual collaboration integration via marketplace with OAuth-based authentication.

* **Documentation**
  * Added comprehensive plugin documentation covering installation, setup, and authentication workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->