### PR TITLE
fix(sync): make sync-skills re-runnable when PR creation fails

### DIFF
--- a/.changes/unreleased/Fixed-20260621-093000.yaml
+++ b/.changes/unreleased/Fixed-20260621-093000.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: sync-skills workflow is now idempotent and re-runnable — it reuses an already-pushed sync branch and opens the PR only when one is not already open, so a run that pushed the branch but failed at `gh pr create` (e.g. the RELEASE_APP app token missing Pull-requests:write) can be re-run to completion. The failure tracking issue now names the actual likely cause (app permissions vs. registry drift).

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -110,23 +110,33 @@ jobs:
         run: |
           BRANCH="chore/sync-skills-${TAG}"
 
-          # Idempotency: the branch name is deterministic, so a duplicate trigger
-          # for the same tag must not fail `git push` (which would fail the job
-          # and open a spurious "sync failed" tracking issue). Skip cleanly if the
-          # branch already exists on the remote.
-          if git ls-remote --exit-code origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Branch $BRANCH already exists — duplicate trigger for $TAG; skipping."
-            exit 0
-          fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git checkout -b "$BRANCH"
-          git add skills/ plugins/
-          git commit -m "chore(skills): sync from agent-skills@${TAG}"
+          # Idempotent + re-runnable: a previous run can push the branch but then
+          # fail before opening the PR — e.g. when the RELEASE_APP token lacks
+          # "Pull requests: write" the `gh pr create` below returns HTTP 403
+          # AFTER the push already landed (issue #121). So treat "branch exists"
+          # and "PR exists" as independent steps instead of assuming a branch
+          # implies a PR. Re-running the workflow then completes the PR for the
+          # already-pushed branch rather than skipping it.
+          if git ls-remote --exit-code origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists on remote — reusing it (re-run or duplicate trigger)."
+            git fetch origin "$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+            git add skills/ plugins/
+            git commit -m "chore(skills): sync from agent-skills@${TAG}"
+            git push -u origin "$BRANCH"
+          fi
 
-          git push -u origin "$BRANCH"
+          # If an open PR for this branch already exists, the sync is complete.
+          EXISTING_PR="$(gh pr list --head "$BRANCH" --state open \
+            --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR is already open for $BRANCH; nothing to do."
+            exit 0
+          fi
 
           # Detect registry drift: bundles still referencing skills that were
           # removed upstream. The plugin trees are auto-pruned by sync-plugins.sh,
@@ -143,7 +153,10 @@ jobs:
           # Pass the repo root so the PR body can flag synced-but-unmapped skills
           # (copied from upstream but not yet referenced by any bundle, so not
           # installable until a maintainer maps them — see CONTRIBUTING).
-          git diff --name-status HEAD~1 HEAD \
+          # Diff the branch against main (three-dot = merge-base..branch tip) so
+          # the body is correct whether the sync commit was made this run or by
+          # a prior run whose branch we are reusing.
+          git diff --name-status origin/main...origin/"$BRANCH" \
             | SYNC_DRIFT="$DRIFT" python3 scripts/sync_pr_body.py "$TAG" . > /tmp/pr-body.md
 
           gh pr create \
@@ -166,7 +179,12 @@ jobs:
         run: |
           set -euo pipefail
           title="sync-skills workflow failed"
-          body="The scheduled or dispatched sync-skills workflow failed (run: ${RUN_URL}). Likely cause: a bundle in registry/bundles/*.yaml references a skill or agent that no longer exists upstream after a rename or removal. sync-plugins.sh now warns instead of aborting, so check the run logs for ::warning:: lines, reconcile the registry, then re-run the sync."
+          body="The scheduled or dispatched sync-skills workflow failed (run: ${RUN_URL}). Check the run logs for the failing step. Common causes:
+
+          - **App permissions** — a failure at the \`gh pr create\` step with \`Resource not accessible by integration (createPullRequest)\` means the RELEASE_APP GitHub App installation is missing **Pull requests: write** (Contents: write alone lets the branch push but not the PR open). Grant it in the App's installation permissions, then re-run.
+          - **Registry drift** — a bundle in registry/bundles/*.yaml references a skill or agent that no longer exists upstream after a rename or removal. sync-plugins.sh warns (\`::warning::\`) instead of aborting, so check the logs for those lines and reconcile the registry.
+
+          The sync branch is pushed before the PR is opened, and the workflow is idempotent: once the cause is fixed, simply re-run it and it will open the PR for the already-pushed branch."
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
             --search "in:title $title" --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -108,6 +108,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
+          set -euo pipefail
           BRANCH="chore/sync-skills-${TAG}"
 
           git config user.name "github-actions[bot]"
@@ -131,8 +132,14 @@ jobs:
           fi
 
           # If an open PR for this branch already exists, the sync is complete.
-          EXISTING_PR="$(gh pr list --head "$BRANCH" --state open \
-            --json number --jq '.[0].number // empty')"
+          # Treat a `gh pr list` failure (auth/network/rate-limit) as fatal rather
+          # than an empty result: otherwise a transient error reads as "no PR" and
+          # falls through to a duplicate `gh pr create`.
+          if ! EXISTING_PR="$(gh pr list --head "$BRANCH" --base main --state open \
+            --json number --jq '.[0].number // empty')"; then
+            echo "::error::gh pr list failed for $BRANCH" >&2
+            exit 1
+          fi
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #$EXISTING_PR is already open for $BRANCH; nothing to do."
             exit 0
@@ -159,7 +166,14 @@ jobs:
           git diff --name-status origin/main...origin/"$BRANCH" \
             | SYNC_DRIFT="$DRIFT" python3 scripts/sync_pr_body.py "$TAG" . > /tmp/pr-body.md
 
+          # Pass --head/--base explicitly: on the branch-reuse path above we only
+          # fetch "$BRANCH" and never check it out, so HEAD stays on the default
+          # branch. gh defaults --head to the current branch, which would target
+          # the wrong head (main) on a re-run — the exact path this step exists to
+          # support. Being explicit also hardens the fresh-branch path.
           gh pr create \
+            --head "$BRANCH" \
+            --base main \
             --title "chore(skills): sync from agent-skills@${TAG}" \
             --body-file /tmp/pr-body.md \
             --label "dependencies"


### PR DESCRIPTION
The v0.10.0 sync run (issue #121) pushed the chore/sync-skills branch but
then failed at `gh pr create` with "Resource not accessible by integration
(createPullRequest)" — the RELEASE_APP app token has Contents:write (push
worked) but lacks Pull-requests:write (PR open failed). The sync itself was
fine; the new cc-web-setup skill synced cleanly and no registry drift exists.

The old idempotency guard assumed "branch exists ⟹ PR exists" and exited 0
on re-run, so the PR could never be opened for the orphaned branch even after
the permission was granted. Treat branch-exists and PR-exists as independent,
idempotent steps: reuse the pushed branch, and create the PR only when one is
not already open. Diff the branch against main (three-dot) so the PR body is
correct on both the fresh-commit and reused-branch paths.

Also rewrite the failure tracking-issue body to name the actual likely cause
(app permissions) alongside registry drift, and note the workflow is now
re-runnable to completion once the cause is fixed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FxT1A4TMbhPCrx8VxYppuf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Sync-skills workflow is now fully idempotent and re-runnable—interrupted runs can be safely resumed without creating duplicate pull requests. Existing branches are reused and PRs are only opened when needed.

## Documentation
* Improved failure tracking with clearer messaging for common causes, including app permission issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->