### PR TITLE
chore: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 # Python bytecode (pipeline-script unit tests)
 __pycache__/
 *.pyc
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
Adds `.DS_Store` to `.gitignore` so macOS Finder metadata files stop showing up as untracked across the repo.

A single unanchored `.DS_Store` pattern matches the basename at every directory level, so this covers the root file plus the stray ones under `agents/`, `mcp/`, `plugins/`, `registry/`, and `skills/`.

## Notes
- Repo-hygiene only — no changelog fragment added (the change isn't user-facing and `changie` is release-only, not a `validate.yml` CI gate).

## Test plan
- `git check-ignore .DS_Store agents/.DS_Store mcp/.DS_Store plugins/.DS_Store registry/.DS_Store skills/.DS_Store` → all six now reported as ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration for improved project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->