### PR TITLE
feat(claude-code): add web-setup skill (recover stranded v0.10.0 sync)

### DIFF
--- a/.changes/unreleased/Added-20260622-090000.yaml
+++ b/.changes/unreleased/Added-20260622-090000.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: '`claude-code:web-setup` — the `cc-web-setup` skill that bootstraps a repository for Claude Code on the web (provisions `.claude/`, the `web-bootstrap.sh` SessionStart hook, and pre-seeds the RDL marketplace). Recovered from the stranded v0.10.0 sync branch (issue #121, never merged because the sync PR failed to open) and mapped into the `claude-code` plugin.'

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -303,12 +303,14 @@
     {
       "name": "claude-code",
       "source": "./plugins/claude-code",
-      "description": "Claude Code — agent-team coordination and hook authoring",
+      "description": "Claude Code — agent-team coordination, hook authoring, and web-session setup",
       "version": "0.11.0",
       "keywords": [
         "claude-code",
         "agents",
-        "hooks"
+        "hooks",
+        "web",
+        "setup"
       ]
     },
     {

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -310,12 +310,13 @@ Charm — build terminal UIs with Bubbletea, Lip Gloss, and Fang.
 
 ## claude-code
 
-Claude Code — agent-team coordination and hook authoring.
+Claude Code — agent-team coordination, hook authoring, and web-session setup.
 
 **Skills**
 
 - `/claude-code:agent-teams`
 - `/claude-code:hook`
+- `/claude-code:web-setup`
 
 ---
 

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code",
   "version": "0.11.0",
-  "description": "Claude Code — agent-team coordination and hook authoring",
+  "description": "Claude Code — agent-team coordination, hook authoring, and web-session setup",
   "author": {
     "name": "nq-rdl"
   },

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -1,0 +1,133 @@
+---
+license: CC-BY-4.0
+description: >-
+  Bootstrap a repository for Claude Code on the web — provision its `.claude/`
+  setup so cloud sessions are correctly configured. Use when the user wants to
+  "set up Claude Code on the web", "bootstrap web sessions", "add the web setup
+  scripts", "configure the SessionStart hook for cloud", "provision a cloud
+  environment", "install web-bootstrap", or "make this repo work with Claude
+  Code on the web". Installs a parameterized `.claude/settings.json` plus
+  portable `scripts/web-bootstrap.sh` (SessionStart hook), `scripts/cc-web-setup.sh`
+  (pre-snapshot setup script that pre-seeds the RDL marketplace), and
+  `scripts/announce-capabilities.sh`. Also covers the setup-script-vs-SessionStart
+  split, the `CLAUDE_CODE_REMOTE` gate, GH/Codex CLI provisioning, and the
+  `*.local.sh` extension seam for project-specific dependencies.
+argument-hint: "Bootstrap this repo for Claude Code on the web? (run from the repo root; say if you have an existing .claude/settings.json to merge)"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Bootstrap a repo for Claude Code on the web
+
+Your job is to provision the current repository so **Claude Code on the web** (cloud)
+sessions start correctly configured: the RDL marketplace registered and pre-seeded,
+the GitHub and Codex CLIs available, and a SessionStart hook that self-heals and
+persists tooling. The portable pieces ship as files in this skill's `assets/`
+directory; you copy them into the target repo and merge the settings idempotently.
+
+## Background you must understand before acting
+
+Claude Code on the web has **two** provisioning mechanisms, and this setup uses both:
+
+1. **Setup script** — bash that runs **once, before Claude starts**, whose filesystem
+   is captured in the environment snapshot. Configured in the web environment's
+   settings UI (not the repo), but the *script it runs* lives in the repo at
+   `scripts/cc-web-setup.sh`. The user wires it by setting the environment's **Setup
+   script** field to `make cc-web-setup` (or `bash scripts/cc-web-setup.sh`). Plugins
+   installed here are available on the **first** session (Claude enumerates skills at
+   startup, before any hook runs).
+2. **SessionStart hook** — `scripts/web-bootstrap.sh`, runs **every session** (cloud
+   *and* local), gated on `CLAUDE_CODE_REMOTE=true` so it is a no-op on a contributor's
+   laptop. It self-heals the plugin pre-seed and provisions per-session tooling.
+
+You cannot set the environment Setup-script field for the user (it is not in the repo).
+**Tell them** to set it to `make cc-web-setup` after you finish.
+
+## Phase 0 — Confirm context
+
+- Confirm you are at the **repo root** of the repo to bootstrap (a `.git` dir is present).
+- Check whether `.claude/settings.json`, `scripts/`, and `Makefile` already exist — this
+  decides create-fresh vs. merge for each.
+- Ask the user only if something is ambiguous (e.g. a pre-existing `settings.json` with a
+  conflicting `model`/`hooks` block). Otherwise proceed with the defaults below.
+
+## Phase 1 — Copy the portable scripts
+
+Copy these three files from this skill's `assets/` into the target repo's `scripts/`,
+creating `scripts/` if absent, and `chmod +x` each:
+
+| From (skill asset) | To (target repo) |
+|---|---|
+| `assets/web-bootstrap.sh` | `scripts/web-bootstrap.sh` |
+| `assets/cc-web-setup.sh` | `scripts/cc-web-setup.sh` |
+| `assets/announce-capabilities.sh` | `scripts/announce-capabilities.sh` |
+
+These are **portable and carry no project-specific dependencies** — do not edit them per
+project. Project specifics go in the optional `*.local.sh` seam (Phase 4).
+
+If a target file already exists and differs, show the diff and ask before overwriting.
+
+## Phase 2 — Merge `.claude/settings.json`
+
+The template is `assets/settings.json.tmpl`. It registers the **`rdl`** marketplace
+(`nq-rdl/agent-extensions`), enables **`rdl@rdl`** (the meta-plugin that installs every
+RDL subject plugin), wires the two SessionStart hooks, and sets opinionated defaults
+(`model: opus`, `alwaysThinkingEnabled`, `effortLevel: xhigh`,
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+
+- **If `.claude/settings.json` is absent:** create `.claude/` and write the template verbatim.
+- **If it exists:** perform an **idempotent JSON-aware deep-merge** (use `jq` or a careful
+  read-modify-write), and **show the diff before writing**:
+  - `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
+  - `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the
+    two hook commands **only if not already present** (dedupe by exact command string), so
+    re-running is a no-op.
+  - `enabledPlugins`: add `"rdl@rdl": true`.
+  - `extraKnownMarketplaces`: add the `rdl` entry; leave any existing marketplaces intact.
+  - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never
+    override a deliberate user choice. Mention they are opinionated defaults the user can
+    decline.
+  - If a stale `"superpowers@claude-plugins-official"` (or other migrated-away entry) is
+    present, point it out and offer to remove it.
+
+## Phase 3 — Merge the Makefile target
+
+Append `assets/Makefile.snippet` to the repo's `Makefile` **only if** a `cc-web-setup:`
+target is not already present. If there is no `Makefile`, create one containing just the
+snippet. This gives the user the `make cc-web-setup` entrypoint to set as the environment
+Setup script.
+
+## Phase 4 — Offer the project extension seam
+
+The portable scripts source two optional, project-owned hooks if present:
+`scripts/cc-web-setup.local.sh` (heavy pre-snapshot deps) and `scripts/web-bootstrap.local.sh`
+(per-session glue: language toolchains on PATH, container runtimes, git-hook wiring like
+`.husky`/`.githooks`/lefthook, fetching the default branch). This is the **only** sanctioned
+place for project-specific provisioning — keep it out of the portable scripts so they stay
+re-syncable.
+
+Offer to scaffold a commented `scripts/web-bootstrap.local.sh` from
+`assets/web-bootstrap.local.sh.example`. Do **not** create it unless the repo actually needs
+project-specific steps.
+
+## Phase 5 — Verify
+
+- Run `CLAUDE_CODE_REMOTE=true bash scripts/web-bootstrap.sh` and confirm it exits 0. (Cloud
+  tooling installs may warn if offline — that is fine; the hook must still exit 0.)
+- Run `bash scripts/web-bootstrap.sh` (no env var) and confirm it is an immediate no-op.
+- Confirm `bash scripts/cc-web-setup.sh` is sentinel-/idempotent — a second run changes nothing.
+- Validate `.claude/settings.json` parses (`jq . .claude/settings.json`).
+
+## Phase 6 — Summarize for the user
+
+Tell the user, concisely:
+- What was created/merged (list the files + the settings keys touched).
+- **The one manual step:** set the web environment's **Setup script** field to
+  `make cc-web-setup` so plugin skills are baked into the snapshot and available on the
+  first session (otherwise they only appear from the second session onward).
+- That `web-bootstrap.sh` is safe locally (no-op unless `CLAUDE_CODE_REMOTE=true`).
+- How to add project-specific deps via `scripts/*.local.sh`.
+- That Codex CLI provisioning activates only when `CODEX_AUTH_JSON` or `CODEX_ACCESS_TOKEN`
+  is set in the environment.
+- To commit the new files so cloud sessions (which clone the repo) pick them up.

--- a/plugins/claude-code/skills/web-setup/assets/Makefile.snippet
+++ b/plugins/claude-code/skills/web-setup/assets/Makefile.snippet
@@ -1,0 +1,9 @@
+# --- Claude Code on the web provisioning (added by claude-code:web-setup) -----
+# Run this ONCE from the web environment's *setup script* (the bash that runs
+# before Claude starts, whose filesystem is captured in the environment
+# snapshot). Installing plugins here — before the snapshot — bakes their skills
+# into the image so they are available on the FIRST session. Exposed as a make
+# target for convenience; the web setup script should call `make cc-web-setup`.
+.PHONY: cc-web-setup
+cc-web-setup: ## Provision a Claude Code on the web VM (plugin pre-seed) — run by the cloud setup script
+	@bash scripts/cc-web-setup.sh

--- a/plugins/claude-code/skills/web-setup/assets/announce-capabilities.sh
+++ b/plugins/claude-code/skills/web-setup/assets/announce-capabilities.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# announce-capabilities.sh — SessionStart hook.
+#
+# Enumerates the skills, slash-commands and MCP servers present in *this*
+# runner and injects a concise summary as `additionalContext`, so Claude is
+# aware of them even on a blank / isolated runner (a GitHub Action job, a web
+# sandbox) where it would otherwise have no cheap way to discover what was
+# provisioned. This is the awareness companion to the explicit plugin install
+# done in the Claude workflows (see .github/workflows/claude*.yml) and the
+# enabledPlugins in .claude/settings.json.
+#
+# Output contract (Claude Code SessionStart hook): emit a single JSON object
+# with hookSpecificOutput.additionalContext, or — as a fallback — plain text on
+# stdout (also accepted). The hook must never fail the session, so it always
+# exits 0.
+#
+# Refs: code.claude.com/docs/en/hooks-guide (SessionStart, additionalContext).
+
+set -u
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${GITHUB_WORKSPACE:-$(pwd)}}"
+
+# --- gather sections -------------------------------------------------------
+
+lines=()
+add() { lines+=("$1"); }
+
+# Join deduped stdin lines with a literal ", ". Avoids `paste -sd', '`, whose
+# multi-char delimiter is cycled char-by-char (a,b c) on GNU and truncated to
+# the first char (a,b) on BSD — neither yields stable comma+space separation.
+join_comma() { sort -u | awk 'NR > 1 { printf ", " } { printf "%s", $0 }'; }
+
+# Repo slash-commands (.claude/commands/*.md)
+commands=()
+if [ -d "$PROJECT_DIR/.claude/commands" ]; then
+  for f in "$PROJECT_DIR"/.claude/commands/*.md; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f" .md)"
+    commands+=("/$name")
+  done
+fi
+
+# Repo skills (.claude/skills/*/SKILL.md) — name + first line of description
+skills=()
+if [ -d "$PROJECT_DIR/.claude/skills" ]; then
+  for s in "$PROJECT_DIR"/.claude/skills/*/SKILL.md; do
+    [ -e "$s" ] || continue
+    sname="$(sed -n 's/^name:[[:space:]]*//p' "$s" | head -n1)"
+    [ -n "$sname" ] || sname="$(basename "$(dirname "$s")")"
+    # Description's first human line. Handle BOTH the inline form
+    # (`description: text`) and YAML block/folded scalars (`description: >-` or
+    # `|` followed by indented lines): a bare `sed` on the `description:` line
+    # would capture the literal `>-`/`|` indicator for the folded form. For a
+    # block indicator (or an empty value) fall through to the first non-empty
+    # continuation line, and strip one layer of surrounding quotes.
+    sdesc="$(awk -v sq="'" '
+      /^description:([[:space:]]|$)/ {
+        line = $0
+        sub(/^description:[[:space:]]*/, "", line)
+        if (line == "" || line ~ /^[|>][+-]?[[:space:]]*$/) {
+          # The text is on the following INDENTED continuation line(s). Reset
+          # first so a missing continuation (e.g. an indicator at EOF) yields an
+          # empty description rather than the literal `>-`/`|`. Skip blank lines,
+          # but STOP at a column-0 line — the closing `---` or a sibling key is
+          # not part of this scalar and must never be taken as the description.
+          line = ""
+          while ((getline nl) > 0) {
+            if (nl ~ /^[[:space:]]*$/) continue
+            if (nl !~ /^[[:space:]]/) break
+            sub(/^[[:space:]]+/, "", nl); line = nl; break
+          }
+        }
+        sub(/^"/, "", line); sub(/"$/, "", line)
+        sub("^" sq, "", line); sub(sq "$", "", line)
+        print line
+        exit
+      }
+    ' "$s" | cut -c1-120)"
+    if [ -n "$sdesc" ]; then
+      skills+=("/$sname — $sdesc")
+    else
+      skills+=("/$sname")
+    fi
+  done
+fi
+
+# MCP servers (.mcp.json at root, plus any mcpServers in .claude/settings.json)
+mcp=()
+if command -v jq >/dev/null 2>&1; then
+  for cfg in "$PROJECT_DIR/.mcp.json" "$PROJECT_DIR/.claude/settings.json"; do
+    [ -f "$cfg" ] || continue
+    while IFS= read -r srv; do
+      [ -n "$srv" ] && mcp+=("$srv")
+    done < <(jq -r '(.mcpServers // {}) | keys[]?' "$cfg" 2>/dev/null)
+  done
+fi
+
+# Enabled plugins — read the authoritative enabledPlugins map from the project
+# settings (true => enabled). This is checked out in both web and Action runs
+# and avoids listing un-enabled marketplace plugins or version-dir noise.
+plugins=()
+if command -v jq >/dev/null 2>&1 && [ -f "$PROJECT_DIR/.claude/settings.json" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] && plugins+=("$p")
+  done < <(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' \
+             "$PROJECT_DIR/.claude/settings.json" 2>/dev/null)
+fi
+
+# --- render ----------------------------------------------------------------
+
+add "## Runner capabilities"
+add ""
+add "This session runs on an isolated/blank runner. The following project capabilities are present and ready to use — prefer a relevant skill before acting, and invoke skills explicitly with the Skill tool / \`/skill-name\` (plugin skills use \`/plugin:skill\`)."
+add ""
+
+if [ "${#skills[@]}" -gt 0 ]; then
+  add "**Repo skills (.claude/skills):**"
+  for x in "${skills[@]}"; do add "- $x"; done
+  add ""
+fi
+
+if [ "${#commands[@]}" -gt 0 ]; then
+  add "**Slash-commands (.claude/commands):** ${commands[*]}"
+  add ""
+fi
+
+if [ "${#mcp[@]}" -gt 0 ]; then
+  # de-dupe
+  uniq_mcp="$(printf '%s\n' "${mcp[@]}" | join_comma)"
+  add "**MCP servers:** $uniq_mcp"
+  add ""
+fi
+
+if [ "${#plugins[@]}" -gt 0 ]; then
+  uniq_plugins="$(printf '%s\n' "${plugins[@]}" | join_comma)"
+  add "**Enabled plugins:** $uniq_plugins"
+  add "Their skills are available via the Skill tool (\`/plugin:skill\`) — list and invoke as relevant."
+  add ""
+fi
+
+context="$(printf '%s\n' "${lines[@]}")"
+
+# --- emit ------------------------------------------------------------------
+
+if command -v jq >/dev/null 2>&1; then
+  jq -cn --arg ctx "$context" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+else
+  printf '%s\n' "$context"
+fi
+
+exit 0

--- a/plugins/claude-code/skills/web-setup/assets/cc-web-setup.sh
+++ b/plugins/claude-code/skills/web-setup/assets/cc-web-setup.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# cc-web-setup.sh — provision a Claude Code on the web (cloud) VM.
+#
+# Run this ONCE per environment from the web environment's *setup script* — the
+# bash that runs before Claude starts and whose filesystem state is captured in
+# the environment snapshot. It is exposed as `make cc-web-setup`.
+#
+# Why a setup-script step rather than (only) the SessionStart hook: Claude
+# enumerates skills at process startup, BEFORE SessionStart hooks run. A plugin
+# installed by the hook (scripts/web-bootstrap.sh) therefore only surfaces its
+# skills on the NEXT session. Installing the plugin here — before the snapshot,
+# before Claude starts — bakes it into the image so its skills are available on
+# the FIRST session.
+#
+# Idempotent and safe to re-run: the plugin pre-seed is a cheap no-op when
+# already current, and an optional project hook (cc-web-setup.local.sh) guards
+# its own heavy work. The SessionStart hook also calls this as a self-heal for
+# environments whose setup script does not run it (on that path the plugins'
+# skills still arrive next session, because the hook runs after skill enumeration).
+#
+# This script is PORTABLE: it carries no project-specific dependencies. Project
+# specifics (language toolchains, container runtimes, heavy installs) belong in
+# an optional, gitignored-or-committed `scripts/cc-web-setup.local.sh` that this
+# script sources if present — see the SOURCE PROJECT HOOK section below.
+#
+# Exit status reflects provisioning (0 = installed or skipped, non-zero =
+# failed) so a setup script can surface provisioning failures; callers that must
+# not fail (the SessionStart hook) invoke it with `|| …`.
+#
+# Output discipline: keep stdout concise — when run from the hook it is injected
+# into Claude's context — so verbose tool output goes to $LOG.
+set -uo pipefail
+
+# Only colorize on a TTY — cloud setup/SessionStart stdout is non-TTY and (for
+# the hook) injected into the model context, where ANSI escapes are just noise.
+if [ -t 1 ]; then _BLU=$'\033[34m'; _RST=$'\033[0m'; else _BLU=''; _RST=''; fi
+log() { printf '%s[cc-web-setup]%s %s\n' "$_BLU" "$_RST" "$*"; }
+
+# Marketplaces to register before installing plugins. On a cold VM this can run
+# BEFORE Claude loads extraKnownMarketplaces from .claude/settings.json, so an
+# explicit `marketplace add` is required — otherwise the plugin install fails with
+# "No marketplaces configured". Each entry is "<github-source>|<registered-name>":
+# `marketplace add` takes the GitHub source, but `marketplace update` takes the
+# name shown by `marketplace list` (these can differ).
+#
+# Parameterized: override the defaults by exporting CC_WEB_MARKETPLACES as a
+# whitespace-separated list of "<source>|<name>" entries (e.g. in
+# cc-web-setup.local.sh or the environment), so a repo can pre-seed extra
+# marketplaces without forking this script.
+if [ -n "${CC_WEB_MARKETPLACES:-}" ]; then
+  read -r -a MARKETPLACES <<<"$CC_WEB_MARKETPLACES"
+else
+  MARKETPLACES=("nq-rdl/agent-extensions|rdl")
+fi
+
+# Plugins to pre-seed. Override with CC_WEB_PLUGINS (whitespace-separated
+# "<plugin>@<marketplace>" entries). Default pre-seeds the RDL meta-plugin, which
+# pulls in every RDL subject plugin in one install.
+if [ -n "${CC_WEB_PLUGINS:-}" ]; then
+  read -r -a PLUGINS <<<"$CC_WEB_PLUGINS"
+else
+  PLUGINS=("rdl@rdl")
+fi
+
+# Imperative body. Wrapped in main() so the script is *sourceable* for unit
+# tests: executing it (`make cc-web-setup`, or `bash …/cc-web-setup.sh` from
+# web-bootstrap.sh) runs main; sourcing it (the test harness) only defines the
+# functions/globals above so they can be exercised against stubbed external
+# tools without running the imperative body or touching the log file. LOG/
+# PROJECT_DIR live IN here (mirroring web-bootstrap.sh) so sourcing never
+# truncates the real log.
+main() {
+  # Verbose output sink (keeps stdout clean — see header).
+  LOG="${TMPDIR:-/tmp}/rdl-cc-web-setup.log"
+  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+
+  # Resolve the repo root. `make cc-web-setup` runs from the repo root and the
+  # hook exports CLAUDE_PROJECT_DIR; fall back to the script's own location so it
+  # also works when run by hand.
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+  local rc=0
+
+  # --- 1. plugin marketplace + plugin pre-seed ------------------------------
+  # Installing the plugin HERE (pre-snapshot, pre-startup) is what makes its skills
+  # available on the first session. Run every invocation (not sentinel-gated) so a
+  # transient marketplace/network failure self-heals on the next call.
+  if command -v claude >/dev/null 2>&1; then
+    # Register marketplaces first so plugins resolve on a cold VM (see MARKETPLACES).
+    # `marketplace add` pulls the marketplace by its GitHub source; if it is already
+    # registered that call fails harmlessly, so fall back to `update` by its
+    # registered name to refresh it.
+    local entry mp_src mp_name plugin
+    for entry in "${MARKETPLACES[@]}"; do
+      mp_src="${entry%%|*}"; mp_name="${entry##*|}"
+      log "Registering plugin marketplace ${mp_name}…"
+      claude plugin marketplace add "$mp_src" </dev/null >>"$LOG" 2>&1 \
+        || claude plugin marketplace update "$mp_name" </dev/null >>"$LOG" 2>&1 \
+        || log "  WARNING: could not register/update marketplace ${mp_name} (see ${LOG})."
+    done
+    for plugin in "${PLUGINS[@]}"; do
+      log "Pre-seeding ${plugin}…"
+      if claude plugin install "$plugin" --scope project </dev/null >>"$LOG" 2>&1 \
+         || claude plugin update "$plugin" --scope project </dev/null >>"$LOG" 2>&1; then
+        log "  ${plugin}: ready."
+      else
+        # A plugin that can neither install nor update is a real provisioning
+        # failure: the documented exit-status contract (0 = installed/skipped,
+        # non-zero = failed) requires surfacing it, even though the SessionStart
+        # hook will retry next session.
+        log "  WARNING: could not install/update ${plugin} (see ${LOG})."
+        rc=1
+      fi
+    done
+  else
+    log "claude CLI not on PATH — skipping plugin pre-seed."
+  fi
+
+  # --- 2. SOURCE PROJECT HOOK (optional, project-specific) ------------------
+  # The portable engine above carries no project dependencies. A repo that needs
+  # heavy provisioning baked into the snapshot (language toolchains, container
+  # runtimes, k8s-in-docker, etc.) puts it in scripts/cc-web-setup.local.sh,
+  # which is sourced here if present. A subshell inherits main()'s helpers and
+  # globals (log, $LOG, $PROJECT_DIR), so file/system side effects persist; the
+  # hook signals a hard provisioning failure by exiting/returning non-zero, which
+  # the subshell exit status captures into rc.
+  #
+  # SECURITY/ISOLATION: cc-web-setup.local.sh is trusted, repo-owned code — the
+  # same trust level as this committed script (and every other file in scripts/).
+  # Running it in a SUBSHELL means a stray `exit` cannot abort provisioning and
+  # its variable edits cannot leak back into main(); it does NOT sandbox the code
+  # (a project hook legitimately needs the session's git/gh credentials).
+  local local_hook="${PROJECT_DIR}/scripts/cc-web-setup.local.sh"
+  if [ -f "$local_hook" ]; then
+    log "Running project setup hook (cc-web-setup.local.sh)…"
+    # shellcheck source=/dev/null
+    ( source "$local_hook" ) || { log "WARNING: project setup hook reported errors (see ${LOG})."; rc=1; }
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    log "Provisioning complete."
+  else
+    log "Provisioning finished with errors (see ${LOG})."
+  fi
+  exit "$rc"
+}
+
+# Run the imperative body only when executed, not when sourced. cc-web-setup is
+# invoked by direct exec (`make cc-web-setup`) and via `bash …/cc-web-setup.sh`
+# from web-bootstrap.sh, so BASH_SOURCE[0] == $0 holds for the real run; the test
+# harness (which sources this file) skips main and just exercises the globals.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/plugins/claude-code/skills/web-setup/assets/settings.json.tmpl
+++ b/plugins/claude-code/skills/web-setup/assets/settings.json.tmpl
@@ -1,0 +1,37 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/web-bootstrap.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/announce-capabilities.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "rdl@rdl": true
+  },
+  "extraKnownMarketplaces": {
+    "rdl": {
+      "source": {
+        "source": "github",
+        "repo": "nq-rdl/agent-extensions"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/plugins/claude-code/skills/web-setup/assets/web-bootstrap.local.sh.example
+++ b/plugins/claude-code/skills/web-setup/assets/web-bootstrap.local.sh.example
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# web-bootstrap.local.sh — OPTIONAL per-project extension to web-bootstrap.sh.
+#
+# This file is the sanctioned seam for project-specific provisioning. If it
+# exists next to scripts/web-bootstrap.sh, the portable hook sources it near the
+# end of its run (inside the CLAUDE_CODE_REMOTE=true gate), AFTER the generic
+# engine (gh CLI, codex CLI, plugin pre-seed self-heal, PATH persistence, git
+# hooks) has run. Put anything specific to THIS repo here so the portable script
+# stays generic and re-syncable.
+#
+# It is sourced (not executed), so it shares web-bootstrap.sh's helpers and
+# globals: log(), $LOG (verbose sink), $PROJECT_DIR, $SUDO, $CLAUDE_ENV_FILE.
+# Keep every step non-fatal — the parent hook must always exit 0 — and route
+# verbose output to "$LOG" so it does not pollute the model context.
+#
+# Rename to `web-bootstrap.local.sh` (drop `.example`) and commit it to enable.
+#
+# Example: bring up the bits DataOps needs (pixi on PATH, docker, k3d, shellcheck).
+# Everything below is illustrative — delete what you do not need.
+
+# # Persist pixi on PATH for later Bash tool commands.
+# if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -x "${HOME}/.pixi/bin/pixi" ]; then
+#   if ! grep -qF 'HOME/.pixi/bin' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+#     # shellcheck disable=SC2016
+#     echo 'export PATH="$HOME/.pixi/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+#     log "Persisted ~/.pixi/bin on PATH via CLAUDE_ENV_FILE."
+#   fi
+# fi
+
+# # Start the Docker daemon (k3d / testcontainers need it).
+# if command -v docker >/dev/null 2>&1 && ! docker info >/dev/null 2>&1; then
+#   if command -v dockerd >/dev/null 2>&1; then
+#     nohup $SUDO dockerd >>"${TMPDIR:-/tmp}/dockerd.log" 2>&1 &
+#     disown 2>/dev/null || true
+#   fi
+# fi

--- a/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+#
+# web-bootstrap.sh — per-session bootstrap for a Claude Code on the web session.
+#
+# Invoked from the repo's .claude/settings.json SessionStart hook. It is a no-op
+# unless running inside an Anthropic-managed cloud VM (CLAUDE_CODE_REMOTE=true),
+# so it never touches a local contributor's machine.
+#
+# The heavy provisioning (Claude plugin pre-seed) lives in
+# scripts/cc-web-setup.sh, which the web environment's *setup script* should run
+# ONCE before the snapshot (`make cc-web-setup`) so plugin skills are available
+# on the FIRST session — Claude enumerates skills at startup, so a plugin
+# installed by this hook only surfaces next session. This per-session hook then:
+#   * self-heals by running cc-web-setup.sh when the environment was not
+#     pre-provisioned (on that path, plugin skills only arrive next session);
+#   * provisions the portable per-session tooling a snapshot cannot carry: the
+#     GitHub CLI (PR/CI automation) and the Codex CLI (a second opinion via
+#     `codex exec`), persisting both on PATH for later Bash commands;
+#   * sources an optional project hook (web-bootstrap.local.sh) for repo-specific
+#     glue (language toolchains, container runtimes, git-hook wiring, …).
+#
+# This script is PORTABLE: it carries no project-specific dependencies. Anything
+# specific to one repo belongs in scripts/web-bootstrap.local.sh (sourced below).
+#
+# Output discipline: SessionStart stdout is injected into Claude's context, so
+# verbose tool output goes to $LOG and only concise status lines reach stdout.
+#
+# Every step is non-fatal: a SessionStart hook that exits non-zero can disrupt
+# session start, so problems are logged and the script always exits 0.
+set -uo pipefail
+
+# Only colorize on a TTY — cloud SessionStart stdout is non-TTY and injected into
+# the model context, where ANSI escapes are just noise.
+if [ -t 1 ]; then _BLU=$'\033[34m'; _RST=$'\033[0m'; else _BLU=''; _RST=''; fi
+log() { printf '%s[web-bootstrap]%s %s\n' "$_BLU" "$_RST" "$*"; }
+
+# Pinned GitHub CLI (gh) release. GitHub releases are on the cloud "Trusted"
+# network allowlist. Update the pin and BOTH per-arch checksums together — the
+# SHA-256 values are gh's published gh_<ver>_checksums.txt entries.
+GH_PIN="2.95.0"
+GH_SHA256_x86_64="25d1e4729e8808c9ed3d613e96ebd3f3e44446f2d368c89d878a71a36ddb3d8c"
+GH_SHA256_aarch64="d41e0b3b6218e5741c8bb4db39b16e53a59e0e06299a8489bd38f623ef7ebaae"
+
+# Install the GitHub CLI from a checksum-pinned GitHub release into ~/.local/bin
+# so PR/CI automation can run from the cloud session (gh authenticates from the
+# GH_TOKEN the environment injects). Idempotent, but PIN-AWARE: it short-circuits
+# ONLY when the gh already on PATH reports the pinned version, so a base image
+# shipping a different gh is replaced by GH_PIN rather than silently used.
+# (GitHub releases, not a vendor install script, because only github.com is on
+# the default Trusted allowlist.)
+ensure_gh() {
+  export PATH="${HOME}/.local/bin:${PATH}"
+  # Fixed-string grep (-F) so the version literal is matched verbatim, no regex.
+  # The trailing space pins the match to the exact version: `gh --version` prints
+  # `gh version X.Y.Z (DATE)`, so the space after ${GH_PIN} stops 2.95.0 from
+  # matching a hypothetical 2.95.01.
+  if command -v gh >/dev/null 2>&1 && gh --version 2>/dev/null | grep -qF "gh version ${GH_PIN} "; then
+    return 0
+  fi
+  # Preflight every external tool the install path needs, failing fast with a
+  # per-tool message so a missing sha256sum does not surface as a misleading
+  # "checksum mismatch".
+  local tool
+  for tool in curl sha256sum tar; do
+    command -v "$tool" >/dev/null 2>&1 || { log "WARNING: $tool not found — cannot install gh."; return 1; }
+  done
+  local arch asset sha url tmp bin
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64)  asset="gh_${GH_PIN}_linux_amd64.tar.gz"; sha="$GH_SHA256_x86_64" ;;
+    aarch64) asset="gh_${GH_PIN}_linux_arm64.tar.gz"; sha="$GH_SHA256_aarch64" ;;
+    *) log "WARNING: unsupported arch '$arch' for the gh install."; return 1 ;;
+  esac
+  url="https://github.com/cli/cli/releases/download/v${GH_PIN}/${asset}"
+  log "Installing gh ${GH_PIN} from GitHub (${asset})…"
+  mkdir -p "${HOME}/.local/bin"
+  # Template-based mktemp: portable across GNU/BSD (a bare `mktemp -d` needs a
+  # template on BSD/macOS).
+  if ! tmp="$(mktemp -d "${TMPDIR:-/tmp}/gh-install.XXXXXX")" || [ -z "$tmp" ]; then
+    log "WARNING: failed to create a temp dir for the gh install."; return 1
+  fi
+  if ! curl -fsSL "$url" -o "$tmp/gh.tar.gz" 2>>"$LOG"; then
+    log "WARNING: gh download failed (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  # Verify the pinned checksum before touching the binary.
+  if ! printf '%s  %s\n' "$sha" "$tmp/gh.tar.gz" | sha256sum -c - >>"$LOG" 2>&1; then
+    log "WARNING: gh checksum mismatch for ${asset} — refusing to install."; rm -rf "$tmp"; return 1
+  fi
+  # Extract/find/install with an explicit, logged failure arm at every step: a
+  # silent no-op here would let the function fall through to a stale wrong-version
+  # gh already on PATH (via the ${HOME}/.local/bin prepend) and falsely report OK.
+  if tar -xzf "$tmp/gh.tar.gz" -C "$tmp" 2>>"$LOG"; then
+    bin="$(find "$tmp" -type f -name gh -path '*/bin/gh' 2>/dev/null | head -1 || true)"
+    if [ -z "$bin" ]; then
+      log "WARNING: gh tarball had no bin/gh after extract — refusing to install."; rm -rf "$tmp"; return 1
+    fi
+    if ! install -m 0755 "$bin" "${HOME}/.local/bin/gh" 2>>"$LOG"; then
+      log "WARNING: failed to install gh into ${HOME}/.local/bin (see ${LOG})."; rm -rf "$tmp"; return 1
+    fi
+  else
+    log "WARNING: failed to extract the gh tarball (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  rm -rf "$tmp"
+  # Honest final signal: confirm the PINNED version is what now resolves (trailing
+  # space => exact match), rather than trusting whatever gh PATH happens to find.
+  gh --version 2>/dev/null | grep -qF "gh version ${GH_PIN} "
+}
+
+# Pinned Codex CLI release (openai/codex). GitHub releases are on the cloud
+# "Trusted" network allowlist, so — like ensure_gh — we install from a release
+# asset rather than npm (not on the default allowlist). We deliberately install
+# the "package" tarball (codex-package-<arch>-unknown-linux-musl.tar.gz), NOT the
+# bare codex-<arch>.tar.gz, for two reasons: (1) OpenAI publishes its SHA-256 in
+# the release's codex-package_SHA256SUMS, so the checksum below is an
+# upstream-published digest (the bare binary has none); (2) it bundles the runtime
+# resources codex uses (the bwrap sandbox + a vendored ripgrep) under
+# codex-resources/ + codex-path/, which the binary resolves relative to its real
+# path. Update the pin and BOTH per-arch checksums together — the values are the
+# codex-package-<arch>-unknown-linux-musl.tar.gz entries from that tag's
+# codex-package_SHA256SUMS.
+CODEX_PIN="0.141.0"
+CODEX_TAG="rust-v${CODEX_PIN}"
+CODEX_SHA256_x86_64="091c8a2e27370c41407fa1cb647fe905bd4fd70e4689c13effee0a2dce1b2b07"
+CODEX_SHA256_aarch64="b70030338592de3e361f3cde83d624f88061df300abe31b62075a5c5a058a6fc"
+
+# True iff the codex on PATH reports EXACTLY the pinned version. `codex --version`
+# prints `codex-cli X.Y.Z`; codex has no trailing space to anchor on (unlike `gh
+# version X.Y.Z `), so we match with an ERE boundary ([[:space:]]|$). That keeps a
+# suffixed build like `codex-cli 0.141.0-alpha.7` from satisfying the pin as a
+# prefix, and the dots in the pin are escaped so they match literally.
+codex_is_pinned() {
+  command -v codex >/dev/null 2>&1 || return 1
+  codex --version 2>/dev/null | grep -Eq "codex-cli ${CODEX_PIN//./\\.}([[:space:]]|\$)"
+}
+
+# Install the Codex CLI from a checksum-pinned GitHub release. Mirrors ensure_gh:
+# idempotent and PIN-AWARE (short-circuits ONLY when the codex on PATH reports the
+# pinned version, so a base image shipping a different codex is replaced rather
+# than silently used), with an explicit logged failure arm at every step so a
+# silent no-op can never make the function falsely report OK.
+#
+# The package tarball is not a lone binary: it extracts to bin/codex plus sibling
+# codex-resources/ + codex-path/ trees. So we stage it into a per-version dir under
+# ${HOME}/.local/share/codex and symlink bin/codex onto ${HOME}/.local/bin. codex
+# locates its resources via its real executable path (/proc/self/exe follows the
+# symlink to the staged dir), so a PATH symlink keeps the bundled sandbox + ripgrep
+# resolvable — verified before adopting this layout.
+ensure_codex_cli() {
+  export PATH="${HOME}/.local/bin:${PATH}"
+  # Pin-aware short-circuit: skip the install ONLY when the codex on PATH already
+  # reports exactly the pinned version (boundary-aware — see codex_is_pinned).
+  if codex_is_pinned; then
+    return 0
+  fi
+  # Preflight every external tool the install path needs, failing fast with a
+  # per-tool message (mirrors ensure_gh — a missing sha256sum must not surface as
+  # a misleading checksum mismatch).
+  local tool
+  for tool in curl sha256sum tar; do
+    command -v "$tool" >/dev/null 2>&1 || { log "WARNING: $tool not found — cannot install codex."; return 1; }
+  done
+  local arch asset sha url tmp staging dest
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64)  asset="codex-package-x86_64-unknown-linux-musl.tar.gz";  sha="$CODEX_SHA256_x86_64" ;;
+    aarch64) asset="codex-package-aarch64-unknown-linux-musl.tar.gz"; sha="$CODEX_SHA256_aarch64" ;;
+    *) log "WARNING: unsupported arch '$arch' for the codex install."; return 1 ;;
+  esac
+  url="https://github.com/openai/codex/releases/download/${CODEX_TAG}/${asset}"
+  log "Installing codex ${CODEX_PIN} from GitHub (${asset})…"
+  mkdir -p "${HOME}/.local/bin" "${HOME}/.local/share/codex"
+  if ! tmp="$(mktemp -d "${TMPDIR:-/tmp}/codex-install.XXXXXX")" || [ -z "$tmp" ]; then
+    log "WARNING: failed to create a temp dir for the codex install."; return 1
+  fi
+  if ! curl -fsSL "$url" -o "$tmp/codex.tar.gz" 2>>"$LOG"; then
+    log "WARNING: codex download failed (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  # Verify the pinned (upstream-published) checksum before touching the archive.
+  if ! printf '%s  %s\n' "$sha" "$tmp/codex.tar.gz" | sha256sum -c - >>"$LOG" 2>&1; then
+    log "WARNING: codex checksum mismatch for ${asset} — refusing to install."; rm -rf "$tmp"; return 1
+  fi
+  # Stage into a sibling of the final dir so the swap-in is an atomic same-FS
+  # rename (mktemp -d under ${HOME}/.local/share/codex), then verify the entrypoint
+  # exists before adopting it — a silent extract no-op must not fall through to the
+  # final version check off a stale codex already on PATH.
+  if ! staging="$(mktemp -d "${HOME}/.local/share/codex/.stage.XXXXXX")" || [ -z "$staging" ]; then
+    log "WARNING: failed to create a staging dir for the codex install."; rm -rf "$tmp"; return 1
+  fi
+  if ! tar -xzf "$tmp/codex.tar.gz" -C "$staging" 2>>"$LOG"; then
+    log "WARNING: failed to extract the codex tarball (see ${LOG})."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  if [ ! -x "$staging/bin/codex" ]; then
+    log "WARNING: codex tarball had no bin/codex after extract — refusing to install."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  dest="${HOME}/.local/share/codex/${CODEX_PIN}"
+  rm -rf "$dest"
+  if ! mv "$staging" "$dest" 2>>"$LOG"; then
+    log "WARNING: failed to move codex into ${dest} (see ${LOG})."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  rm -rf "$tmp"
+  if ! ln -sf "$dest/bin/codex" "${HOME}/.local/bin/codex" 2>>"$LOG"; then
+    log "WARNING: failed to symlink codex onto ${HOME}/.local/bin (see ${LOG})."; return 1
+  fi
+  # Honest final signal: confirm the PINNED version is what now resolves on PATH,
+  # rather than trusting whatever codex PATH happens to find.
+  codex_is_pinned
+}
+
+# Seed $CODEX_HOME/auth.json from a pre-obtained ChatGPT-OAuth credential blob.
+#
+# This is the headless path for a *personal* ChatGPT plan (Plus/Pro/Team), which
+# CANNOT mint the enterprise agent-identity JWT that `--with-access-token` requires
+# (see ensure_codex_auth). Instead the user runs `codex login` once on a trusted
+# machine with a browser — configuring `cli_auth_credentials_store = "file"` in
+# ~/.codex/config.toml so codex writes the credential to disk rather than the OS
+# keychain — and injects the ENTIRE resulting ~/.codex/auth.json as the secret
+# CODEX_AUTH_JSON. We write it back verbatim, so the on-disk shape always matches
+# the codex version that produced it. The long-lived refresh_token then lets codex
+# refresh the short-lived access_token in place during the session.
+#
+# Idempotent and non-destructive: writes only when no auth.json exists yet, so a
+# token codex already refreshed THIS session is never clobbered. printf + umask 077
+# keep the secret off argv and off a group/other-readable file. Quiet no-op when
+# CODEX_AUTH_JSON is unset (returns 1 so the caller can fall back to the token path).
+seed_codex_auth_json() {
+  [ -n "${CODEX_AUTH_JSON:-}" ] || return 1
+  if ! command -v codex >/dev/null 2>&1; then
+    log "WARNING: CODEX_AUTH_JSON is set but the codex CLI is not on PATH — skipping."
+    return 1
+  fi
+  local codex_home auth
+  codex_home="${CODEX_HOME:-${HOME}/.codex}"
+  auth="${codex_home}/auth.json"
+  # Already present (a resume, or codex refreshed it this session) => trust it and
+  # do not overwrite a possibly-refreshed file with the original secret.
+  if [ -f "$auth" ]; then
+    log "Codex auth.json already present — leaving it untouched."
+    return 0
+  fi
+  if ! mkdir -p "$codex_home" 2>>"$LOG"; then
+    log "WARNING: could not create ${codex_home} for the codex auth.json (see ${LOG})."; return 1
+  fi
+  # Subshell umask so the secret file is created 0600 from the outset (never a
+  # group/other-readable window); printf keeps the blob off argv.
+  if ! ( umask 077; printf '%s' "$CODEX_AUTH_JSON" > "$auth" ) 2>>"$LOG"; then
+    log "WARNING: failed to write ${auth} from CODEX_AUTH_JSON (see ${LOG})."; return 1
+  fi
+  chmod 600 "$auth" 2>>"$LOG" || true
+  # Honest signal: confirm codex actually accepts the seeded credentials, rather
+  # than trusting that a written file means a working login. Probe with
+  # CODEX_ACCESS_TOKEN unset so it reflects ONLY auth.json (mirrors ensure_codex_auth).
+  if ( unset CODEX_ACCESS_TOKEN; codex login status ) >>"$LOG" 2>&1; then
+    log "Seeded codex auth.json from CODEX_AUTH_JSON (authenticated)."
+    return 0
+  fi
+  log "WARNING: seeded auth.json but 'codex login status' still reports unauthenticated — re-capture CODEX_AUTH_JSON from a fresh local 'codex login' (see ${LOG})."
+  return 1
+}
+
+# Drop CODEX_ACCESS_TOKEN on BOTH fronts so a value codex can't use as a JWT never
+# reaches it: (1) `unset` it in THIS process, and (2) persist `unset CODEX_ACCESS_TOKEN`
+# to CLAUDE_ENV_FILE so later Bash tool shells inherit the unset too. Codex reads
+# CODEX_ACCESS_TOKEN from the live env at runtime and parses it AS a JWT, so leaving a
+# blank/whitespace or auth.json-blob value in place makes every later `codex exec` fail
+# even when a valid auth.json is on disk. $1 is a short reason for the log line.
+drop_codex_access_token() {
+  local reason="$1"
+  if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qF 'unset CODEX_ACCESS_TOKEN' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    if echo 'unset CODEX_ACCESS_TOKEN' >> "$CLAUDE_ENV_FILE" 2>>"$LOG"; then
+      log "Unset CODEX_ACCESS_TOKEN for the session (${reason})."
+    else
+      log "WARNING: could not append 'unset CODEX_ACCESS_TOKEN' to CLAUDE_ENV_FILE — later codex calls may still see it (see ${LOG})."
+    fi
+  fi
+  unset CODEX_ACCESS_TOKEN
+}
+
+# Authenticate the Codex CLI non-interactively from an env-injected OAuth token.
+#
+# The web container is fresh each session and ~/.codex is not persisted, so the
+# interactive browser login cannot be used. Codex stores credentials in
+# $CODEX_HOME/auth.json (default ~/.codex/auth.json); the supported headless path
+# is `codex login --with-access-token`, which reads the token from STDIN. We pipe
+# it in via printf so the secret never appears on a command line (argv is visible
+# to other processes via `ps`/\proc) and never lands in CLAUDE_ENV_FILE.
+#
+# CODEX_ACCESS_TOKEN must be a Codex **agent identity JWT** — the only thing
+# `--with-access-token` accepts. A ChatGPT *user* OAuth access token or an
+# OPENAI_API_KEY is rejected on this path.
+#
+# Tolerated convenience case: if CODEX_ACCESS_TOKEN actually holds a full auth.json
+# blob (leading '{') rather than a JWT, we route it to seed_codex_auth_json and
+# unset the env var for the session, so a ChatGPT-OAuth blob works regardless of
+# which secret slot it landed in (CODEX_AUTH_JSON is still the canonical name).
+#
+# Non-fatal and idempotent: absent token => quiet no-op; already-authenticated
+# (e.g. a resume) => skip the re-login.
+ensure_codex_auth() {
+  # No token => nothing to do. Stay TRULY silent here: SessionStart stdout is
+  # injected into the model context and this is the common case.
+  if [ -z "${CODEX_ACCESS_TOKEN:-}" ]; then
+    return 0
+  fi
+  # A CODEX_ACCESS_TOKEN with surrounding whitespace passes the -z guard above but
+  # is unusable as-is: a JWT never contains leading/trailing whitespace, yet a
+  # secret injected from a file commonly carries a stray trailing newline (and a
+  # slot may hold only spaces). Trim BOTH ends once — reused by the blank check,
+  # the auth.json-blob detection, AND the login below — so an otherwise-valid
+  # token isn't piped verbatim to `codex login --with-access-token` and rejected
+  # as a malformed JWT (which emits a misleading "must be an agent identity JWT"
+  # warning). If nothing remains, surface a clear "blank" diagnostic instead.
+  local _codex_tok_trimmed="${CODEX_ACCESS_TOKEN#"${CODEX_ACCESS_TOKEN%%[![:space:]]*}"}"
+  _codex_tok_trimmed="${_codex_tok_trimmed%"${_codex_tok_trimmed##*[![:space:]]}"}"
+  if [ -z "$_codex_tok_trimmed" ]; then
+    log "WARNING: CODEX_ACCESS_TOKEN is set but contains only whitespace — treating as unset (no codex login)."
+    # "treating as unset" must be literal: codex reads CODEX_ACCESS_TOKEN at runtime
+    # and would still parse the whitespace as a (malformed) JWT, so drop it for real.
+    drop_codex_access_token "it contains only whitespace"
+    return 1
+  fi
+  if ! command -v codex >/dev/null 2>&1; then
+    log "WARNING: CODEX_ACCESS_TOKEN is set but the codex CLI is not on PATH — skipping."
+    return 1
+  fi
+  # A full auth.json blob — not a JWT — is sometimes injected into CODEX_ACCESS_TOKEN
+  # (e.g. to reuse a single GH_TOKEN-style secret slot for a personal ChatGPT-OAuth
+  # credential). `--with-access-token` would reject it as a malformed JWT, so detect
+  # the JSON shape (a leading '{' after optional whitespace) and route it to the
+  # auth.json seeding path instead. Drop CODEX_ACCESS_TOKEN first (see
+  # drop_codex_access_token) so codex doesn't parse the blob as a JWT at runtime; it
+  # then falls back to ~/.codex/auth.json.
+  # (_codex_tok_trimmed is the leading-trimmed token computed above.)
+  if [ "${_codex_tok_trimmed:0:1}" = '{' ]; then
+    local _codex_blob="$CODEX_ACCESS_TOKEN"
+    drop_codex_access_token "it holds an auth.json blob, not a JWT"
+    CODEX_AUTH_JSON="$_codex_blob" seed_codex_auth_json
+    return $?
+  fi
+  # Idempotent: skip the re-login when a prior run THIS session already persisted
+  # auth.json. The probe runs with CODEX_ACCESS_TOKEN unset so it reflects ONLY
+  # saved credentials.
+  if ( unset CODEX_ACCESS_TOKEN; codex login status ) >>"$LOG" 2>&1; then
+    log "Codex already authenticated — skipping login."
+    return 0
+  fi
+  # printf (no trailing newline) keeps the token off argv; codex reads it on stdin.
+  # Pipe the whitespace-trimmed token: a stray leading/trailing newline would make
+  # codex reject an otherwise-valid JWT (see _codex_tok_trimmed above).
+  if printf '%s' "$_codex_tok_trimmed" | codex login --with-access-token >>"$LOG" 2>&1; then
+    log "Codex authenticated via access token."
+    # The trimmed value only fixed THIS login. If the raw env var carried
+    # surrounding whitespace, the value still visible to later Bash tool shells is
+    # a MALFORMED JWT — codex reads live CODEX_ACCESS_TOKEN before ~/.codex/auth.json,
+    # so every later `codex exec` would fail despite the auth.json this login just
+    # wrote. Drop the raw value (codex then falls back to auth.json). A clean token
+    # (raw == trimmed) is left in place so the normal direct-token path keeps working.
+    if [ "$CODEX_ACCESS_TOKEN" != "$_codex_tok_trimmed" ]; then
+      drop_codex_access_token "it carried surrounding whitespace (a malformed JWT for later codex calls)"
+    fi
+    return 0
+  fi
+  log "WARNING: 'codex login --with-access-token' failed — CODEX_ACCESS_TOKEN must be a Codex agent identity JWT, not a ChatGPT access token or API key (see ${LOG})."
+  return 1
+}
+
+# Turn OFF codex's own inner sandbox in $CODEX_HOME/config.toml. This whole hook
+# only runs when CLAUDE_CODE_REMOTE=true (main() is gated on it), i.e. inside the
+# isolated, ephemeral cloud container — which is ALREADY an external sandbox. So
+# codex re-sandboxing every model-run command is redundant; worse, the container
+# ships no bubblewrap on PATH, so each `codex exec` prints a "could not find
+# bubblewrap" warning. Setting sandbox_mode = "danger-full-access" (the value
+# codex documents for "environments that are externally sandboxed") disables the
+# inner sandbox and silences that warning.
+#
+# Non-destructive + idempotent: leave config.toml untouched if the user has
+# already made a deliberate sandbox/permissions choice (a top-level sandbox_mode
+# key, a top-level default_permissions key, or any [permissions.*] table).
+# "Top-level" matters: a key buried inside a [table] is an unrelated setting, so
+# the guard inspects ONLY the region before the first [table] header. Otherwise
+# inject the key — PREPEND it when a config already exists (a bare top-level key
+# must precede any [table] header), or create it fresh. Failure is non-fatal.
+configure_codex_sandbox() {
+  local codex_home config
+  codex_home="${CODEX_HOME:-${HOME}/.codex}"
+  config="${codex_home}/config.toml"
+
+  if [ -f "$config" ]; then
+    local toplevel
+    toplevel="$(awk '/^[[:space:]]*\[/{exit} {print}' "$config" 2>>"$LOG")"
+
+    if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*sandbox_mode[[:space:]]*='; then
+      log "Codex sandbox_mode already set in config.toml — leaving it untouched."
+      return 0
+    fi
+
+    # `[].]` is a valid two-member bracket class {']', '.'} — a `]` immediately
+    # after `[` is literal in POSIX ERE — so this matches a `[permissions]` table
+    # header or any `[permissions.<sub>]` subtable, and nothing else.
+    if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*default_permissions[[:space:]]*=' \
+        || grep -Eq '^[[:space:]]*\[permissions[].]' "$config"; then
+      log "Codex permission profile already configured — leaving config.toml untouched."
+      return 0
+    fi
+  fi
+
+  if ! mkdir -p "$codex_home" 2>>"$LOG"; then
+    log "WARNING: could not create ${codex_home} for the codex config (see ${LOG})."
+    return 1
+  fi
+
+  if [ -f "$config" ]; then
+    local tmp
+    if ! tmp="$(mktemp "${config}.XXXXXX")" || [ -z "$tmp" ]; then
+      log "WARNING: could not stage a temp file to update the codex config (see ${LOG})."
+      return 1
+    fi
+    if { printf 'sandbox_mode = "danger-full-access"\n'; cat "$config"; } >"$tmp" 2>>"$LOG" \
+        && mv "$tmp" "$config" 2>>"$LOG"; then
+      log "Disabled codex inner sandbox (sandbox_mode=danger-full-access) — the runner is already sandboxed."
+      return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    log "WARNING: failed to update ${config} with sandbox_mode (see ${LOG})."
+    return 1
+  fi
+
+  if ( umask 022; printf 'sandbox_mode = "danger-full-access"\n' >"$config" ) 2>>"$LOG"; then
+    log "Disabled codex inner sandbox (sandbox_mode=danger-full-access) — the runner is already sandboxed."
+    return 0
+  fi
+  log "WARNING: failed to write ${config} with sandbox_mode (see ${LOG})."
+  return 1
+}
+
+# Persist a directory on PATH for subsequent Claude Bash tool commands. SessionStart
+# hooks persist env for later commands by appending `export` lines to the file at
+# $CLAUDE_ENV_FILE (which subsequent Bash commands source). Idempotent via a grep
+# guard so re-runs do not duplicate the line. No-op when CLAUDE_ENV_FILE is unset.
+persist_path() {
+  local dir="$1" line
+  [ -n "${CLAUDE_ENV_FILE:-}" ] || return 0
+  # shellcheck disable=SC2016  # literal $PATH intended — expanded when sourced later
+  line="export PATH=\"${dir}:\$PATH\""
+  # Idempotent on the EXACT line (grep -qxF), not a substring: an unusual dir
+  # cannot false-match another entry and skip a needed export. printf avoids
+  # echo's backslash/-flag surprises.
+  if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE"
+    log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+  fi
+}
+
+# Imperative body. Wrapped in main() so the script is *sourceable* for unit
+# tests: executing it (the SessionStart hook runs it by direct exec) runs main;
+# sourcing it (the test harness) only defines the functions/globals above so they
+# can be exercised against stubbed external tools. SUDO/LOG/PROJECT_DIR and the
+# CLAUDE_CODE_REMOTE gate live in here so sourcing never touches the environment.
+main() {
+  # Only run inside Claude Code on the web. Locally this is a fast no-op so the
+  # same committed hook is safe for every contributor.
+  if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+  fi
+
+  # SUDO is intentionally exposed as a global for the sourced project hook
+  # (web-bootstrap.local.sh) to use when starting daemons (e.g. dockerd).
+  SUDO=''
+  # -n (non-interactive): a SessionStart hook has no TTY, so a sudo that needs a
+  # password must fail fast rather than block the session waiting on input.
+  # shellcheck disable=SC2034  # consumed by the sourced project hook, not this file
+  [ "$(id -u)" -eq 0 ] || SUDO='sudo -n'
+
+  # Verbose output sink (keeps the model's context clean — see header). Created
+  # 0600 via a subshell umask so the log (which may capture command output) is
+  # not world-readable from the outset.
+  LOG="${TMPDIR:-/tmp}/rdl-web-bootstrap.log"
+  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+
+  # Resolve the repo root. The hook exports CLAUDE_PROJECT_DIR; fall back to the
+  # script's own location so it also works when run by hand.
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+  # --- 1. provisioning self-heal (plugin pre-seed) ----------------------------
+  # Normally already done ONCE by the environment setup script (`make
+  # cc-web-setup`) before the snapshot, which is what makes plugin skills available
+  # this session. Re-running is idempotent, so this self-heals environments whose
+  # setup script does not run it — though on that path plugin skills only surface
+  # next session.
+  if [ -f "${PROJECT_DIR}/scripts/cc-web-setup.sh" ]; then
+    bash "${PROJECT_DIR}/scripts/cc-web-setup.sh" \
+      || log "WARNING: cc-web-setup reported errors (see ${TMPDIR:-/tmp}/rdl-cc-web-setup.log)."
+  fi
+
+  # --- 2. GitHub CLI + token (every session) ----------------------------------
+  # Provision gh so PR/CI automation can run from the cloud session, and report
+  # whether the environment injected a GitHub token. gh reads GH_TOKEN (or
+  # GITHUB_TOKEN) straight from the env — no `gh auth login` — so we just verify it
+  # resolves. The install is idempotent, so after the first session this is cheap.
+  if ensure_gh; then
+    log "gh CLI ready ($(gh --version 2>/dev/null | head -1))."
+    persist_path "${HOME}/.local/bin"
+    if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+      if gh auth status >>"$LOG" 2>&1; then
+        log "GitHub token present — gh is authenticated."
+      else
+        log "GitHub token present but 'gh auth status' did not confirm auth (see ${LOG})."
+      fi
+    else
+      log "WARNING: no GH_TOKEN/GITHUB_TOKEN in env — gh API calls will be unauthenticated/rate-limited."
+    fi
+  else
+    log "WARNING: gh CLI not available (install failed — see ${LOG})."
+  fi
+
+  # --- 3. Codex CLI install + auth (every session; quiet no-op without creds) --
+  # Install the Codex CLI and authenticate it so `codex exec` works headlessly.
+  # Two supported credential inputs, in priority order:
+  #   * CODEX_AUTH_JSON   — the full contents of a ~/.codex/auth.json captured from
+  #                         a local `codex login` (ChatGPT OAuth). See seed_codex_auth_json.
+  #   * CODEX_ACCESS_TOKEN — a Codex *agent identity JWT* for `--with-access-token`.
+  #                         As a convenience this slot also accepts a full auth.json
+  #                         blob (leading '{'), which is then seeded and unset.
+  # Either one is the signal that codex is wanted here; with neither we skip the
+  # (non-trivial) download too, keeping the committed hook a quiet no-op for
+  # contributors who do not use Codex.
+  if [ -n "${CODEX_AUTH_JSON:-}" ] || [ -n "${CODEX_ACCESS_TOKEN:-}" ]; then
+    if ensure_codex_cli; then
+      log "Codex CLI ready ($(codex --version 2>/dev/null | head -1))."
+      persist_path "${HOME}/.local/bin"
+      # Disable codex's inner sandbox: the runner is already an external sandbox.
+      configure_codex_sandbox || true
+      # Auth: prefer a pre-obtained auth.json blob (ChatGPT OAuth, personal plans);
+      # fall back to the agent-identity token login (enterprise). Both idempotent.
+      seed_codex_auth_json || ensure_codex_auth || true
+    else
+      log "WARNING: codex CLI install failed — 'codex exec' will be unavailable (see ${LOG})."
+    fi
+  fi
+
+  # --- 4. SOURCE PROJECT HOOK (optional, project-specific) --------------------
+  # The portable engine above carries no project dependencies. Repo-specific glue
+  # — language toolchains on PATH, container runtimes, git-hook wiring (.husky /
+  # .githooks / lefthook), fetching the default branch for merge-base checks, etc.
+  # — belongs in scripts/web-bootstrap.local.sh, sourced here if present. A subshell
+  # inherits main()'s helpers and globals (log, $LOG, $PROJECT_DIR, $SUDO,
+  # $CLAUDE_ENV_FILE, persist_path), so its file/system side effects persist.
+  #
+  # SECURITY/ISOLATION: web-bootstrap.local.sh is trusted, repo-owned code — the
+  # same trust level as this committed hook. Running it in a SUBSHELL keeps a stray
+  # `exit` (or `exit 1`) from breaking this hook's "always exit 0" discipline and
+  # stops its variable edits from leaking back; it does NOT sandbox the code (a
+  # project hook legitimately needs the session's git/gh credentials). Signal a
+  # soft failure with a non-zero exit/return — it is logged, never fatal.
+  local local_hook="${PROJECT_DIR}/scripts/web-bootstrap.local.sh"
+  if [ -f "$local_hook" ]; then
+    log "Running project bootstrap hook (web-bootstrap.local.sh)…"
+    # shellcheck source=/dev/null
+    ( source "$local_hook" ) || log "WARNING: project bootstrap hook reported errors (see ${LOG})."
+  fi
+
+  log "Session bootstrap complete."
+  exit 0
+}
+
+# Run the imperative body only when executed, not when sourced. The hook is
+# invoked by direct exec ("$CLAUDE_PROJECT_DIR"/scripts/web-bootstrap.sh from the
+# SessionStart hook), so BASH_SOURCE[0] == $0 holds for the real run and the test
+# harness (which sources this file) skips main and just exercises the functions.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
@@ -397,7 +397,7 @@ configure_codex_sandbox() {
     # after `[` is literal in POSIX ERE — so this matches a `[permissions]` table
     # header or any `[permissions.<sub>]` subtable, and nothing else.
     if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*default_permissions[[:space:]]*=' \
-        || grep -Eq '^[[:space:]]*\[permissions[].]' "$config"; then
+        || grep -Eq '^[[:space:]]*\[permissions([.][^]]+)?\][[:space:]]*$' "$config"; then
       log "Codex permission profile already configured — leaving config.toml untouched."
       return 0
     fi

--- a/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
@@ -445,8 +445,15 @@ persist_path() {
   # cannot false-match another entry and skip a needed export. printf avoids
   # echo's backslash/-flag surprises.
   if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
-    printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE"
-    log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+    # Check the append: an unwritable CLAUDE_ENV_FILE would otherwise leave later
+    # Bash shells without ${dir} on PATH while we falsely log success. LOG may be
+    # unset here (persist_path runs outside main() in tests), so guard the stderr
+    # redirect with ${LOG:-/dev/null} to stay safe under `set -u`.
+    if printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE" 2>>"${LOG:-/dev/null}"; then
+      log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+    else
+      log "WARNING: could not append PATH export for ${dir} to CLAUDE_ENV_FILE — later Bash shells will not see ${dir} on PATH."
+    fi
   fi
 }
 
@@ -531,7 +538,17 @@ main() {
       configure_codex_sandbox || true
       # Auth: prefer a pre-obtained auth.json blob (ChatGPT OAuth, personal plans);
       # fall back to the agent-identity token login (enterprise). Both idempotent.
-      seed_codex_auth_json || ensure_codex_auth || true
+      if seed_codex_auth_json; then
+        # auth.json is now the credential of record (freshly seeded OR already present
+        # on a resume). codex reads CODEX_ACCESS_TOKEN BEFORE ~/.codex/auth.json, so a
+        # leftover raw token would shadow the valid auth.json and break later
+        # `codex exec`. ensure_codex_auth (the only caller of drop_codex_access_token)
+        # never runs on this arm, so drop a stale token here ourselves.
+        [ -n "${CODEX_ACCESS_TOKEN:-}" ] \
+          && drop_codex_access_token "auth.json seeded; raw token would shadow it for later codex exec"
+      else
+        ensure_codex_auth || true
+      fi
     else
       log "WARNING: codex CLI install failed — 'codex exec' will be unavailable (see ${LOG})."
     fi

--- a/plugins/claude-code/skills/web-setup/scripts/test-cc-web-setup.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/test-cc-web-setup.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# scripts/test-cc-web-setup.sh
+# Tests for assets/cc-web-setup.sh (the portable pre-snapshot setup script shipped
+# by the cc-web-setup skill).
+#
+# The plugin pre-seed runs against a stubbed `claude` CLI that records every
+# subcommand it sees, so the tests assert WHICH marketplaces/plugins are seeded
+# (defaults + CC_WEB_* overrides), the no-claude path, and that the optional
+# project hook (cc-web-setup.local.sh) is sourced. Run via the harness or by hand.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../assets/cc-web-setup.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS  $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL  $*"; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cc-web-setup-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# A `claude` stub that appends every invocation's args to $CLAUDE_LOG. The path is
+# passed via env so the same stub works across scenarios.
+make_claude_stub() { # <dir>
+  local dir="$1"
+  cat >"$dir/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAUDE_LOG"
+exit 0
+EOF
+  chmod +x "$dir/claude"
+}
+
+# Like make_claude_stub, but the plugin install AND update both fail (marketplace
+# registration still succeeds), so the pre-seed cannot recover — exercises the
+# documented non-zero exit on a real provisioning failure.
+make_claude_stub_failing() { # <dir>
+  local dir="$1"
+  cat >"$dir/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAUDE_LOG"
+case "$*" in
+  *"plugin install"*|*"plugin update"*) exit 1 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$dir/claude"
+}
+
+new_bin() { # build a PATH dir with coreutils + optional claude
+  local d tool real; d="$(mktemp -d "$WORK/bin.XXXXXX")"
+  for tool in bash printf cat rm mkdir dirname grep head touch; do
+    real="$(command -v "$tool" 2>/dev/null || true)"; [ -n "$real" ] && ln -s "$real" "$d/$tool"
+  done
+  echo "$d"
+}
+
+# run_setup <bin_dir> <project_dir> <out> [env assignments...] — execute the REAL
+# script as a subprocess (so main() runs) with an isolated PATH/PROJECT_DIR.
+run_setup() {
+  local bin="$1" proj="$2" out="$3"; shift 3
+  # shellcheck disable=SC2163  # "$@" holds KEY=val assignments to export, intentional
+  ( export PATH="$bin" CLAUDE_PROJECT_DIR="$proj" TMPDIR="$WORK" "$@"; bash "$SCRIPT" ) >"$out" 2>&1
+}
+
+# --- Test 1: defaults -> seeds rdl marketplace + rdl@rdl ---------------------
+test_defaults() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p1.XXXXXX")"; out="$WORK/t1.out"
+  make_claude_stub "$bin"; clog="$WORK/t1-claude.log"; : > "$clog"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" && ok "defaults: exit 0" || fail "defaults: non-zero exit"
+  grep -q 'plugin marketplace add nq-rdl/agent-extensions' "$clog" \
+    && ok "defaults: registered the rdl marketplace (nq-rdl/agent-extensions)" \
+    || fail "defaults: did not register rdl marketplace. Log: $(cat "$clog")"
+  grep -q 'plugin install rdl@rdl --scope project' "$clog" \
+    && ok "defaults: pre-seeded rdl@rdl" \
+    || fail "defaults: did not pre-seed rdl@rdl. Log: $(cat "$clog")"
+}
+
+# --- Test 2: CC_WEB_* overrides honored --------------------------------------
+test_overrides() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p2.XXXXXX")"; out="$WORK/t2.out"
+  make_claude_stub "$bin"; clog="$WORK/t2-claude.log"; : > "$clog"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" \
+    "CC_WEB_MARKETPLACES=acme/plugins|acme" "CC_WEB_PLUGINS=foo@acme bar@acme" \
+    && ok "overrides: exit 0" || fail "overrides: non-zero exit"
+  grep -q 'plugin marketplace add acme/plugins' "$clog" \
+    && ok "overrides: registered the overridden marketplace" \
+    || fail "overrides: override marketplace not used. Log: $(cat "$clog")"
+  grep -q 'plugin install foo@acme --scope project' "$clog" && grep -q 'plugin install bar@acme --scope project' "$clog" \
+    && ok "overrides: pre-seeded both overridden plugins" \
+    || fail "overrides: override plugins not used. Log: $(cat "$clog")"
+  grep -q 'rdl@rdl' "$clog" \
+    && fail "overrides: still seeded the default rdl@rdl (override ignored)" \
+    || ok "overrides: defaults were replaced, not appended"
+}
+
+# --- Test 3: no claude on PATH -> skip pre-seed, still exit 0 -----------------
+test_no_claude() {
+  local bin proj out; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p3.XXXXXX")"; out="$WORK/t3.out"
+  # No claude stub on this PATH.
+  run_setup "$bin" "$proj" "$out" && ok "no-claude: exit 0" || fail "no-claude: non-zero exit"
+  grep -q 'claude CLI not on PATH' "$out" \
+    && ok "no-claude: logged the skip" \
+    || fail "no-claude: did not log the skip. Out: $(cat "$out")"
+}
+
+# --- Test 4: project hook sourced --------------------------------------------
+test_local_hook() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p4.XXXXXX")"; out="$WORK/t4.out"
+  make_claude_stub "$bin"; clog="$WORK/t4-claude.log"; : > "$clog"
+  mkdir -p "$proj/scripts"
+  printf 'touch "%s/t4-sentinel"\n' "$WORK" > "$proj/scripts/cc-web-setup.local.sh"
+  rm -f "$WORK/t4-sentinel"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" >/dev/null \
+    && ok "local-hook: exit 0 when project hook succeeds" \
+    || fail "local-hook: non-zero exit. Out: $(cat "$out")"
+  [ -e "$WORK/t4-sentinel" ] \
+    && ok "local-hook: cc-web-setup.local.sh was sourced" \
+    || fail "local-hook: project hook not sourced. Out: $(cat "$out")"
+}
+
+# --- Test 6: plugin pre-seed failure -> non-zero exit ------------------------
+test_plugin_failure_rc() {
+  # The exit-status contract: a plugin that can neither install nor update is a
+  # provisioning failure and must produce a non-zero exit (not a silent rc=0).
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p6.XXXXXX")"; out="$WORK/t6.out"
+  make_claude_stub_failing "$bin"; clog="$WORK/t6-claude.log"; : > "$clog"
+  if run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog"; then
+    fail "plugin-fail: expected non-zero exit when pre-seed fails. Out: $(cat "$out")"
+  else
+    ok "plugin-fail: non-zero exit when a plugin can neither install nor update"
+  fi
+  grep -q 'Provisioning finished with errors' "$out" \
+    && ok "plugin-fail: surfaced the provisioning failure in the epilogue" \
+    || fail "plugin-fail: did not log the failure. Out: $(cat "$out")"
+}
+
+# --- Test 7: a project hook that exits is contained by the subshell ----------
+test_local_hook_exit_contained() {
+  # `( source "$local_hook" )` must isolate a stray `exit` so it cannot abort
+  # main() at the source line: rc becomes 1 and the epilogue still runs.
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p7.XXXXXX")"; out="$WORK/t7.out"
+  make_claude_stub "$bin"; clog="$WORK/t7-claude.log"; : > "$clog"
+  mkdir -p "$proj/scripts"
+  printf 'touch "%s/t7-before"\nexit 1\n' "$WORK" > "$proj/scripts/cc-web-setup.local.sh"
+  rm -f "$WORK/t7-before"
+  if run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog"; then
+    fail "exit-contained: expected non-zero exit (hook failed). Out: $(cat "$out")"
+  else
+    ok "exit-contained: hook's non-zero exit propagates to rc"
+  fi
+  [ -e "$WORK/t7-before" ] \
+    && ok "exit-contained: the hook actually ran" \
+    || fail "exit-contained: hook did not run at all. Out: $(cat "$out")"
+  grep -q 'Provisioning finished with errors' "$out" \
+    && ok "exit-contained: main() ran its epilogue (the exit did not escape the subshell)" \
+    || fail "exit-contained: epilogue missing — exit escaped the subshell. Out: $(cat "$out")"
+}
+
+# --- Test 5: sourceable (main-guard) -----------------------------------------
+test_sourceable() {
+  # Sourcing must NOT run main(): define globals only. Assert MARKETPLACES exists
+  # and main() did not exit the shell.
+  # shellcheck disable=SC1090
+  ( set +e; source "$SCRIPT"; [ "${MARKETPLACES[0]}" = "nq-rdl/agent-extensions|rdl" ] ) \
+    && ok "sourceable: source defines globals without running main()" \
+    || fail "sourceable: sourcing did not behave (main ran or globals missing)"
+}
+
+test_defaults
+test_overrides
+test_no_claude
+test_local_hook
+test_plugin_failure_rc
+test_local_hook_exit_contained
+test_sourceable
+
+echo ""
+echo "cc-web-setup: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/plugins/claude-code/skills/web-setup/scripts/test-web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/test-web-bootstrap.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# scripts/test-web-bootstrap.sh
+# Unit + integration tests for assets/web-bootstrap.sh (the portable SessionStart
+# hook shipped by the cc-web-setup skill).
+#
+# web-bootstrap.sh is sourceable (its imperative body is guarded by
+# `[ "${BASH_SOURCE[0]}" = "${0}" ]`), so this harness sources it to get the REAL
+# ensure_gh / codex functions / persist_path and exercises them against a fake
+# PATH of stub executables — the only things stubbed are the external I/O boundary
+# (gh/codex/curl/tar/sha256sum/uname). No network. The CLAUDE_CODE_REMOTE gate and
+# the *.local.sh seam are covered by running the script as a subprocess.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../assets/web-bootstrap.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS  $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL  $*"; }
+
+# Source the script under test. With the main-guard in place, sourcing only
+# defines the functions and never runs the hook body (side-effect free).
+# shellcheck source=../assets/web-bootstrap.sh
+source "$SCRIPT"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/web-bootstrap-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Coreutils the functions legitimately use (not the stubbed I/O boundary).
+COREUTILS="bash mkdir mktemp find head rm install env cat dirname grep ln tail touch mv chmod printf awk sed id"
+
+new_stub_dir() {
+  local d tool real
+  d="$(mktemp -d "$WORK/path.XXXXXX")"
+  for tool in $COREUTILS; do
+    real="$(command -v "$tool" 2>/dev/null || true)"
+    [ -n "$real" ] && ln -s "$real" "$d/$tool"
+  done
+  echo "$d"
+}
+
+write_stub() {
+  local dir="$1" name="$2" body="$3"
+  # new_stub_dir() pre-populates the dir with symlinks to the real coreutils
+  # (e.g. `id`). Without removing it first, the `>` redirect would FOLLOW such a
+  # symlink and try to overwrite the real system binary (clobbering it, or
+  # failing with EACCES) instead of replacing the link with our stub. Drop any
+  # existing entry so the stub always lands in the temp dir.
+  rm -f "$dir/$name"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" >"$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+run_in_subshell() { # <stub_dir> <out_file> <home> <fn>
+  local stub_dir="$1" out_file="$2" home="$3" fn="$4"
+  # shellcheck disable=SC2030,SC2031
+  (
+    export HOME="$home" PATH="$stub_dir" TMPDIR="$WORK"
+    LOG="$out_file"
+    "$fn"
+  ) >>"$out_file" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# ensure_gh()
+# ---------------------------------------------------------------------------
+run_ensure_gh() {
+  local stub_dir="$1" out_file="$2" home="${3:-}"
+  [ -n "$home" ] || home="$(mktemp -d "$WORK/home.XXXXXX")"
+  run_in_subshell "$stub_dir" "$out_file" "$home" ensure_gh
+}
+
+test_gh_pin_match() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g1.log"
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" curl "touch '$WORK/g1-download'; exit 1"
+  rm -f "$WORK/g1-download"
+  run_ensure_gh "$d" "$log" && ok "gh pin match: returns 0 (idempotent)" \
+    || fail "gh pin match: returned non-zero for a pinned gh"
+  [ -e "$WORK/g1-download" ] && fail "gh pin match: attempted a download" \
+    || ok "gh pin match: did NOT attempt a download"
+}
+
+test_gh_pin_mismatch() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g2.log"
+  write_stub "$d" gh "echo 'gh version 2.40.0 (2024-01-01)'"
+  write_stub "$d" curl "exit 1"
+  write_stub "$d" uname "echo x86_64"
+  run_ensure_gh "$d" "$log" && fail "gh pin mismatch: accepted a wrong-version gh" \
+    || ok "gh pin mismatch: rejected wrong-version gh and failed the install"
+}
+
+test_gh_missing_sha256sum() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g3.log"
+  # shellcheck disable=SC2016
+  write_stub "$d" curl 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { out="$2"; shift; }; shift; done; printf dummy >"$out"'
+  write_stub "$d" uname "echo x86_64"
+  write_stub "$d" tar "exit 0"
+  # No sha256sum stub on this PATH; remove the symlinked real one too.
+  rm -f "$d/sha256sum"
+  run_ensure_gh "$d" "$log" && fail "gh missing-sha: returned 0 with no sha256sum" \
+    || ok "gh missing-sha: returned non-zero"
+  grep -q 'sha256sum not found' "$log" 2>/dev/null \
+    && ok "gh missing-sha: attributed to the missing tool" \
+    || fail "gh missing-sha: cause not named. Log: $(cat "$log" 2>/dev/null)"
+}
+
+# ---------------------------------------------------------------------------
+# codex auth + sandbox
+# ---------------------------------------------------------------------------
+run_ensure_codex_auth() {
+  local stub_dir="$1" out_file="$2" token="${3-}"
+  # shellcheck disable=SC2030,SC2031
+  (
+    export PATH="$stub_dir" TMPDIR="$WORK"
+    if [ "$#" -ge 3 ]; then export CODEX_ACCESS_TOKEN="$token"; else unset CODEX_ACCESS_TOKEN; fi
+    LOG="$out_file"
+    ensure_codex_auth
+  ) >>"$out_file" 2>&1
+}
+
+test_codex_no_token() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c1.log"
+  write_stub "$d" codex "> '$WORK/c1-called'; exit 0"
+  rm -f "$WORK/c1-called"
+  run_ensure_codex_auth "$d" "$log" && ok "codex no-token: returns 0 (quiet no-op)" \
+    || fail "codex no-token: returned non-zero"
+  [ -e "$WORK/c1-called" ] && fail "codex no-token: codex was invoked" \
+    || ok "codex no-token: codex NOT invoked"
+}
+
+test_codex_missing_cli() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c2.log"
+  run_ensure_codex_auth "$d" "$log" "tok.tok.tok" \
+    && fail "codex missing-cli: returned 0 with no codex" \
+    || ok "codex missing-cli: returned non-zero"
+  grep -q 'not on PATH' "$log" 2>/dev/null && ok "codex missing-cli: names the missing CLI" \
+    || fail "codex missing-cli: cause not named"
+}
+
+test_codex_fresh_login() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c3.log"
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then printf "%s" "$*" > "'"$WORK"'/c3-argv"; cat > "'"$WORK"'/c3-stdin"; exit 0; fi
+     exit 1'
+  rm -f "$WORK/c3-argv" "$WORK/c3-stdin"
+  run_ensure_codex_auth "$d" "$log" "SECRET.JWT.VALUE" && ok "codex fresh-login: returns 0" \
+    || fail "codex fresh-login: returned non-zero"
+  [ "$(cat "$WORK/c3-stdin" 2>/dev/null)" = "SECRET.JWT.VALUE" ] \
+    && ok "codex fresh-login: token delivered on stdin" \
+    || fail "codex fresh-login: token not on stdin"
+  grep -q 'SECRET.JWT.VALUE' "$WORK/c3-argv" 2>/dev/null \
+    && fail "codex fresh-login: token LEAKED into argv" \
+    || ok "codex fresh-login: token never in argv"
+}
+
+test_codex_blank_token() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c4.log"; envf="$WORK/c4-envfile"; : > "$envf"
+  # codex stub drops a sentinel if it is ever invoked.
+  write_stub "$d" codex "> '$WORK/c4-called'; exit 0"
+  rm -f "$WORK/c4-called"
+  # A whitespace-only token is non-empty (passes the -z guard) but unusable: it
+  # must be diagnosed as blank, NOT piped to `codex login --with-access-token`.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "   " ) \
+    && fail "codex blank-token: returned 0 for a whitespace-only token" \
+    || ok "codex blank-token: returned non-zero"
+  grep -q 'only whitespace' "$log" 2>/dev/null \
+    && ok "codex blank-token: diagnosed as blank" \
+    || fail "codex blank-token: not diagnosed as blank. Log: $(cat "$log" 2>/dev/null)"
+  [ -e "$WORK/c4-called" ] && fail "codex blank-token: codex was invoked" \
+    || ok "codex blank-token: codex NOT invoked"
+  # "treating as unset" must be honored: the blank token has to be dropped from the
+  # session env (codex reads CODEX_ACCESS_TOKEN at runtime), so the unset is persisted.
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex blank-token: persisted unset to CLAUDE_ENV_FILE" \
+    || fail "codex blank-token: did not persist unset. File: $(cat "$envf" 2>/dev/null)"
+}
+
+test_codex_trims_token() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c5.log"; envf="$WORK/c5-envfile"; : > "$envf"
+  # codex stub: report "unauthenticated" so login runs, then capture the stdin the
+  # token is piped on.
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then cat > "'"$WORK"'/c5-stdin"; exit 0; fi
+     exit 1'
+  rm -f "$WORK/c5-stdin"
+  # A valid JWT wrapped in surrounding whitespace (e.g. a secret read from a file
+  # with a trailing newline). It must be trimmed before being piped to codex,
+  # otherwise codex rejects the otherwise-valid JWT as malformed.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "
+  SECRET.JWT.VALUE
+  " ) && ok "codex trim-token: returns 0" \
+    || fail "codex trim-token: returned non-zero"
+  [ "$(cat "$WORK/c5-stdin" 2>/dev/null)" = "SECRET.JWT.VALUE" ] \
+    && ok "codex trim-token: surrounding whitespace stripped before stdin" \
+    || fail "codex trim-token: token not trimmed. Got: [$(cat "$WORK/c5-stdin" 2>/dev/null)]"
+  # The RAW (whitespace-wrapped) value still in the live env is a malformed JWT for
+  # later `codex exec`, so after the trimmed login it must be dropped + persisted.
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex trim-token: dropped the raw whitespace token from the session env" \
+    || fail "codex trim-token: did not persist unset of the raw token. File: [$(cat "$envf" 2>/dev/null)]"
+}
+
+test_codex_clean_token_kept() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c6.log"; envf="$WORK/c6-envfile"; : > "$envf"
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then exit 0; fi
+     exit 1'
+  # A pristine JWT (no surrounding whitespace) must be LEFT in the env so the normal
+  # direct-token path keeps working for later codex calls — do NOT drop it.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "SECRET.JWT.VALUE" ) \
+    && ok "codex clean-token: returns 0" \
+    || fail "codex clean-token: returned non-zero"
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && fail "codex clean-token: wrongly dropped a pristine token. File: [$(cat "$envf" 2>/dev/null)]" \
+    || ok "codex clean-token: pristine token left in place"
+}
+
+run_configure_codex_sandbox() {
+  local home="$1" out_file="$2"
+  # shellcheck disable=SC2030,SC2031,SC2034  # LOG is read by configure_codex_sandbox (sourced)
+  ( export CODEX_HOME="$home" TMPDIR="$WORK"; LOG="$out_file"; configure_codex_sandbox ) >>"$out_file" 2>&1
+}
+
+test_sandbox_creates() {
+  local home log; home="$(mktemp -d "$WORK/s1.XXXXXX")"; log="$WORK/s1.log"
+  run_configure_codex_sandbox "$home" "$log" && ok "sandbox create: returns 0" \
+    || fail "sandbox create: returned non-zero"
+  [ "$(cat "$home/config.toml" 2>/dev/null)" = 'sandbox_mode = "danger-full-access"' ] \
+    && ok "sandbox create: config.toml written with danger-full-access" \
+    || fail "sandbox create: config.toml not as expected"
+}
+
+test_sandbox_respects_existing() {
+  local home log before; home="$(mktemp -d "$WORK/s2.XXXXXX")"; log="$WORK/s2.log"
+  mkdir -p "$home"; printf 'sandbox_mode = "workspace-write"\nmodel = "x"\n' > "$home/config.toml"
+  before="$(cat "$home/config.toml")"
+  run_configure_codex_sandbox "$home" "$log" >/dev/null
+  [ "$(cat "$home/config.toml")" = "$before" ] \
+    && ok "sandbox respect: user-set sandbox_mode left untouched" \
+    || fail "sandbox respect: clobbered a user-set sandbox_mode"
+}
+
+# ---------------------------------------------------------------------------
+# persist_path()
+# ---------------------------------------------------------------------------
+test_persist_path() {
+  local envf; envf="$WORK/p1-envfile"; : > "$envf"
+  ( export CLAUDE_ENV_FILE="$envf"; persist_path "/opt/x/bin"; persist_path "/opt/x/bin" ) >/dev/null 2>&1
+  grep -qF 'export PATH="/opt/x/bin:$PATH"' "$envf" \
+    && ok "persist_path: wrote the export line" \
+    || fail "persist_path: did not write the export line. File: $(cat "$envf")"
+  [ "$(grep -cF '/opt/x/bin' "$envf")" -eq 1 ] \
+    && ok "persist_path: idempotent (no duplicate on re-run)" \
+    || fail "persist_path: duplicated the line on re-run"
+}
+
+# ---------------------------------------------------------------------------
+# main() gate + project hook seam (subprocess)
+# ---------------------------------------------------------------------------
+test_gate_local_noop() {
+  # No CLAUDE_CODE_REMOTE => must be an immediate no-op (exit 0), no install.
+  local out; out="$WORK/gate.out"
+  if CLAUDE_CODE_REMOTE='' bash "$SCRIPT" >"$out" 2>&1; then
+    ok "gate: no-op exit 0 when CLAUDE_CODE_REMOTE unset"
+  else
+    fail "gate: non-zero exit when CLAUDE_CODE_REMOTE unset"
+  fi
+  [ -s "$out" ] && fail "gate: produced output when it should be silent" \
+    || ok "gate: produced no output (true no-op)"
+}
+
+test_local_hook_sourced() {
+  # CLAUDE_CODE_REMOTE=true with a project hook present => hook is sourced, exit 0.
+  local proj d out; proj="$(mktemp -d "$WORK/proj.XXXXXX")"; d="$(new_stub_dir)"; out="$WORK/lh.out"
+  mkdir -p "$proj/scripts"
+  # A cc-web-setup.sh that no-ops (so the self-heal call is cheap) and a local hook
+  # that drops a sentinel.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$proj/scripts/cc-web-setup.sh"; chmod +x "$proj/scripts/cc-web-setup.sh"
+  printf 'touch "%s/lh-sentinel"\n' "$WORK" > "$proj/scripts/web-bootstrap.local.sh"
+  rm -f "$WORK/lh-sentinel"
+  # Stub gh to the pinned version so ensure_gh short-circuits; no codex creds so codex is skipped.
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" id "echo 0"
+  # shellcheck disable=SC2030,SC2031
+  if ( export PATH="$d:/usr/bin:/bin" HOME="$WORK/lh-home" CLAUDE_CODE_REMOTE=true \
+         CLAUDE_PROJECT_DIR="$proj" TMPDIR="$WORK"; bash "$SCRIPT" ) >"$out" 2>&1; then
+    ok "local-hook: main() exits 0 in remote mode"
+  else
+    fail "local-hook: main() exited non-zero. Out: $(cat "$out" 2>/dev/null)"
+  fi
+  [ -e "$WORK/lh-sentinel" ] \
+    && ok "local-hook: web-bootstrap.local.sh was sourced" \
+    || fail "local-hook: project hook was NOT sourced. Out: $(cat "$out" 2>/dev/null)"
+}
+
+test_gh_pin_match
+test_gh_pin_mismatch
+test_gh_missing_sha256sum
+test_codex_no_token
+test_codex_missing_cli
+test_codex_fresh_login
+test_codex_blank_token
+test_codex_trims_token
+test_codex_clean_token_kept
+test_sandbox_creates
+test_sandbox_respects_existing
+test_persist_path
+test_gate_local_noop
+test_local_hook_sourced
+
+echo ""
+echo "web-bootstrap: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/plugins/claude-code/skills/web-setup/scripts/test-web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/test-web-bootstrap.sh
@@ -220,6 +220,45 @@ test_codex_clean_token_kept() {
     || ok "codex clean-token: pristine token left in place"
 }
 
+# Fix A regression: when seed_codex_auth_json wins (auth.json is the credential of
+# record), a stale CODEX_ACCESS_TOKEN must be dropped — codex reads the raw token
+# BEFORE ~/.codex/auth.json, so a leftover would shadow the valid auth.json and break
+# later `codex exec`. This exercises main()'s auth arm as a subprocess: codex installs
+# at the pinned version, seed_codex_auth_json succeeds, and a non-JWT raw token is set.
+test_codex_authjson_drops_stale_token() {
+  local proj d out envf home; proj="$(mktemp -d "$WORK/aj-proj.XXXXXX")"; d="$(new_stub_dir)"
+  out="$WORK/aj.out"; envf="$WORK/aj-envfile"; : > "$envf"; home="$WORK/aj-home"; mkdir -p "$home"
+  mkdir -p "$proj/scripts"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$proj/scripts/cc-web-setup.sh"; chmod +x "$proj/scripts/cc-web-setup.sh"
+  # gh pinned so ensure_gh short-circuits with no download.
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" id "echo 0"
+  # codex stub: report the pinned version so ensure_codex_cli short-circuits (no
+  # download), and report "authenticated" for `login status` so seed_codex_auth_json's
+  # post-write probe succeeds.
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    'case "$1 $2" in
+       "--version "*|"--version") echo "codex-cli '"${CODEX_PIN}"'"; exit 0 ;;
+       "login status") exit 0 ;;
+     esac
+     exit 0'
+  # CODEX_AUTH_JSON present => seed_codex_auth_json wins. A stale, NON-JWT raw token is
+  # live; it must be dropped + persisted as `unset CODEX_ACCESS_TOKEN`.
+  # shellcheck disable=SC2030,SC2031
+  if ( export PATH="$d:/usr/bin:/bin" HOME="$home" CLAUDE_CODE_REMOTE=true \
+         CLAUDE_PROJECT_DIR="$proj" CLAUDE_ENV_FILE="$envf" TMPDIR="$WORK" \
+         CODEX_HOME="$home/.codex" CODEX_AUTH_JSON='{"tokens":{"access_token":"x"}}' \
+         CODEX_ACCESS_TOKEN='stale-not-a-jwt'; bash "$SCRIPT" ) >"$out" 2>&1; then
+    ok "codex authjson-drop: main() exits 0 in remote mode"
+  else
+    fail "codex authjson-drop: main() exited non-zero. Out: $(cat "$out" 2>/dev/null)"
+  fi
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex authjson-drop: stale token unset persisted to CLAUDE_ENV_FILE" \
+    || fail "codex authjson-drop: stale token NOT dropped after auth.json seeded. File: [$(cat "$envf" 2>/dev/null)] Out: $(cat "$out" 2>/dev/null)"
+}
+
 run_configure_codex_sandbox() {
   local home="$1" out_file="$2"
   # shellcheck disable=SC2030,SC2031,SC2034  # LOG is read by configure_codex_sandbox (sourced)
@@ -257,6 +296,41 @@ test_persist_path() {
   [ "$(grep -cF '/opt/x/bin' "$envf")" -eq 1 ] \
     && ok "persist_path: idempotent (no duplicate on re-run)" \
     || fail "persist_path: duplicated the line on re-run"
+}
+
+# Fix B regression: a read-only CLAUDE_ENV_FILE makes the append fail. persist_path
+# must WARN (not falsely log "Persisted"), so later shells are not silently left
+# without the dir on PATH. Run it twice — with $LOG set and with $LOG UNSET — to lock
+# in the ${LOG:-/dev/null} discipline (a bare $LOG would crash under `set -u`).
+test_persist_path_readonly_warns() {
+  local envf out; envf="$WORK/p2-envfile"; : > "$envf"; chmod 0444 "$envf"
+
+  # (1) with $LOG set.
+  out="$WORK/p2-log-set.out"
+  ( export CLAUDE_ENV_FILE="$envf"; LOG="$WORK/p2-LOG"; persist_path "/opt/ro/bin" ) >"$out" 2>&1
+  grep -q 'WARNING: could not append PATH export for /opt/ro/bin' "$out" \
+    && ok "persist_path readonly (LOG set): warned on append failure" \
+    || fail "persist_path readonly (LOG set): no WARNING. Out: $(cat "$out" 2>/dev/null)"
+  grep -q 'Persisted /opt/ro/bin' "$out" \
+    && fail "persist_path readonly (LOG set): falsely claimed success" \
+    || ok "persist_path readonly (LOG set): did NOT falsely claim success"
+
+  # (2) with $LOG UNSET — must not crash under `set -u` (guarded ${LOG:-/dev/null}).
+  out="$WORK/p2-log-unset.out"
+  if ( export CLAUDE_ENV_FILE="$envf"; unset LOG; persist_path "/opt/ro/bin" ) >"$out" 2>&1; then
+    ok "persist_path readonly (LOG unset): ran without crashing under set -u"
+  else
+    fail "persist_path readonly (LOG unset): crashed (likely a bare \$LOG). Out: $(cat "$out" 2>/dev/null)"
+  fi
+  grep -q 'WARNING: could not append PATH export for /opt/ro/bin' "$out" \
+    && ok "persist_path readonly (LOG unset): warned on append failure" \
+    || fail "persist_path readonly (LOG unset): no WARNING. Out: $(cat "$out" 2>/dev/null)"
+
+  chmod 0644 "$envf" 2>/dev/null || true
+  # The unwritable file must remain empty — nothing was appended on either run.
+  [ ! -s "$envf" ] \
+    && ok "persist_path readonly: nothing written to the unwritable file" \
+    || fail "persist_path readonly: unexpectedly wrote to the file. File: [$(cat "$envf" 2>/dev/null)]"
 }
 
 # ---------------------------------------------------------------------------
@@ -307,9 +381,11 @@ test_codex_fresh_login
 test_codex_blank_token
 test_codex_trims_token
 test_codex_clean_token_kept
+test_codex_authjson_drops_stale_token
 test_sandbox_creates
 test_sandbox_respects_existing
 test_persist_path
+test_persist_path_readonly_warns
 test_gate_local_noop
 test_local_hook_sourced
 

--- a/registry/bundles/claude-code.yaml
+++ b/registry/bundles/claude-code.yaml
@@ -1,8 +1,8 @@
 schemaVersion: v1
 id: claude-code
 displayName: Claude Code
-description: Claude Code — agent-team coordination and hook authoring
-keywords: [claude-code, agents, hooks]
+description: Claude Code — agent-team coordination, hook authoring, and web-session setup
+keywords: [claude-code, agents, hooks, web, setup]
 owners:
   - rdl
 channels:
@@ -10,6 +10,7 @@ channels:
 skills:
   - {source: cc-agent-teams, leaf: agent-teams}
   - {source: cc-hook, leaf: hook}
+  - {source: cc-web-setup, leaf: web-setup}
 agents: []
 hooks: []
 prompts: []

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: cc-web-setup
+license: CC-BY-4.0
+description: >-
+  Bootstrap a repository for Claude Code on the web — provision its `.claude/`
+  setup so cloud sessions are correctly configured. Use when the user wants to
+  "set up Claude Code on the web", "bootstrap web sessions", "add the web setup
+  scripts", "configure the SessionStart hook for cloud", "provision a cloud
+  environment", "install web-bootstrap", or "make this repo work with Claude
+  Code on the web". Installs a parameterized `.claude/settings.json` plus
+  portable `scripts/web-bootstrap.sh` (SessionStart hook), `scripts/cc-web-setup.sh`
+  (pre-snapshot setup script that pre-seeds the RDL marketplace), and
+  `scripts/announce-capabilities.sh`. Also covers the setup-script-vs-SessionStart
+  split, the `CLAUDE_CODE_REMOTE` gate, GH/Codex CLI provisioning, and the
+  `*.local.sh` extension seam for project-specific dependencies.
+argument-hint: "Bootstrap this repo for Claude Code on the web? (run from the repo root; say if you have an existing .claude/settings.json to merge)"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Bootstrap a repo for Claude Code on the web
+
+Your job is to provision the current repository so **Claude Code on the web** (cloud)
+sessions start correctly configured: the RDL marketplace registered and pre-seeded,
+the GitHub and Codex CLIs available, and a SessionStart hook that self-heals and
+persists tooling. The portable pieces ship as files in this skill's `assets/`
+directory; you copy them into the target repo and merge the settings idempotently.
+
+## Background you must understand before acting
+
+Claude Code on the web has **two** provisioning mechanisms, and this setup uses both:
+
+1. **Setup script** — bash that runs **once, before Claude starts**, whose filesystem
+   is captured in the environment snapshot. Configured in the web environment's
+   settings UI (not the repo), but the *script it runs* lives in the repo at
+   `scripts/cc-web-setup.sh`. The user wires it by setting the environment's **Setup
+   script** field to `make cc-web-setup` (or `bash scripts/cc-web-setup.sh`). Plugins
+   installed here are available on the **first** session (Claude enumerates skills at
+   startup, before any hook runs).
+2. **SessionStart hook** — `scripts/web-bootstrap.sh`, runs **every session** (cloud
+   *and* local), gated on `CLAUDE_CODE_REMOTE=true` so it is a no-op on a contributor's
+   laptop. It self-heals the plugin pre-seed and provisions per-session tooling.
+
+You cannot set the environment Setup-script field for the user (it is not in the repo).
+**Tell them** to set it to `make cc-web-setup` after you finish.
+
+## Phase 0 — Confirm context
+
+- Confirm you are at the **repo root** of the repo to bootstrap (a `.git` dir is present).
+- Check whether `.claude/settings.json`, `scripts/`, and `Makefile` already exist — this
+  decides create-fresh vs. merge for each.
+- Ask the user only if something is ambiguous (e.g. a pre-existing `settings.json` with a
+  conflicting `model`/`hooks` block). Otherwise proceed with the defaults below.
+
+## Phase 1 — Copy the portable scripts
+
+Copy these three files from this skill's `assets/` into the target repo's `scripts/`,
+creating `scripts/` if absent, and `chmod +x` each:
+
+| From (skill asset) | To (target repo) |
+|---|---|
+| `assets/web-bootstrap.sh` | `scripts/web-bootstrap.sh` |
+| `assets/cc-web-setup.sh` | `scripts/cc-web-setup.sh` |
+| `assets/announce-capabilities.sh` | `scripts/announce-capabilities.sh` |
+
+These are **portable and carry no project-specific dependencies** — do not edit them per
+project. Project specifics go in the optional `*.local.sh` seam (Phase 4).
+
+If a target file already exists and differs, show the diff and ask before overwriting.
+
+## Phase 2 — Merge `.claude/settings.json`
+
+The template is `assets/settings.json.tmpl`. It registers the **`rdl`** marketplace
+(`nq-rdl/agent-extensions`), enables **`rdl@rdl`** (the meta-plugin that installs every
+RDL subject plugin), wires the two SessionStart hooks, and sets opinionated defaults
+(`model: opus`, `alwaysThinkingEnabled`, `effortLevel: xhigh`,
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+
+- **If `.claude/settings.json` is absent:** create `.claude/` and write the template verbatim.
+- **If it exists:** perform an **idempotent JSON-aware deep-merge** (use `jq` or a careful
+  read-modify-write), and **show the diff before writing**:
+  - `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
+  - `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the
+    two hook commands **only if not already present** (dedupe by exact command string), so
+    re-running is a no-op.
+  - `enabledPlugins`: add `"rdl@rdl": true`.
+  - `extraKnownMarketplaces`: add the `rdl` entry; leave any existing marketplaces intact.
+  - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never
+    override a deliberate user choice. Mention they are opinionated defaults the user can
+    decline.
+  - If a stale `"superpowers@claude-plugins-official"` (or other migrated-away entry) is
+    present, point it out and offer to remove it.
+
+## Phase 3 — Merge the Makefile target
+
+Append `assets/Makefile.snippet` to the repo's `Makefile` **only if** a `cc-web-setup:`
+target is not already present. If there is no `Makefile`, create one containing just the
+snippet. This gives the user the `make cc-web-setup` entrypoint to set as the environment
+Setup script.
+
+## Phase 4 — Offer the project extension seam
+
+The portable scripts source two optional, project-owned hooks if present:
+`scripts/cc-web-setup.local.sh` (heavy pre-snapshot deps) and `scripts/web-bootstrap.local.sh`
+(per-session glue: language toolchains on PATH, container runtimes, git-hook wiring like
+`.husky`/`.githooks`/lefthook, fetching the default branch). This is the **only** sanctioned
+place for project-specific provisioning — keep it out of the portable scripts so they stay
+re-syncable.
+
+Offer to scaffold a commented `scripts/web-bootstrap.local.sh` from
+`assets/web-bootstrap.local.sh.example`. Do **not** create it unless the repo actually needs
+project-specific steps.
+
+## Phase 5 — Verify
+
+- Run `CLAUDE_CODE_REMOTE=true bash scripts/web-bootstrap.sh` and confirm it exits 0. (Cloud
+  tooling installs may warn if offline — that is fine; the hook must still exit 0.)
+- Run `bash scripts/web-bootstrap.sh` (no env var) and confirm it is an immediate no-op.
+- Confirm `bash scripts/cc-web-setup.sh` is sentinel-/idempotent — a second run changes nothing.
+- Validate `.claude/settings.json` parses (`jq . .claude/settings.json`).
+
+## Phase 6 — Summarize for the user
+
+Tell the user, concisely:
+- What was created/merged (list the files + the settings keys touched).
+- **The one manual step:** set the web environment's **Setup script** field to
+  `make cc-web-setup` so plugin skills are baked into the snapshot and available on the
+  first session (otherwise they only appear from the second session onward).
+- That `web-bootstrap.sh` is safe locally (no-op unless `CLAUDE_CODE_REMOTE=true`).
+- How to add project-specific deps via `scripts/*.local.sh`.
+- That Codex CLI provisioning activates only when `CODEX_AUTH_JSON` or `CODEX_ACCESS_TOKEN`
+  is set in the environment.
+- To commit the new files so cloud sessions (which clone the repo) pick them up.

--- a/skills/cc-web-setup/assets/Makefile.snippet
+++ b/skills/cc-web-setup/assets/Makefile.snippet
@@ -1,0 +1,9 @@
+# --- Claude Code on the web provisioning (added by claude-code:web-setup) -----
+# Run this ONCE from the web environment's *setup script* (the bash that runs
+# before Claude starts, whose filesystem is captured in the environment
+# snapshot). Installing plugins here — before the snapshot — bakes their skills
+# into the image so they are available on the FIRST session. Exposed as a make
+# target for convenience; the web setup script should call `make cc-web-setup`.
+.PHONY: cc-web-setup
+cc-web-setup: ## Provision a Claude Code on the web VM (plugin pre-seed) — run by the cloud setup script
+	@bash scripts/cc-web-setup.sh

--- a/skills/cc-web-setup/assets/announce-capabilities.sh
+++ b/skills/cc-web-setup/assets/announce-capabilities.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# announce-capabilities.sh — SessionStart hook.
+#
+# Enumerates the skills, slash-commands and MCP servers present in *this*
+# runner and injects a concise summary as `additionalContext`, so Claude is
+# aware of them even on a blank / isolated runner (a GitHub Action job, a web
+# sandbox) where it would otherwise have no cheap way to discover what was
+# provisioned. This is the awareness companion to the explicit plugin install
+# done in the Claude workflows (see .github/workflows/claude*.yml) and the
+# enabledPlugins in .claude/settings.json.
+#
+# Output contract (Claude Code SessionStart hook): emit a single JSON object
+# with hookSpecificOutput.additionalContext, or — as a fallback — plain text on
+# stdout (also accepted). The hook must never fail the session, so it always
+# exits 0.
+#
+# Refs: code.claude.com/docs/en/hooks-guide (SessionStart, additionalContext).
+
+set -u
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${GITHUB_WORKSPACE:-$(pwd)}}"
+
+# --- gather sections -------------------------------------------------------
+
+lines=()
+add() { lines+=("$1"); }
+
+# Join deduped stdin lines with a literal ", ". Avoids `paste -sd', '`, whose
+# multi-char delimiter is cycled char-by-char (a,b c) on GNU and truncated to
+# the first char (a,b) on BSD — neither yields stable comma+space separation.
+join_comma() { sort -u | awk 'NR > 1 { printf ", " } { printf "%s", $0 }'; }
+
+# Repo slash-commands (.claude/commands/*.md)
+commands=()
+if [ -d "$PROJECT_DIR/.claude/commands" ]; then
+  for f in "$PROJECT_DIR"/.claude/commands/*.md; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f" .md)"
+    commands+=("/$name")
+  done
+fi
+
+# Repo skills (.claude/skills/*/SKILL.md) — name + first line of description
+skills=()
+if [ -d "$PROJECT_DIR/.claude/skills" ]; then
+  for s in "$PROJECT_DIR"/.claude/skills/*/SKILL.md; do
+    [ -e "$s" ] || continue
+    sname="$(sed -n 's/^name:[[:space:]]*//p' "$s" | head -n1)"
+    [ -n "$sname" ] || sname="$(basename "$(dirname "$s")")"
+    # Description's first human line. Handle BOTH the inline form
+    # (`description: text`) and YAML block/folded scalars (`description: >-` or
+    # `|` followed by indented lines): a bare `sed` on the `description:` line
+    # would capture the literal `>-`/`|` indicator for the folded form. For a
+    # block indicator (or an empty value) fall through to the first non-empty
+    # continuation line, and strip one layer of surrounding quotes.
+    sdesc="$(awk -v sq="'" '
+      /^description:([[:space:]]|$)/ {
+        line = $0
+        sub(/^description:[[:space:]]*/, "", line)
+        if (line == "" || line ~ /^[|>][+-]?[[:space:]]*$/) {
+          # The text is on the following INDENTED continuation line(s). Reset
+          # first so a missing continuation (e.g. an indicator at EOF) yields an
+          # empty description rather than the literal `>-`/`|`. Skip blank lines,
+          # but STOP at a column-0 line — the closing `---` or a sibling key is
+          # not part of this scalar and must never be taken as the description.
+          line = ""
+          while ((getline nl) > 0) {
+            if (nl ~ /^[[:space:]]*$/) continue
+            if (nl !~ /^[[:space:]]/) break
+            sub(/^[[:space:]]+/, "", nl); line = nl; break
+          }
+        }
+        sub(/^"/, "", line); sub(/"$/, "", line)
+        sub("^" sq, "", line); sub(sq "$", "", line)
+        print line
+        exit
+      }
+    ' "$s" | cut -c1-120)"
+    if [ -n "$sdesc" ]; then
+      skills+=("/$sname — $sdesc")
+    else
+      skills+=("/$sname")
+    fi
+  done
+fi
+
+# MCP servers (.mcp.json at root, plus any mcpServers in .claude/settings.json)
+mcp=()
+if command -v jq >/dev/null 2>&1; then
+  for cfg in "$PROJECT_DIR/.mcp.json" "$PROJECT_DIR/.claude/settings.json"; do
+    [ -f "$cfg" ] || continue
+    while IFS= read -r srv; do
+      [ -n "$srv" ] && mcp+=("$srv")
+    done < <(jq -r '(.mcpServers // {}) | keys[]?' "$cfg" 2>/dev/null)
+  done
+fi
+
+# Enabled plugins — read the authoritative enabledPlugins map from the project
+# settings (true => enabled). This is checked out in both web and Action runs
+# and avoids listing un-enabled marketplace plugins or version-dir noise.
+plugins=()
+if command -v jq >/dev/null 2>&1 && [ -f "$PROJECT_DIR/.claude/settings.json" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] && plugins+=("$p")
+  done < <(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value == true) | .key' \
+             "$PROJECT_DIR/.claude/settings.json" 2>/dev/null)
+fi
+
+# --- render ----------------------------------------------------------------
+
+add "## Runner capabilities"
+add ""
+add "This session runs on an isolated/blank runner. The following project capabilities are present and ready to use — prefer a relevant skill before acting, and invoke skills explicitly with the Skill tool / \`/skill-name\` (plugin skills use \`/plugin:skill\`)."
+add ""
+
+if [ "${#skills[@]}" -gt 0 ]; then
+  add "**Repo skills (.claude/skills):**"
+  for x in "${skills[@]}"; do add "- $x"; done
+  add ""
+fi
+
+if [ "${#commands[@]}" -gt 0 ]; then
+  add "**Slash-commands (.claude/commands):** ${commands[*]}"
+  add ""
+fi
+
+if [ "${#mcp[@]}" -gt 0 ]; then
+  # de-dupe
+  uniq_mcp="$(printf '%s\n' "${mcp[@]}" | join_comma)"
+  add "**MCP servers:** $uniq_mcp"
+  add ""
+fi
+
+if [ "${#plugins[@]}" -gt 0 ]; then
+  uniq_plugins="$(printf '%s\n' "${plugins[@]}" | join_comma)"
+  add "**Enabled plugins:** $uniq_plugins"
+  add "Their skills are available via the Skill tool (\`/plugin:skill\`) — list and invoke as relevant."
+  add ""
+fi
+
+context="$(printf '%s\n' "${lines[@]}")"
+
+# --- emit ------------------------------------------------------------------
+
+if command -v jq >/dev/null 2>&1; then
+  jq -cn --arg ctx "$context" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+else
+  printf '%s\n' "$context"
+fi
+
+exit 0

--- a/skills/cc-web-setup/assets/cc-web-setup.sh
+++ b/skills/cc-web-setup/assets/cc-web-setup.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# cc-web-setup.sh — provision a Claude Code on the web (cloud) VM.
+#
+# Run this ONCE per environment from the web environment's *setup script* — the
+# bash that runs before Claude starts and whose filesystem state is captured in
+# the environment snapshot. It is exposed as `make cc-web-setup`.
+#
+# Why a setup-script step rather than (only) the SessionStart hook: Claude
+# enumerates skills at process startup, BEFORE SessionStart hooks run. A plugin
+# installed by the hook (scripts/web-bootstrap.sh) therefore only surfaces its
+# skills on the NEXT session. Installing the plugin here — before the snapshot,
+# before Claude starts — bakes it into the image so its skills are available on
+# the FIRST session.
+#
+# Idempotent and safe to re-run: the plugin pre-seed is a cheap no-op when
+# already current, and an optional project hook (cc-web-setup.local.sh) guards
+# its own heavy work. The SessionStart hook also calls this as a self-heal for
+# environments whose setup script does not run it (on that path the plugins'
+# skills still arrive next session, because the hook runs after skill enumeration).
+#
+# This script is PORTABLE: it carries no project-specific dependencies. Project
+# specifics (language toolchains, container runtimes, heavy installs) belong in
+# an optional, gitignored-or-committed `scripts/cc-web-setup.local.sh` that this
+# script sources if present — see the SOURCE PROJECT HOOK section below.
+#
+# Exit status reflects provisioning (0 = installed or skipped, non-zero =
+# failed) so a setup script can surface provisioning failures; callers that must
+# not fail (the SessionStart hook) invoke it with `|| …`.
+#
+# Output discipline: keep stdout concise — when run from the hook it is injected
+# into Claude's context — so verbose tool output goes to $LOG.
+set -uo pipefail
+
+# Only colorize on a TTY — cloud setup/SessionStart stdout is non-TTY and (for
+# the hook) injected into the model context, where ANSI escapes are just noise.
+if [ -t 1 ]; then _BLU=$'\033[34m'; _RST=$'\033[0m'; else _BLU=''; _RST=''; fi
+log() { printf '%s[cc-web-setup]%s %s\n' "$_BLU" "$_RST" "$*"; }
+
+# Marketplaces to register before installing plugins. On a cold VM this can run
+# BEFORE Claude loads extraKnownMarketplaces from .claude/settings.json, so an
+# explicit `marketplace add` is required — otherwise the plugin install fails with
+# "No marketplaces configured". Each entry is "<github-source>|<registered-name>":
+# `marketplace add` takes the GitHub source, but `marketplace update` takes the
+# name shown by `marketplace list` (these can differ).
+#
+# Parameterized: override the defaults by exporting CC_WEB_MARKETPLACES as a
+# whitespace-separated list of "<source>|<name>" entries (e.g. in
+# cc-web-setup.local.sh or the environment), so a repo can pre-seed extra
+# marketplaces without forking this script.
+if [ -n "${CC_WEB_MARKETPLACES:-}" ]; then
+  read -r -a MARKETPLACES <<<"$CC_WEB_MARKETPLACES"
+else
+  MARKETPLACES=("nq-rdl/agent-extensions|rdl")
+fi
+
+# Plugins to pre-seed. Override with CC_WEB_PLUGINS (whitespace-separated
+# "<plugin>@<marketplace>" entries). Default pre-seeds the RDL meta-plugin, which
+# pulls in every RDL subject plugin in one install.
+if [ -n "${CC_WEB_PLUGINS:-}" ]; then
+  read -r -a PLUGINS <<<"$CC_WEB_PLUGINS"
+else
+  PLUGINS=("rdl@rdl")
+fi
+
+# Imperative body. Wrapped in main() so the script is *sourceable* for unit
+# tests: executing it (`make cc-web-setup`, or `bash …/cc-web-setup.sh` from
+# web-bootstrap.sh) runs main; sourcing it (the test harness) only defines the
+# functions/globals above so they can be exercised against stubbed external
+# tools without running the imperative body or touching the log file. LOG/
+# PROJECT_DIR live IN here (mirroring web-bootstrap.sh) so sourcing never
+# truncates the real log.
+main() {
+  # Verbose output sink (keeps stdout clean — see header).
+  LOG="${TMPDIR:-/tmp}/rdl-cc-web-setup.log"
+  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+
+  # Resolve the repo root. `make cc-web-setup` runs from the repo root and the
+  # hook exports CLAUDE_PROJECT_DIR; fall back to the script's own location so it
+  # also works when run by hand.
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+  local rc=0
+
+  # --- 1. plugin marketplace + plugin pre-seed ------------------------------
+  # Installing the plugin HERE (pre-snapshot, pre-startup) is what makes its skills
+  # available on the first session. Run every invocation (not sentinel-gated) so a
+  # transient marketplace/network failure self-heals on the next call.
+  if command -v claude >/dev/null 2>&1; then
+    # Register marketplaces first so plugins resolve on a cold VM (see MARKETPLACES).
+    # `marketplace add` pulls the marketplace by its GitHub source; if it is already
+    # registered that call fails harmlessly, so fall back to `update` by its
+    # registered name to refresh it.
+    local entry mp_src mp_name plugin
+    for entry in "${MARKETPLACES[@]}"; do
+      mp_src="${entry%%|*}"; mp_name="${entry##*|}"
+      log "Registering plugin marketplace ${mp_name}…"
+      claude plugin marketplace add "$mp_src" </dev/null >>"$LOG" 2>&1 \
+        || claude plugin marketplace update "$mp_name" </dev/null >>"$LOG" 2>&1 \
+        || log "  WARNING: could not register/update marketplace ${mp_name} (see ${LOG})."
+    done
+    for plugin in "${PLUGINS[@]}"; do
+      log "Pre-seeding ${plugin}…"
+      if claude plugin install "$plugin" --scope project </dev/null >>"$LOG" 2>&1 \
+         || claude plugin update "$plugin" --scope project </dev/null >>"$LOG" 2>&1; then
+        log "  ${plugin}: ready."
+      else
+        # A plugin that can neither install nor update is a real provisioning
+        # failure: the documented exit-status contract (0 = installed/skipped,
+        # non-zero = failed) requires surfacing it, even though the SessionStart
+        # hook will retry next session.
+        log "  WARNING: could not install/update ${plugin} (see ${LOG})."
+        rc=1
+      fi
+    done
+  else
+    log "claude CLI not on PATH — skipping plugin pre-seed."
+  fi
+
+  # --- 2. SOURCE PROJECT HOOK (optional, project-specific) ------------------
+  # The portable engine above carries no project dependencies. A repo that needs
+  # heavy provisioning baked into the snapshot (language toolchains, container
+  # runtimes, k8s-in-docker, etc.) puts it in scripts/cc-web-setup.local.sh,
+  # which is sourced here if present. A subshell inherits main()'s helpers and
+  # globals (log, $LOG, $PROJECT_DIR), so file/system side effects persist; the
+  # hook signals a hard provisioning failure by exiting/returning non-zero, which
+  # the subshell exit status captures into rc.
+  #
+  # SECURITY/ISOLATION: cc-web-setup.local.sh is trusted, repo-owned code — the
+  # same trust level as this committed script (and every other file in scripts/).
+  # Running it in a SUBSHELL means a stray `exit` cannot abort provisioning and
+  # its variable edits cannot leak back into main(); it does NOT sandbox the code
+  # (a project hook legitimately needs the session's git/gh credentials).
+  local local_hook="${PROJECT_DIR}/scripts/cc-web-setup.local.sh"
+  if [ -f "$local_hook" ]; then
+    log "Running project setup hook (cc-web-setup.local.sh)…"
+    # shellcheck source=/dev/null
+    ( source "$local_hook" ) || { log "WARNING: project setup hook reported errors (see ${LOG})."; rc=1; }
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    log "Provisioning complete."
+  else
+    log "Provisioning finished with errors (see ${LOG})."
+  fi
+  exit "$rc"
+}
+
+# Run the imperative body only when executed, not when sourced. cc-web-setup is
+# invoked by direct exec (`make cc-web-setup`) and via `bash …/cc-web-setup.sh`
+# from web-bootstrap.sh, so BASH_SOURCE[0] == $0 holds for the real run; the test
+# harness (which sources this file) skips main and just exercises the globals.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/skills/cc-web-setup/assets/settings.json.tmpl
+++ b/skills/cc-web-setup/assets/settings.json.tmpl
@@ -1,0 +1,37 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/web-bootstrap.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/announce-capabilities.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "rdl@rdl": true
+  },
+  "extraKnownMarketplaces": {
+    "rdl": {
+      "source": {
+        "source": "github",
+        "repo": "nq-rdl/agent-extensions"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/skills/cc-web-setup/assets/web-bootstrap.local.sh.example
+++ b/skills/cc-web-setup/assets/web-bootstrap.local.sh.example
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# web-bootstrap.local.sh — OPTIONAL per-project extension to web-bootstrap.sh.
+#
+# This file is the sanctioned seam for project-specific provisioning. If it
+# exists next to scripts/web-bootstrap.sh, the portable hook sources it near the
+# end of its run (inside the CLAUDE_CODE_REMOTE=true gate), AFTER the generic
+# engine (gh CLI, codex CLI, plugin pre-seed self-heal, PATH persistence, git
+# hooks) has run. Put anything specific to THIS repo here so the portable script
+# stays generic and re-syncable.
+#
+# It is sourced (not executed), so it shares web-bootstrap.sh's helpers and
+# globals: log(), $LOG (verbose sink), $PROJECT_DIR, $SUDO, $CLAUDE_ENV_FILE.
+# Keep every step non-fatal — the parent hook must always exit 0 — and route
+# verbose output to "$LOG" so it does not pollute the model context.
+#
+# Rename to `web-bootstrap.local.sh` (drop `.example`) and commit it to enable.
+#
+# Example: bring up the bits DataOps needs (pixi on PATH, docker, k3d, shellcheck).
+# Everything below is illustrative — delete what you do not need.
+
+# # Persist pixi on PATH for later Bash tool commands.
+# if [ -n "${CLAUDE_ENV_FILE:-}" ] && [ -x "${HOME}/.pixi/bin/pixi" ]; then
+#   if ! grep -qF 'HOME/.pixi/bin' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+#     # shellcheck disable=SC2016
+#     echo 'export PATH="$HOME/.pixi/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+#     log "Persisted ~/.pixi/bin on PATH via CLAUDE_ENV_FILE."
+#   fi
+# fi
+
+# # Start the Docker daemon (k3d / testcontainers need it).
+# if command -v docker >/dev/null 2>&1 && ! docker info >/dev/null 2>&1; then
+#   if command -v dockerd >/dev/null 2>&1; then
+#     nohup $SUDO dockerd >>"${TMPDIR:-/tmp}/dockerd.log" 2>&1 &
+#     disown 2>/dev/null || true
+#   fi
+# fi

--- a/skills/cc-web-setup/assets/web-bootstrap.sh
+++ b/skills/cc-web-setup/assets/web-bootstrap.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+#
+# web-bootstrap.sh — per-session bootstrap for a Claude Code on the web session.
+#
+# Invoked from the repo's .claude/settings.json SessionStart hook. It is a no-op
+# unless running inside an Anthropic-managed cloud VM (CLAUDE_CODE_REMOTE=true),
+# so it never touches a local contributor's machine.
+#
+# The heavy provisioning (Claude plugin pre-seed) lives in
+# scripts/cc-web-setup.sh, which the web environment's *setup script* should run
+# ONCE before the snapshot (`make cc-web-setup`) so plugin skills are available
+# on the FIRST session — Claude enumerates skills at startup, so a plugin
+# installed by this hook only surfaces next session. This per-session hook then:
+#   * self-heals by running cc-web-setup.sh when the environment was not
+#     pre-provisioned (on that path, plugin skills only arrive next session);
+#   * provisions the portable per-session tooling a snapshot cannot carry: the
+#     GitHub CLI (PR/CI automation) and the Codex CLI (a second opinion via
+#     `codex exec`), persisting both on PATH for later Bash commands;
+#   * sources an optional project hook (web-bootstrap.local.sh) for repo-specific
+#     glue (language toolchains, container runtimes, git-hook wiring, …).
+#
+# This script is PORTABLE: it carries no project-specific dependencies. Anything
+# specific to one repo belongs in scripts/web-bootstrap.local.sh (sourced below).
+#
+# Output discipline: SessionStart stdout is injected into Claude's context, so
+# verbose tool output goes to $LOG and only concise status lines reach stdout.
+#
+# Every step is non-fatal: a SessionStart hook that exits non-zero can disrupt
+# session start, so problems are logged and the script always exits 0.
+set -uo pipefail
+
+# Only colorize on a TTY — cloud SessionStart stdout is non-TTY and injected into
+# the model context, where ANSI escapes are just noise.
+if [ -t 1 ]; then _BLU=$'\033[34m'; _RST=$'\033[0m'; else _BLU=''; _RST=''; fi
+log() { printf '%s[web-bootstrap]%s %s\n' "$_BLU" "$_RST" "$*"; }
+
+# Pinned GitHub CLI (gh) release. GitHub releases are on the cloud "Trusted"
+# network allowlist. Update the pin and BOTH per-arch checksums together — the
+# SHA-256 values are gh's published gh_<ver>_checksums.txt entries.
+GH_PIN="2.95.0"
+GH_SHA256_x86_64="25d1e4729e8808c9ed3d613e96ebd3f3e44446f2d368c89d878a71a36ddb3d8c"
+GH_SHA256_aarch64="d41e0b3b6218e5741c8bb4db39b16e53a59e0e06299a8489bd38f623ef7ebaae"
+
+# Install the GitHub CLI from a checksum-pinned GitHub release into ~/.local/bin
+# so PR/CI automation can run from the cloud session (gh authenticates from the
+# GH_TOKEN the environment injects). Idempotent, but PIN-AWARE: it short-circuits
+# ONLY when the gh already on PATH reports the pinned version, so a base image
+# shipping a different gh is replaced by GH_PIN rather than silently used.
+# (GitHub releases, not a vendor install script, because only github.com is on
+# the default Trusted allowlist.)
+ensure_gh() {
+  export PATH="${HOME}/.local/bin:${PATH}"
+  # Fixed-string grep (-F) so the version literal is matched verbatim, no regex.
+  # The trailing space pins the match to the exact version: `gh --version` prints
+  # `gh version X.Y.Z (DATE)`, so the space after ${GH_PIN} stops 2.95.0 from
+  # matching a hypothetical 2.95.01.
+  if command -v gh >/dev/null 2>&1 && gh --version 2>/dev/null | grep -qF "gh version ${GH_PIN} "; then
+    return 0
+  fi
+  # Preflight every external tool the install path needs, failing fast with a
+  # per-tool message so a missing sha256sum does not surface as a misleading
+  # "checksum mismatch".
+  local tool
+  for tool in curl sha256sum tar; do
+    command -v "$tool" >/dev/null 2>&1 || { log "WARNING: $tool not found — cannot install gh."; return 1; }
+  done
+  local arch asset sha url tmp bin
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64)  asset="gh_${GH_PIN}_linux_amd64.tar.gz"; sha="$GH_SHA256_x86_64" ;;
+    aarch64) asset="gh_${GH_PIN}_linux_arm64.tar.gz"; sha="$GH_SHA256_aarch64" ;;
+    *) log "WARNING: unsupported arch '$arch' for the gh install."; return 1 ;;
+  esac
+  url="https://github.com/cli/cli/releases/download/v${GH_PIN}/${asset}"
+  log "Installing gh ${GH_PIN} from GitHub (${asset})…"
+  mkdir -p "${HOME}/.local/bin"
+  # Template-based mktemp: portable across GNU/BSD (a bare `mktemp -d` needs a
+  # template on BSD/macOS).
+  if ! tmp="$(mktemp -d "${TMPDIR:-/tmp}/gh-install.XXXXXX")" || [ -z "$tmp" ]; then
+    log "WARNING: failed to create a temp dir for the gh install."; return 1
+  fi
+  if ! curl -fsSL "$url" -o "$tmp/gh.tar.gz" 2>>"$LOG"; then
+    log "WARNING: gh download failed (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  # Verify the pinned checksum before touching the binary.
+  if ! printf '%s  %s\n' "$sha" "$tmp/gh.tar.gz" | sha256sum -c - >>"$LOG" 2>&1; then
+    log "WARNING: gh checksum mismatch for ${asset} — refusing to install."; rm -rf "$tmp"; return 1
+  fi
+  # Extract/find/install with an explicit, logged failure arm at every step: a
+  # silent no-op here would let the function fall through to a stale wrong-version
+  # gh already on PATH (via the ${HOME}/.local/bin prepend) and falsely report OK.
+  if tar -xzf "$tmp/gh.tar.gz" -C "$tmp" 2>>"$LOG"; then
+    bin="$(find "$tmp" -type f -name gh -path '*/bin/gh' 2>/dev/null | head -1 || true)"
+    if [ -z "$bin" ]; then
+      log "WARNING: gh tarball had no bin/gh after extract — refusing to install."; rm -rf "$tmp"; return 1
+    fi
+    if ! install -m 0755 "$bin" "${HOME}/.local/bin/gh" 2>>"$LOG"; then
+      log "WARNING: failed to install gh into ${HOME}/.local/bin (see ${LOG})."; rm -rf "$tmp"; return 1
+    fi
+  else
+    log "WARNING: failed to extract the gh tarball (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  rm -rf "$tmp"
+  # Honest final signal: confirm the PINNED version is what now resolves (trailing
+  # space => exact match), rather than trusting whatever gh PATH happens to find.
+  gh --version 2>/dev/null | grep -qF "gh version ${GH_PIN} "
+}
+
+# Pinned Codex CLI release (openai/codex). GitHub releases are on the cloud
+# "Trusted" network allowlist, so — like ensure_gh — we install from a release
+# asset rather than npm (not on the default allowlist). We deliberately install
+# the "package" tarball (codex-package-<arch>-unknown-linux-musl.tar.gz), NOT the
+# bare codex-<arch>.tar.gz, for two reasons: (1) OpenAI publishes its SHA-256 in
+# the release's codex-package_SHA256SUMS, so the checksum below is an
+# upstream-published digest (the bare binary has none); (2) it bundles the runtime
+# resources codex uses (the bwrap sandbox + a vendored ripgrep) under
+# codex-resources/ + codex-path/, which the binary resolves relative to its real
+# path. Update the pin and BOTH per-arch checksums together — the values are the
+# codex-package-<arch>-unknown-linux-musl.tar.gz entries from that tag's
+# codex-package_SHA256SUMS.
+CODEX_PIN="0.141.0"
+CODEX_TAG="rust-v${CODEX_PIN}"
+CODEX_SHA256_x86_64="091c8a2e27370c41407fa1cb647fe905bd4fd70e4689c13effee0a2dce1b2b07"
+CODEX_SHA256_aarch64="b70030338592de3e361f3cde83d624f88061df300abe31b62075a5c5a058a6fc"
+
+# True iff the codex on PATH reports EXACTLY the pinned version. `codex --version`
+# prints `codex-cli X.Y.Z`; codex has no trailing space to anchor on (unlike `gh
+# version X.Y.Z `), so we match with an ERE boundary ([[:space:]]|$). That keeps a
+# suffixed build like `codex-cli 0.141.0-alpha.7` from satisfying the pin as a
+# prefix, and the dots in the pin are escaped so they match literally.
+codex_is_pinned() {
+  command -v codex >/dev/null 2>&1 || return 1
+  codex --version 2>/dev/null | grep -Eq "codex-cli ${CODEX_PIN//./\\.}([[:space:]]|\$)"
+}
+
+# Install the Codex CLI from a checksum-pinned GitHub release. Mirrors ensure_gh:
+# idempotent and PIN-AWARE (short-circuits ONLY when the codex on PATH reports the
+# pinned version, so a base image shipping a different codex is replaced rather
+# than silently used), with an explicit logged failure arm at every step so a
+# silent no-op can never make the function falsely report OK.
+#
+# The package tarball is not a lone binary: it extracts to bin/codex plus sibling
+# codex-resources/ + codex-path/ trees. So we stage it into a per-version dir under
+# ${HOME}/.local/share/codex and symlink bin/codex onto ${HOME}/.local/bin. codex
+# locates its resources via its real executable path (/proc/self/exe follows the
+# symlink to the staged dir), so a PATH symlink keeps the bundled sandbox + ripgrep
+# resolvable — verified before adopting this layout.
+ensure_codex_cli() {
+  export PATH="${HOME}/.local/bin:${PATH}"
+  # Pin-aware short-circuit: skip the install ONLY when the codex on PATH already
+  # reports exactly the pinned version (boundary-aware — see codex_is_pinned).
+  if codex_is_pinned; then
+    return 0
+  fi
+  # Preflight every external tool the install path needs, failing fast with a
+  # per-tool message (mirrors ensure_gh — a missing sha256sum must not surface as
+  # a misleading checksum mismatch).
+  local tool
+  for tool in curl sha256sum tar; do
+    command -v "$tool" >/dev/null 2>&1 || { log "WARNING: $tool not found — cannot install codex."; return 1; }
+  done
+  local arch asset sha url tmp staging dest
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64)  asset="codex-package-x86_64-unknown-linux-musl.tar.gz";  sha="$CODEX_SHA256_x86_64" ;;
+    aarch64) asset="codex-package-aarch64-unknown-linux-musl.tar.gz"; sha="$CODEX_SHA256_aarch64" ;;
+    *) log "WARNING: unsupported arch '$arch' for the codex install."; return 1 ;;
+  esac
+  url="https://github.com/openai/codex/releases/download/${CODEX_TAG}/${asset}"
+  log "Installing codex ${CODEX_PIN} from GitHub (${asset})…"
+  mkdir -p "${HOME}/.local/bin" "${HOME}/.local/share/codex"
+  if ! tmp="$(mktemp -d "${TMPDIR:-/tmp}/codex-install.XXXXXX")" || [ -z "$tmp" ]; then
+    log "WARNING: failed to create a temp dir for the codex install."; return 1
+  fi
+  if ! curl -fsSL "$url" -o "$tmp/codex.tar.gz" 2>>"$LOG"; then
+    log "WARNING: codex download failed (see ${LOG})."; rm -rf "$tmp"; return 1
+  fi
+  # Verify the pinned (upstream-published) checksum before touching the archive.
+  if ! printf '%s  %s\n' "$sha" "$tmp/codex.tar.gz" | sha256sum -c - >>"$LOG" 2>&1; then
+    log "WARNING: codex checksum mismatch for ${asset} — refusing to install."; rm -rf "$tmp"; return 1
+  fi
+  # Stage into a sibling of the final dir so the swap-in is an atomic same-FS
+  # rename (mktemp -d under ${HOME}/.local/share/codex), then verify the entrypoint
+  # exists before adopting it — a silent extract no-op must not fall through to the
+  # final version check off a stale codex already on PATH.
+  if ! staging="$(mktemp -d "${HOME}/.local/share/codex/.stage.XXXXXX")" || [ -z "$staging" ]; then
+    log "WARNING: failed to create a staging dir for the codex install."; rm -rf "$tmp"; return 1
+  fi
+  if ! tar -xzf "$tmp/codex.tar.gz" -C "$staging" 2>>"$LOG"; then
+    log "WARNING: failed to extract the codex tarball (see ${LOG})."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  if [ ! -x "$staging/bin/codex" ]; then
+    log "WARNING: codex tarball had no bin/codex after extract — refusing to install."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  dest="${HOME}/.local/share/codex/${CODEX_PIN}"
+  rm -rf "$dest"
+  if ! mv "$staging" "$dest" 2>>"$LOG"; then
+    log "WARNING: failed to move codex into ${dest} (see ${LOG})."; rm -rf "$tmp" "$staging"; return 1
+  fi
+  rm -rf "$tmp"
+  if ! ln -sf "$dest/bin/codex" "${HOME}/.local/bin/codex" 2>>"$LOG"; then
+    log "WARNING: failed to symlink codex onto ${HOME}/.local/bin (see ${LOG})."; return 1
+  fi
+  # Honest final signal: confirm the PINNED version is what now resolves on PATH,
+  # rather than trusting whatever codex PATH happens to find.
+  codex_is_pinned
+}
+
+# Seed $CODEX_HOME/auth.json from a pre-obtained ChatGPT-OAuth credential blob.
+#
+# This is the headless path for a *personal* ChatGPT plan (Plus/Pro/Team), which
+# CANNOT mint the enterprise agent-identity JWT that `--with-access-token` requires
+# (see ensure_codex_auth). Instead the user runs `codex login` once on a trusted
+# machine with a browser — configuring `cli_auth_credentials_store = "file"` in
+# ~/.codex/config.toml so codex writes the credential to disk rather than the OS
+# keychain — and injects the ENTIRE resulting ~/.codex/auth.json as the secret
+# CODEX_AUTH_JSON. We write it back verbatim, so the on-disk shape always matches
+# the codex version that produced it. The long-lived refresh_token then lets codex
+# refresh the short-lived access_token in place during the session.
+#
+# Idempotent and non-destructive: writes only when no auth.json exists yet, so a
+# token codex already refreshed THIS session is never clobbered. printf + umask 077
+# keep the secret off argv and off a group/other-readable file. Quiet no-op when
+# CODEX_AUTH_JSON is unset (returns 1 so the caller can fall back to the token path).
+seed_codex_auth_json() {
+  [ -n "${CODEX_AUTH_JSON:-}" ] || return 1
+  if ! command -v codex >/dev/null 2>&1; then
+    log "WARNING: CODEX_AUTH_JSON is set but the codex CLI is not on PATH — skipping."
+    return 1
+  fi
+  local codex_home auth
+  codex_home="${CODEX_HOME:-${HOME}/.codex}"
+  auth="${codex_home}/auth.json"
+  # Already present (a resume, or codex refreshed it this session) => trust it and
+  # do not overwrite a possibly-refreshed file with the original secret.
+  if [ -f "$auth" ]; then
+    log "Codex auth.json already present — leaving it untouched."
+    return 0
+  fi
+  if ! mkdir -p "$codex_home" 2>>"$LOG"; then
+    log "WARNING: could not create ${codex_home} for the codex auth.json (see ${LOG})."; return 1
+  fi
+  # Subshell umask so the secret file is created 0600 from the outset (never a
+  # group/other-readable window); printf keeps the blob off argv.
+  if ! ( umask 077; printf '%s' "$CODEX_AUTH_JSON" > "$auth" ) 2>>"$LOG"; then
+    log "WARNING: failed to write ${auth} from CODEX_AUTH_JSON (see ${LOG})."; return 1
+  fi
+  chmod 600 "$auth" 2>>"$LOG" || true
+  # Honest signal: confirm codex actually accepts the seeded credentials, rather
+  # than trusting that a written file means a working login. Probe with
+  # CODEX_ACCESS_TOKEN unset so it reflects ONLY auth.json (mirrors ensure_codex_auth).
+  if ( unset CODEX_ACCESS_TOKEN; codex login status ) >>"$LOG" 2>&1; then
+    log "Seeded codex auth.json from CODEX_AUTH_JSON (authenticated)."
+    return 0
+  fi
+  log "WARNING: seeded auth.json but 'codex login status' still reports unauthenticated — re-capture CODEX_AUTH_JSON from a fresh local 'codex login' (see ${LOG})."
+  return 1
+}
+
+# Drop CODEX_ACCESS_TOKEN on BOTH fronts so a value codex can't use as a JWT never
+# reaches it: (1) `unset` it in THIS process, and (2) persist `unset CODEX_ACCESS_TOKEN`
+# to CLAUDE_ENV_FILE so later Bash tool shells inherit the unset too. Codex reads
+# CODEX_ACCESS_TOKEN from the live env at runtime and parses it AS a JWT, so leaving a
+# blank/whitespace or auth.json-blob value in place makes every later `codex exec` fail
+# even when a valid auth.json is on disk. $1 is a short reason for the log line.
+drop_codex_access_token() {
+  local reason="$1"
+  if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qF 'unset CODEX_ACCESS_TOKEN' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    if echo 'unset CODEX_ACCESS_TOKEN' >> "$CLAUDE_ENV_FILE" 2>>"$LOG"; then
+      log "Unset CODEX_ACCESS_TOKEN for the session (${reason})."
+    else
+      log "WARNING: could not append 'unset CODEX_ACCESS_TOKEN' to CLAUDE_ENV_FILE — later codex calls may still see it (see ${LOG})."
+    fi
+  fi
+  unset CODEX_ACCESS_TOKEN
+}
+
+# Authenticate the Codex CLI non-interactively from an env-injected OAuth token.
+#
+# The web container is fresh each session and ~/.codex is not persisted, so the
+# interactive browser login cannot be used. Codex stores credentials in
+# $CODEX_HOME/auth.json (default ~/.codex/auth.json); the supported headless path
+# is `codex login --with-access-token`, which reads the token from STDIN. We pipe
+# it in via printf so the secret never appears on a command line (argv is visible
+# to other processes via `ps`/\proc) and never lands in CLAUDE_ENV_FILE.
+#
+# CODEX_ACCESS_TOKEN must be a Codex **agent identity JWT** — the only thing
+# `--with-access-token` accepts. A ChatGPT *user* OAuth access token or an
+# OPENAI_API_KEY is rejected on this path.
+#
+# Tolerated convenience case: if CODEX_ACCESS_TOKEN actually holds a full auth.json
+# blob (leading '{') rather than a JWT, we route it to seed_codex_auth_json and
+# unset the env var for the session, so a ChatGPT-OAuth blob works regardless of
+# which secret slot it landed in (CODEX_AUTH_JSON is still the canonical name).
+#
+# Non-fatal and idempotent: absent token => quiet no-op; already-authenticated
+# (e.g. a resume) => skip the re-login.
+ensure_codex_auth() {
+  # No token => nothing to do. Stay TRULY silent here: SessionStart stdout is
+  # injected into the model context and this is the common case.
+  if [ -z "${CODEX_ACCESS_TOKEN:-}" ]; then
+    return 0
+  fi
+  # A CODEX_ACCESS_TOKEN with surrounding whitespace passes the -z guard above but
+  # is unusable as-is: a JWT never contains leading/trailing whitespace, yet a
+  # secret injected from a file commonly carries a stray trailing newline (and a
+  # slot may hold only spaces). Trim BOTH ends once — reused by the blank check,
+  # the auth.json-blob detection, AND the login below — so an otherwise-valid
+  # token isn't piped verbatim to `codex login --with-access-token` and rejected
+  # as a malformed JWT (which emits a misleading "must be an agent identity JWT"
+  # warning). If nothing remains, surface a clear "blank" diagnostic instead.
+  local _codex_tok_trimmed="${CODEX_ACCESS_TOKEN#"${CODEX_ACCESS_TOKEN%%[![:space:]]*}"}"
+  _codex_tok_trimmed="${_codex_tok_trimmed%"${_codex_tok_trimmed##*[![:space:]]}"}"
+  if [ -z "$_codex_tok_trimmed" ]; then
+    log "WARNING: CODEX_ACCESS_TOKEN is set but contains only whitespace — treating as unset (no codex login)."
+    # "treating as unset" must be literal: codex reads CODEX_ACCESS_TOKEN at runtime
+    # and would still parse the whitespace as a (malformed) JWT, so drop it for real.
+    drop_codex_access_token "it contains only whitespace"
+    return 1
+  fi
+  if ! command -v codex >/dev/null 2>&1; then
+    log "WARNING: CODEX_ACCESS_TOKEN is set but the codex CLI is not on PATH — skipping."
+    return 1
+  fi
+  # A full auth.json blob — not a JWT — is sometimes injected into CODEX_ACCESS_TOKEN
+  # (e.g. to reuse a single GH_TOKEN-style secret slot for a personal ChatGPT-OAuth
+  # credential). `--with-access-token` would reject it as a malformed JWT, so detect
+  # the JSON shape (a leading '{' after optional whitespace) and route it to the
+  # auth.json seeding path instead. Drop CODEX_ACCESS_TOKEN first (see
+  # drop_codex_access_token) so codex doesn't parse the blob as a JWT at runtime; it
+  # then falls back to ~/.codex/auth.json.
+  # (_codex_tok_trimmed is the leading-trimmed token computed above.)
+  if [ "${_codex_tok_trimmed:0:1}" = '{' ]; then
+    local _codex_blob="$CODEX_ACCESS_TOKEN"
+    drop_codex_access_token "it holds an auth.json blob, not a JWT"
+    CODEX_AUTH_JSON="$_codex_blob" seed_codex_auth_json
+    return $?
+  fi
+  # Idempotent: skip the re-login when a prior run THIS session already persisted
+  # auth.json. The probe runs with CODEX_ACCESS_TOKEN unset so it reflects ONLY
+  # saved credentials.
+  if ( unset CODEX_ACCESS_TOKEN; codex login status ) >>"$LOG" 2>&1; then
+    log "Codex already authenticated — skipping login."
+    return 0
+  fi
+  # printf (no trailing newline) keeps the token off argv; codex reads it on stdin.
+  # Pipe the whitespace-trimmed token: a stray leading/trailing newline would make
+  # codex reject an otherwise-valid JWT (see _codex_tok_trimmed above).
+  if printf '%s' "$_codex_tok_trimmed" | codex login --with-access-token >>"$LOG" 2>&1; then
+    log "Codex authenticated via access token."
+    # The trimmed value only fixed THIS login. If the raw env var carried
+    # surrounding whitespace, the value still visible to later Bash tool shells is
+    # a MALFORMED JWT — codex reads live CODEX_ACCESS_TOKEN before ~/.codex/auth.json,
+    # so every later `codex exec` would fail despite the auth.json this login just
+    # wrote. Drop the raw value (codex then falls back to auth.json). A clean token
+    # (raw == trimmed) is left in place so the normal direct-token path keeps working.
+    if [ "$CODEX_ACCESS_TOKEN" != "$_codex_tok_trimmed" ]; then
+      drop_codex_access_token "it carried surrounding whitespace (a malformed JWT for later codex calls)"
+    fi
+    return 0
+  fi
+  log "WARNING: 'codex login --with-access-token' failed — CODEX_ACCESS_TOKEN must be a Codex agent identity JWT, not a ChatGPT access token or API key (see ${LOG})."
+  return 1
+}
+
+# Turn OFF codex's own inner sandbox in $CODEX_HOME/config.toml. This whole hook
+# only runs when CLAUDE_CODE_REMOTE=true (main() is gated on it), i.e. inside the
+# isolated, ephemeral cloud container — which is ALREADY an external sandbox. So
+# codex re-sandboxing every model-run command is redundant; worse, the container
+# ships no bubblewrap on PATH, so each `codex exec` prints a "could not find
+# bubblewrap" warning. Setting sandbox_mode = "danger-full-access" (the value
+# codex documents for "environments that are externally sandboxed") disables the
+# inner sandbox and silences that warning.
+#
+# Non-destructive + idempotent: leave config.toml untouched if the user has
+# already made a deliberate sandbox/permissions choice (a top-level sandbox_mode
+# key, a top-level default_permissions key, or any [permissions.*] table).
+# "Top-level" matters: a key buried inside a [table] is an unrelated setting, so
+# the guard inspects ONLY the region before the first [table] header. Otherwise
+# inject the key — PREPEND it when a config already exists (a bare top-level key
+# must precede any [table] header), or create it fresh. Failure is non-fatal.
+configure_codex_sandbox() {
+  local codex_home config
+  codex_home="${CODEX_HOME:-${HOME}/.codex}"
+  config="${codex_home}/config.toml"
+
+  if [ -f "$config" ]; then
+    local toplevel
+    toplevel="$(awk '/^[[:space:]]*\[/{exit} {print}' "$config" 2>>"$LOG")"
+
+    if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*sandbox_mode[[:space:]]*='; then
+      log "Codex sandbox_mode already set in config.toml — leaving it untouched."
+      return 0
+    fi
+
+    # `[].]` is a valid two-member bracket class {']', '.'} — a `]` immediately
+    # after `[` is literal in POSIX ERE — so this matches a `[permissions]` table
+    # header or any `[permissions.<sub>]` subtable, and nothing else.
+    if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*default_permissions[[:space:]]*=' \
+        || grep -Eq '^[[:space:]]*\[permissions[].]' "$config"; then
+      log "Codex permission profile already configured — leaving config.toml untouched."
+      return 0
+    fi
+  fi
+
+  if ! mkdir -p "$codex_home" 2>>"$LOG"; then
+    log "WARNING: could not create ${codex_home} for the codex config (see ${LOG})."
+    return 1
+  fi
+
+  if [ -f "$config" ]; then
+    local tmp
+    if ! tmp="$(mktemp "${config}.XXXXXX")" || [ -z "$tmp" ]; then
+      log "WARNING: could not stage a temp file to update the codex config (see ${LOG})."
+      return 1
+    fi
+    if { printf 'sandbox_mode = "danger-full-access"\n'; cat "$config"; } >"$tmp" 2>>"$LOG" \
+        && mv "$tmp" "$config" 2>>"$LOG"; then
+      log "Disabled codex inner sandbox (sandbox_mode=danger-full-access) — the runner is already sandboxed."
+      return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    log "WARNING: failed to update ${config} with sandbox_mode (see ${LOG})."
+    return 1
+  fi
+
+  if ( umask 022; printf 'sandbox_mode = "danger-full-access"\n' >"$config" ) 2>>"$LOG"; then
+    log "Disabled codex inner sandbox (sandbox_mode=danger-full-access) — the runner is already sandboxed."
+    return 0
+  fi
+  log "WARNING: failed to write ${config} with sandbox_mode (see ${LOG})."
+  return 1
+}
+
+# Persist a directory on PATH for subsequent Claude Bash tool commands. SessionStart
+# hooks persist env for later commands by appending `export` lines to the file at
+# $CLAUDE_ENV_FILE (which subsequent Bash commands source). Idempotent via a grep
+# guard so re-runs do not duplicate the line. No-op when CLAUDE_ENV_FILE is unset.
+persist_path() {
+  local dir="$1" line
+  [ -n "${CLAUDE_ENV_FILE:-}" ] || return 0
+  # shellcheck disable=SC2016  # literal $PATH intended — expanded when sourced later
+  line="export PATH=\"${dir}:\$PATH\""
+  # Idempotent on the EXACT line (grep -qxF), not a substring: an unusual dir
+  # cannot false-match another entry and skip a needed export. printf avoids
+  # echo's backslash/-flag surprises.
+  if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE"
+    log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+  fi
+}
+
+# Imperative body. Wrapped in main() so the script is *sourceable* for unit
+# tests: executing it (the SessionStart hook runs it by direct exec) runs main;
+# sourcing it (the test harness) only defines the functions/globals above so they
+# can be exercised against stubbed external tools. SUDO/LOG/PROJECT_DIR and the
+# CLAUDE_CODE_REMOTE gate live in here so sourcing never touches the environment.
+main() {
+  # Only run inside Claude Code on the web. Locally this is a fast no-op so the
+  # same committed hook is safe for every contributor.
+  if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+  fi
+
+  # SUDO is intentionally exposed as a global for the sourced project hook
+  # (web-bootstrap.local.sh) to use when starting daemons (e.g. dockerd).
+  SUDO=''
+  # -n (non-interactive): a SessionStart hook has no TTY, so a sudo that needs a
+  # password must fail fast rather than block the session waiting on input.
+  # shellcheck disable=SC2034  # consumed by the sourced project hook, not this file
+  [ "$(id -u)" -eq 0 ] || SUDO='sudo -n'
+
+  # Verbose output sink (keeps the model's context clean — see header). Created
+  # 0600 via a subshell umask so the log (which may capture command output) is
+  # not world-readable from the outset.
+  LOG="${TMPDIR:-/tmp}/rdl-web-bootstrap.log"
+  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+
+  # Resolve the repo root. The hook exports CLAUDE_PROJECT_DIR; fall back to the
+  # script's own location so it also works when run by hand.
+  PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+  # --- 1. provisioning self-heal (plugin pre-seed) ----------------------------
+  # Normally already done ONCE by the environment setup script (`make
+  # cc-web-setup`) before the snapshot, which is what makes plugin skills available
+  # this session. Re-running is idempotent, so this self-heals environments whose
+  # setup script does not run it — though on that path plugin skills only surface
+  # next session.
+  if [ -f "${PROJECT_DIR}/scripts/cc-web-setup.sh" ]; then
+    bash "${PROJECT_DIR}/scripts/cc-web-setup.sh" \
+      || log "WARNING: cc-web-setup reported errors (see ${TMPDIR:-/tmp}/rdl-cc-web-setup.log)."
+  fi
+
+  # --- 2. GitHub CLI + token (every session) ----------------------------------
+  # Provision gh so PR/CI automation can run from the cloud session, and report
+  # whether the environment injected a GitHub token. gh reads GH_TOKEN (or
+  # GITHUB_TOKEN) straight from the env — no `gh auth login` — so we just verify it
+  # resolves. The install is idempotent, so after the first session this is cheap.
+  if ensure_gh; then
+    log "gh CLI ready ($(gh --version 2>/dev/null | head -1))."
+    persist_path "${HOME}/.local/bin"
+    if [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]; then
+      if gh auth status >>"$LOG" 2>&1; then
+        log "GitHub token present — gh is authenticated."
+      else
+        log "GitHub token present but 'gh auth status' did not confirm auth (see ${LOG})."
+      fi
+    else
+      log "WARNING: no GH_TOKEN/GITHUB_TOKEN in env — gh API calls will be unauthenticated/rate-limited."
+    fi
+  else
+    log "WARNING: gh CLI not available (install failed — see ${LOG})."
+  fi
+
+  # --- 3. Codex CLI install + auth (every session; quiet no-op without creds) --
+  # Install the Codex CLI and authenticate it so `codex exec` works headlessly.
+  # Two supported credential inputs, in priority order:
+  #   * CODEX_AUTH_JSON   — the full contents of a ~/.codex/auth.json captured from
+  #                         a local `codex login` (ChatGPT OAuth). See seed_codex_auth_json.
+  #   * CODEX_ACCESS_TOKEN — a Codex *agent identity JWT* for `--with-access-token`.
+  #                         As a convenience this slot also accepts a full auth.json
+  #                         blob (leading '{'), which is then seeded and unset.
+  # Either one is the signal that codex is wanted here; with neither we skip the
+  # (non-trivial) download too, keeping the committed hook a quiet no-op for
+  # contributors who do not use Codex.
+  if [ -n "${CODEX_AUTH_JSON:-}" ] || [ -n "${CODEX_ACCESS_TOKEN:-}" ]; then
+    if ensure_codex_cli; then
+      log "Codex CLI ready ($(codex --version 2>/dev/null | head -1))."
+      persist_path "${HOME}/.local/bin"
+      # Disable codex's inner sandbox: the runner is already an external sandbox.
+      configure_codex_sandbox || true
+      # Auth: prefer a pre-obtained auth.json blob (ChatGPT OAuth, personal plans);
+      # fall back to the agent-identity token login (enterprise). Both idempotent.
+      seed_codex_auth_json || ensure_codex_auth || true
+    else
+      log "WARNING: codex CLI install failed — 'codex exec' will be unavailable (see ${LOG})."
+    fi
+  fi
+
+  # --- 4. SOURCE PROJECT HOOK (optional, project-specific) --------------------
+  # The portable engine above carries no project dependencies. Repo-specific glue
+  # — language toolchains on PATH, container runtimes, git-hook wiring (.husky /
+  # .githooks / lefthook), fetching the default branch for merge-base checks, etc.
+  # — belongs in scripts/web-bootstrap.local.sh, sourced here if present. A subshell
+  # inherits main()'s helpers and globals (log, $LOG, $PROJECT_DIR, $SUDO,
+  # $CLAUDE_ENV_FILE, persist_path), so its file/system side effects persist.
+  #
+  # SECURITY/ISOLATION: web-bootstrap.local.sh is trusted, repo-owned code — the
+  # same trust level as this committed hook. Running it in a SUBSHELL keeps a stray
+  # `exit` (or `exit 1`) from breaking this hook's "always exit 0" discipline and
+  # stops its variable edits from leaking back; it does NOT sandbox the code (a
+  # project hook legitimately needs the session's git/gh credentials). Signal a
+  # soft failure with a non-zero exit/return — it is logged, never fatal.
+  local local_hook="${PROJECT_DIR}/scripts/web-bootstrap.local.sh"
+  if [ -f "$local_hook" ]; then
+    log "Running project bootstrap hook (web-bootstrap.local.sh)…"
+    # shellcheck source=/dev/null
+    ( source "$local_hook" ) || log "WARNING: project bootstrap hook reported errors (see ${LOG})."
+  fi
+
+  log "Session bootstrap complete."
+  exit 0
+}
+
+# Run the imperative body only when executed, not when sourced. The hook is
+# invoked by direct exec ("$CLAUDE_PROJECT_DIR"/scripts/web-bootstrap.sh from the
+# SessionStart hook), so BASH_SOURCE[0] == $0 holds for the real run and the test
+# harness (which sources this file) skips main and just exercises the functions.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/skills/cc-web-setup/assets/web-bootstrap.sh
+++ b/skills/cc-web-setup/assets/web-bootstrap.sh
@@ -397,7 +397,7 @@ configure_codex_sandbox() {
     # after `[` is literal in POSIX ERE — so this matches a `[permissions]` table
     # header or any `[permissions.<sub>]` subtable, and nothing else.
     if printf '%s\n' "$toplevel" | grep -Eq '^[[:space:]]*default_permissions[[:space:]]*=' \
-        || grep -Eq '^[[:space:]]*\[permissions[].]' "$config"; then
+        || grep -Eq '^[[:space:]]*\[permissions([.][^]]+)?\][[:space:]]*$' "$config"; then
       log "Codex permission profile already configured — leaving config.toml untouched."
       return 0
     fi

--- a/skills/cc-web-setup/assets/web-bootstrap.sh
+++ b/skills/cc-web-setup/assets/web-bootstrap.sh
@@ -445,8 +445,15 @@ persist_path() {
   # cannot false-match another entry and skip a needed export. printf avoids
   # echo's backslash/-flag surprises.
   if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
-    printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE"
-    log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+    # Check the append: an unwritable CLAUDE_ENV_FILE would otherwise leave later
+    # Bash shells without ${dir} on PATH while we falsely log success. LOG may be
+    # unset here (persist_path runs outside main() in tests), so guard the stderr
+    # redirect with ${LOG:-/dev/null} to stay safe under `set -u`.
+    if printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE" 2>>"${LOG:-/dev/null}"; then
+      log "Persisted ${dir} on PATH via CLAUDE_ENV_FILE."
+    else
+      log "WARNING: could not append PATH export for ${dir} to CLAUDE_ENV_FILE — later Bash shells will not see ${dir} on PATH."
+    fi
   fi
 }
 
@@ -531,7 +538,17 @@ main() {
       configure_codex_sandbox || true
       # Auth: prefer a pre-obtained auth.json blob (ChatGPT OAuth, personal plans);
       # fall back to the agent-identity token login (enterprise). Both idempotent.
-      seed_codex_auth_json || ensure_codex_auth || true
+      if seed_codex_auth_json; then
+        # auth.json is now the credential of record (freshly seeded OR already present
+        # on a resume). codex reads CODEX_ACCESS_TOKEN BEFORE ~/.codex/auth.json, so a
+        # leftover raw token would shadow the valid auth.json and break later
+        # `codex exec`. ensure_codex_auth (the only caller of drop_codex_access_token)
+        # never runs on this arm, so drop a stale token here ourselves.
+        [ -n "${CODEX_ACCESS_TOKEN:-}" ] \
+          && drop_codex_access_token "auth.json seeded; raw token would shadow it for later codex exec"
+      else
+        ensure_codex_auth || true
+      fi
     else
       log "WARNING: codex CLI install failed — 'codex exec' will be unavailable (see ${LOG})."
     fi

--- a/skills/cc-web-setup/scripts/test-cc-web-setup.sh
+++ b/skills/cc-web-setup/scripts/test-cc-web-setup.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# scripts/test-cc-web-setup.sh
+# Tests for assets/cc-web-setup.sh (the portable pre-snapshot setup script shipped
+# by the cc-web-setup skill).
+#
+# The plugin pre-seed runs against a stubbed `claude` CLI that records every
+# subcommand it sees, so the tests assert WHICH marketplaces/plugins are seeded
+# (defaults + CC_WEB_* overrides), the no-claude path, and that the optional
+# project hook (cc-web-setup.local.sh) is sourced. Run via the harness or by hand.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../assets/cc-web-setup.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS  $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL  $*"; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cc-web-setup-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# A `claude` stub that appends every invocation's args to $CLAUDE_LOG. The path is
+# passed via env so the same stub works across scenarios.
+make_claude_stub() { # <dir>
+  local dir="$1"
+  cat >"$dir/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAUDE_LOG"
+exit 0
+EOF
+  chmod +x "$dir/claude"
+}
+
+# Like make_claude_stub, but the plugin install AND update both fail (marketplace
+# registration still succeeds), so the pre-seed cannot recover — exercises the
+# documented non-zero exit on a real provisioning failure.
+make_claude_stub_failing() { # <dir>
+  local dir="$1"
+  cat >"$dir/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CLAUDE_LOG"
+case "$*" in
+  *"plugin install"*|*"plugin update"*) exit 1 ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$dir/claude"
+}
+
+new_bin() { # build a PATH dir with coreutils + optional claude
+  local d tool real; d="$(mktemp -d "$WORK/bin.XXXXXX")"
+  for tool in bash printf cat rm mkdir dirname grep head touch; do
+    real="$(command -v "$tool" 2>/dev/null || true)"; [ -n "$real" ] && ln -s "$real" "$d/$tool"
+  done
+  echo "$d"
+}
+
+# run_setup <bin_dir> <project_dir> <out> [env assignments...] — execute the REAL
+# script as a subprocess (so main() runs) with an isolated PATH/PROJECT_DIR.
+run_setup() {
+  local bin="$1" proj="$2" out="$3"; shift 3
+  # shellcheck disable=SC2163  # "$@" holds KEY=val assignments to export, intentional
+  ( export PATH="$bin" CLAUDE_PROJECT_DIR="$proj" TMPDIR="$WORK" "$@"; bash "$SCRIPT" ) >"$out" 2>&1
+}
+
+# --- Test 1: defaults -> seeds rdl marketplace + rdl@rdl ---------------------
+test_defaults() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p1.XXXXXX")"; out="$WORK/t1.out"
+  make_claude_stub "$bin"; clog="$WORK/t1-claude.log"; : > "$clog"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" && ok "defaults: exit 0" || fail "defaults: non-zero exit"
+  grep -q 'plugin marketplace add nq-rdl/agent-extensions' "$clog" \
+    && ok "defaults: registered the rdl marketplace (nq-rdl/agent-extensions)" \
+    || fail "defaults: did not register rdl marketplace. Log: $(cat "$clog")"
+  grep -q 'plugin install rdl@rdl --scope project' "$clog" \
+    && ok "defaults: pre-seeded rdl@rdl" \
+    || fail "defaults: did not pre-seed rdl@rdl. Log: $(cat "$clog")"
+}
+
+# --- Test 2: CC_WEB_* overrides honored --------------------------------------
+test_overrides() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p2.XXXXXX")"; out="$WORK/t2.out"
+  make_claude_stub "$bin"; clog="$WORK/t2-claude.log"; : > "$clog"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" \
+    "CC_WEB_MARKETPLACES=acme/plugins|acme" "CC_WEB_PLUGINS=foo@acme bar@acme" \
+    && ok "overrides: exit 0" || fail "overrides: non-zero exit"
+  grep -q 'plugin marketplace add acme/plugins' "$clog" \
+    && ok "overrides: registered the overridden marketplace" \
+    || fail "overrides: override marketplace not used. Log: $(cat "$clog")"
+  grep -q 'plugin install foo@acme --scope project' "$clog" && grep -q 'plugin install bar@acme --scope project' "$clog" \
+    && ok "overrides: pre-seeded both overridden plugins" \
+    || fail "overrides: override plugins not used. Log: $(cat "$clog")"
+  grep -q 'rdl@rdl' "$clog" \
+    && fail "overrides: still seeded the default rdl@rdl (override ignored)" \
+    || ok "overrides: defaults were replaced, not appended"
+}
+
+# --- Test 3: no claude on PATH -> skip pre-seed, still exit 0 -----------------
+test_no_claude() {
+  local bin proj out; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p3.XXXXXX")"; out="$WORK/t3.out"
+  # No claude stub on this PATH.
+  run_setup "$bin" "$proj" "$out" && ok "no-claude: exit 0" || fail "no-claude: non-zero exit"
+  grep -q 'claude CLI not on PATH' "$out" \
+    && ok "no-claude: logged the skip" \
+    || fail "no-claude: did not log the skip. Out: $(cat "$out")"
+}
+
+# --- Test 4: project hook sourced --------------------------------------------
+test_local_hook() {
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p4.XXXXXX")"; out="$WORK/t4.out"
+  make_claude_stub "$bin"; clog="$WORK/t4-claude.log"; : > "$clog"
+  mkdir -p "$proj/scripts"
+  printf 'touch "%s/t4-sentinel"\n' "$WORK" > "$proj/scripts/cc-web-setup.local.sh"
+  rm -f "$WORK/t4-sentinel"
+  run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog" >/dev/null \
+    && ok "local-hook: exit 0 when project hook succeeds" \
+    || fail "local-hook: non-zero exit. Out: $(cat "$out")"
+  [ -e "$WORK/t4-sentinel" ] \
+    && ok "local-hook: cc-web-setup.local.sh was sourced" \
+    || fail "local-hook: project hook not sourced. Out: $(cat "$out")"
+}
+
+# --- Test 6: plugin pre-seed failure -> non-zero exit ------------------------
+test_plugin_failure_rc() {
+  # The exit-status contract: a plugin that can neither install nor update is a
+  # provisioning failure and must produce a non-zero exit (not a silent rc=0).
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p6.XXXXXX")"; out="$WORK/t6.out"
+  make_claude_stub_failing "$bin"; clog="$WORK/t6-claude.log"; : > "$clog"
+  if run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog"; then
+    fail "plugin-fail: expected non-zero exit when pre-seed fails. Out: $(cat "$out")"
+  else
+    ok "plugin-fail: non-zero exit when a plugin can neither install nor update"
+  fi
+  grep -q 'Provisioning finished with errors' "$out" \
+    && ok "plugin-fail: surfaced the provisioning failure in the epilogue" \
+    || fail "plugin-fail: did not log the failure. Out: $(cat "$out")"
+}
+
+# --- Test 7: a project hook that exits is contained by the subshell ----------
+test_local_hook_exit_contained() {
+  # `( source "$local_hook" )` must isolate a stray `exit` so it cannot abort
+  # main() at the source line: rc becomes 1 and the epilogue still runs.
+  local bin proj out clog; bin="$(new_bin)"; proj="$(mktemp -d "$WORK/p7.XXXXXX")"; out="$WORK/t7.out"
+  make_claude_stub "$bin"; clog="$WORK/t7-claude.log"; : > "$clog"
+  mkdir -p "$proj/scripts"
+  printf 'touch "%s/t7-before"\nexit 1\n' "$WORK" > "$proj/scripts/cc-web-setup.local.sh"
+  rm -f "$WORK/t7-before"
+  if run_setup "$bin" "$proj" "$out" "CLAUDE_LOG=$clog"; then
+    fail "exit-contained: expected non-zero exit (hook failed). Out: $(cat "$out")"
+  else
+    ok "exit-contained: hook's non-zero exit propagates to rc"
+  fi
+  [ -e "$WORK/t7-before" ] \
+    && ok "exit-contained: the hook actually ran" \
+    || fail "exit-contained: hook did not run at all. Out: $(cat "$out")"
+  grep -q 'Provisioning finished with errors' "$out" \
+    && ok "exit-contained: main() ran its epilogue (the exit did not escape the subshell)" \
+    || fail "exit-contained: epilogue missing — exit escaped the subshell. Out: $(cat "$out")"
+}
+
+# --- Test 5: sourceable (main-guard) -----------------------------------------
+test_sourceable() {
+  # Sourcing must NOT run main(): define globals only. Assert MARKETPLACES exists
+  # and main() did not exit the shell.
+  # shellcheck disable=SC1090
+  ( set +e; source "$SCRIPT"; [ "${MARKETPLACES[0]}" = "nq-rdl/agent-extensions|rdl" ] ) \
+    && ok "sourceable: source defines globals without running main()" \
+    || fail "sourceable: sourcing did not behave (main ran or globals missing)"
+}
+
+test_defaults
+test_overrides
+test_no_claude
+test_local_hook
+test_plugin_failure_rc
+test_local_hook_exit_contained
+test_sourceable
+
+echo ""
+echo "cc-web-setup: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/skills/cc-web-setup/scripts/test-web-bootstrap.sh
+++ b/skills/cc-web-setup/scripts/test-web-bootstrap.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# scripts/test-web-bootstrap.sh
+# Unit + integration tests for assets/web-bootstrap.sh (the portable SessionStart
+# hook shipped by the cc-web-setup skill).
+#
+# web-bootstrap.sh is sourceable (its imperative body is guarded by
+# `[ "${BASH_SOURCE[0]}" = "${0}" ]`), so this harness sources it to get the REAL
+# ensure_gh / codex functions / persist_path and exercises them against a fake
+# PATH of stub executables — the only things stubbed are the external I/O boundary
+# (gh/codex/curl/tar/sha256sum/uname). No network. The CLAUDE_CODE_REMOTE gate and
+# the *.local.sh seam are covered by running the script as a subprocess.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../assets/web-bootstrap.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS  $*"; }
+fail() { FAIL=$((FAIL+1)); echo "  FAIL  $*"; }
+
+# Source the script under test. With the main-guard in place, sourcing only
+# defines the functions and never runs the hook body (side-effect free).
+# shellcheck source=../assets/web-bootstrap.sh
+source "$SCRIPT"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/web-bootstrap-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Coreutils the functions legitimately use (not the stubbed I/O boundary).
+COREUTILS="bash mkdir mktemp find head rm install env cat dirname grep ln tail touch mv chmod printf awk sed id"
+
+new_stub_dir() {
+  local d tool real
+  d="$(mktemp -d "$WORK/path.XXXXXX")"
+  for tool in $COREUTILS; do
+    real="$(command -v "$tool" 2>/dev/null || true)"
+    [ -n "$real" ] && ln -s "$real" "$d/$tool"
+  done
+  echo "$d"
+}
+
+write_stub() {
+  local dir="$1" name="$2" body="$3"
+  # new_stub_dir() pre-populates the dir with symlinks to the real coreutils
+  # (e.g. `id`). Without removing it first, the `>` redirect would FOLLOW such a
+  # symlink and try to overwrite the real system binary (clobbering it, or
+  # failing with EACCES) instead of replacing the link with our stub. Drop any
+  # existing entry so the stub always lands in the temp dir.
+  rm -f "$dir/$name"
+  printf '#!/usr/bin/env bash\n%s\n' "$body" >"$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+run_in_subshell() { # <stub_dir> <out_file> <home> <fn>
+  local stub_dir="$1" out_file="$2" home="$3" fn="$4"
+  # shellcheck disable=SC2030,SC2031
+  (
+    export HOME="$home" PATH="$stub_dir" TMPDIR="$WORK"
+    LOG="$out_file"
+    "$fn"
+  ) >>"$out_file" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# ensure_gh()
+# ---------------------------------------------------------------------------
+run_ensure_gh() {
+  local stub_dir="$1" out_file="$2" home="${3:-}"
+  [ -n "$home" ] || home="$(mktemp -d "$WORK/home.XXXXXX")"
+  run_in_subshell "$stub_dir" "$out_file" "$home" ensure_gh
+}
+
+test_gh_pin_match() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g1.log"
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" curl "touch '$WORK/g1-download'; exit 1"
+  rm -f "$WORK/g1-download"
+  run_ensure_gh "$d" "$log" && ok "gh pin match: returns 0 (idempotent)" \
+    || fail "gh pin match: returned non-zero for a pinned gh"
+  [ -e "$WORK/g1-download" ] && fail "gh pin match: attempted a download" \
+    || ok "gh pin match: did NOT attempt a download"
+}
+
+test_gh_pin_mismatch() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g2.log"
+  write_stub "$d" gh "echo 'gh version 2.40.0 (2024-01-01)'"
+  write_stub "$d" curl "exit 1"
+  write_stub "$d" uname "echo x86_64"
+  run_ensure_gh "$d" "$log" && fail "gh pin mismatch: accepted a wrong-version gh" \
+    || ok "gh pin mismatch: rejected wrong-version gh and failed the install"
+}
+
+test_gh_missing_sha256sum() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/g3.log"
+  # shellcheck disable=SC2016
+  write_stub "$d" curl 'while [ $# -gt 0 ]; do [ "$1" = "-o" ] && { out="$2"; shift; }; shift; done; printf dummy >"$out"'
+  write_stub "$d" uname "echo x86_64"
+  write_stub "$d" tar "exit 0"
+  # No sha256sum stub on this PATH; remove the symlinked real one too.
+  rm -f "$d/sha256sum"
+  run_ensure_gh "$d" "$log" && fail "gh missing-sha: returned 0 with no sha256sum" \
+    || ok "gh missing-sha: returned non-zero"
+  grep -q 'sha256sum not found' "$log" 2>/dev/null \
+    && ok "gh missing-sha: attributed to the missing tool" \
+    || fail "gh missing-sha: cause not named. Log: $(cat "$log" 2>/dev/null)"
+}
+
+# ---------------------------------------------------------------------------
+# codex auth + sandbox
+# ---------------------------------------------------------------------------
+run_ensure_codex_auth() {
+  local stub_dir="$1" out_file="$2" token="${3-}"
+  # shellcheck disable=SC2030,SC2031
+  (
+    export PATH="$stub_dir" TMPDIR="$WORK"
+    if [ "$#" -ge 3 ]; then export CODEX_ACCESS_TOKEN="$token"; else unset CODEX_ACCESS_TOKEN; fi
+    LOG="$out_file"
+    ensure_codex_auth
+  ) >>"$out_file" 2>&1
+}
+
+test_codex_no_token() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c1.log"
+  write_stub "$d" codex "> '$WORK/c1-called'; exit 0"
+  rm -f "$WORK/c1-called"
+  run_ensure_codex_auth "$d" "$log" && ok "codex no-token: returns 0 (quiet no-op)" \
+    || fail "codex no-token: returned non-zero"
+  [ -e "$WORK/c1-called" ] && fail "codex no-token: codex was invoked" \
+    || ok "codex no-token: codex NOT invoked"
+}
+
+test_codex_missing_cli() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c2.log"
+  run_ensure_codex_auth "$d" "$log" "tok.tok.tok" \
+    && fail "codex missing-cli: returned 0 with no codex" \
+    || ok "codex missing-cli: returned non-zero"
+  grep -q 'not on PATH' "$log" 2>/dev/null && ok "codex missing-cli: names the missing CLI" \
+    || fail "codex missing-cli: cause not named"
+}
+
+test_codex_fresh_login() {
+  local d log; d="$(new_stub_dir)"; log="$WORK/c3.log"
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then printf "%s" "$*" > "'"$WORK"'/c3-argv"; cat > "'"$WORK"'/c3-stdin"; exit 0; fi
+     exit 1'
+  rm -f "$WORK/c3-argv" "$WORK/c3-stdin"
+  run_ensure_codex_auth "$d" "$log" "SECRET.JWT.VALUE" && ok "codex fresh-login: returns 0" \
+    || fail "codex fresh-login: returned non-zero"
+  [ "$(cat "$WORK/c3-stdin" 2>/dev/null)" = "SECRET.JWT.VALUE" ] \
+    && ok "codex fresh-login: token delivered on stdin" \
+    || fail "codex fresh-login: token not on stdin"
+  grep -q 'SECRET.JWT.VALUE' "$WORK/c3-argv" 2>/dev/null \
+    && fail "codex fresh-login: token LEAKED into argv" \
+    || ok "codex fresh-login: token never in argv"
+}
+
+test_codex_blank_token() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c4.log"; envf="$WORK/c4-envfile"; : > "$envf"
+  # codex stub drops a sentinel if it is ever invoked.
+  write_stub "$d" codex "> '$WORK/c4-called'; exit 0"
+  rm -f "$WORK/c4-called"
+  # A whitespace-only token is non-empty (passes the -z guard) but unusable: it
+  # must be diagnosed as blank, NOT piped to `codex login --with-access-token`.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "   " ) \
+    && fail "codex blank-token: returned 0 for a whitespace-only token" \
+    || ok "codex blank-token: returned non-zero"
+  grep -q 'only whitespace' "$log" 2>/dev/null \
+    && ok "codex blank-token: diagnosed as blank" \
+    || fail "codex blank-token: not diagnosed as blank. Log: $(cat "$log" 2>/dev/null)"
+  [ -e "$WORK/c4-called" ] && fail "codex blank-token: codex was invoked" \
+    || ok "codex blank-token: codex NOT invoked"
+  # "treating as unset" must be honored: the blank token has to be dropped from the
+  # session env (codex reads CODEX_ACCESS_TOKEN at runtime), so the unset is persisted.
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex blank-token: persisted unset to CLAUDE_ENV_FILE" \
+    || fail "codex blank-token: did not persist unset. File: $(cat "$envf" 2>/dev/null)"
+}
+
+test_codex_trims_token() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c5.log"; envf="$WORK/c5-envfile"; : > "$envf"
+  # codex stub: report "unauthenticated" so login runs, then capture the stdin the
+  # token is piped on.
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then cat > "'"$WORK"'/c5-stdin"; exit 0; fi
+     exit 1'
+  rm -f "$WORK/c5-stdin"
+  # A valid JWT wrapped in surrounding whitespace (e.g. a secret read from a file
+  # with a trailing newline). It must be trimmed before being piped to codex,
+  # otherwise codex rejects the otherwise-valid JWT as malformed.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "
+  SECRET.JWT.VALUE
+  " ) && ok "codex trim-token: returns 0" \
+    || fail "codex trim-token: returned non-zero"
+  [ "$(cat "$WORK/c5-stdin" 2>/dev/null)" = "SECRET.JWT.VALUE" ] \
+    && ok "codex trim-token: surrounding whitespace stripped before stdin" \
+    || fail "codex trim-token: token not trimmed. Got: [$(cat "$WORK/c5-stdin" 2>/dev/null)]"
+  # The RAW (whitespace-wrapped) value still in the live env is a malformed JWT for
+  # later `codex exec`, so after the trimmed login it must be dropped + persisted.
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex trim-token: dropped the raw whitespace token from the session env" \
+    || fail "codex trim-token: did not persist unset of the raw token. File: [$(cat "$envf" 2>/dev/null)]"
+}
+
+test_codex_clean_token_kept() {
+  local d log envf; d="$(new_stub_dir)"; log="$WORK/c6.log"; envf="$WORK/c6-envfile"; : > "$envf"
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    '[ "$1 $2" = "login status" ] && exit 1
+     if [ "$2" = "--with-access-token" ]; then exit 0; fi
+     exit 1'
+  # A pristine JWT (no surrounding whitespace) must be LEFT in the env so the normal
+  # direct-token path keeps working for later codex calls — do NOT drop it.
+  ( export CLAUDE_ENV_FILE="$envf"; run_ensure_codex_auth "$d" "$log" "SECRET.JWT.VALUE" ) \
+    && ok "codex clean-token: returns 0" \
+    || fail "codex clean-token: returned non-zero"
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && fail "codex clean-token: wrongly dropped a pristine token. File: [$(cat "$envf" 2>/dev/null)]" \
+    || ok "codex clean-token: pristine token left in place"
+}
+
+run_configure_codex_sandbox() {
+  local home="$1" out_file="$2"
+  # shellcheck disable=SC2030,SC2031,SC2034  # LOG is read by configure_codex_sandbox (sourced)
+  ( export CODEX_HOME="$home" TMPDIR="$WORK"; LOG="$out_file"; configure_codex_sandbox ) >>"$out_file" 2>&1
+}
+
+test_sandbox_creates() {
+  local home log; home="$(mktemp -d "$WORK/s1.XXXXXX")"; log="$WORK/s1.log"
+  run_configure_codex_sandbox "$home" "$log" && ok "sandbox create: returns 0" \
+    || fail "sandbox create: returned non-zero"
+  [ "$(cat "$home/config.toml" 2>/dev/null)" = 'sandbox_mode = "danger-full-access"' ] \
+    && ok "sandbox create: config.toml written with danger-full-access" \
+    || fail "sandbox create: config.toml not as expected"
+}
+
+test_sandbox_respects_existing() {
+  local home log before; home="$(mktemp -d "$WORK/s2.XXXXXX")"; log="$WORK/s2.log"
+  mkdir -p "$home"; printf 'sandbox_mode = "workspace-write"\nmodel = "x"\n' > "$home/config.toml"
+  before="$(cat "$home/config.toml")"
+  run_configure_codex_sandbox "$home" "$log" >/dev/null
+  [ "$(cat "$home/config.toml")" = "$before" ] \
+    && ok "sandbox respect: user-set sandbox_mode left untouched" \
+    || fail "sandbox respect: clobbered a user-set sandbox_mode"
+}
+
+# ---------------------------------------------------------------------------
+# persist_path()
+# ---------------------------------------------------------------------------
+test_persist_path() {
+  local envf; envf="$WORK/p1-envfile"; : > "$envf"
+  ( export CLAUDE_ENV_FILE="$envf"; persist_path "/opt/x/bin"; persist_path "/opt/x/bin" ) >/dev/null 2>&1
+  grep -qF 'export PATH="/opt/x/bin:$PATH"' "$envf" \
+    && ok "persist_path: wrote the export line" \
+    || fail "persist_path: did not write the export line. File: $(cat "$envf")"
+  [ "$(grep -cF '/opt/x/bin' "$envf")" -eq 1 ] \
+    && ok "persist_path: idempotent (no duplicate on re-run)" \
+    || fail "persist_path: duplicated the line on re-run"
+}
+
+# ---------------------------------------------------------------------------
+# main() gate + project hook seam (subprocess)
+# ---------------------------------------------------------------------------
+test_gate_local_noop() {
+  # No CLAUDE_CODE_REMOTE => must be an immediate no-op (exit 0), no install.
+  local out; out="$WORK/gate.out"
+  if CLAUDE_CODE_REMOTE='' bash "$SCRIPT" >"$out" 2>&1; then
+    ok "gate: no-op exit 0 when CLAUDE_CODE_REMOTE unset"
+  else
+    fail "gate: non-zero exit when CLAUDE_CODE_REMOTE unset"
+  fi
+  [ -s "$out" ] && fail "gate: produced output when it should be silent" \
+    || ok "gate: produced no output (true no-op)"
+}
+
+test_local_hook_sourced() {
+  # CLAUDE_CODE_REMOTE=true with a project hook present => hook is sourced, exit 0.
+  local proj d out; proj="$(mktemp -d "$WORK/proj.XXXXXX")"; d="$(new_stub_dir)"; out="$WORK/lh.out"
+  mkdir -p "$proj/scripts"
+  # A cc-web-setup.sh that no-ops (so the self-heal call is cheap) and a local hook
+  # that drops a sentinel.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$proj/scripts/cc-web-setup.sh"; chmod +x "$proj/scripts/cc-web-setup.sh"
+  printf 'touch "%s/lh-sentinel"\n' "$WORK" > "$proj/scripts/web-bootstrap.local.sh"
+  rm -f "$WORK/lh-sentinel"
+  # Stub gh to the pinned version so ensure_gh short-circuits; no codex creds so codex is skipped.
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" id "echo 0"
+  # shellcheck disable=SC2030,SC2031
+  if ( export PATH="$d:/usr/bin:/bin" HOME="$WORK/lh-home" CLAUDE_CODE_REMOTE=true \
+         CLAUDE_PROJECT_DIR="$proj" TMPDIR="$WORK"; bash "$SCRIPT" ) >"$out" 2>&1; then
+    ok "local-hook: main() exits 0 in remote mode"
+  else
+    fail "local-hook: main() exited non-zero. Out: $(cat "$out" 2>/dev/null)"
+  fi
+  [ -e "$WORK/lh-sentinel" ] \
+    && ok "local-hook: web-bootstrap.local.sh was sourced" \
+    || fail "local-hook: project hook was NOT sourced. Out: $(cat "$out" 2>/dev/null)"
+}
+
+test_gh_pin_match
+test_gh_pin_mismatch
+test_gh_missing_sha256sum
+test_codex_no_token
+test_codex_missing_cli
+test_codex_fresh_login
+test_codex_blank_token
+test_codex_trims_token
+test_codex_clean_token_kept
+test_sandbox_creates
+test_sandbox_respects_existing
+test_persist_path
+test_gate_local_noop
+test_local_hook_sourced
+
+echo ""
+echo "web-bootstrap: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/skills/cc-web-setup/scripts/test-web-bootstrap.sh
+++ b/skills/cc-web-setup/scripts/test-web-bootstrap.sh
@@ -220,6 +220,45 @@ test_codex_clean_token_kept() {
     || ok "codex clean-token: pristine token left in place"
 }
 
+# Fix A regression: when seed_codex_auth_json wins (auth.json is the credential of
+# record), a stale CODEX_ACCESS_TOKEN must be dropped — codex reads the raw token
+# BEFORE ~/.codex/auth.json, so a leftover would shadow the valid auth.json and break
+# later `codex exec`. This exercises main()'s auth arm as a subprocess: codex installs
+# at the pinned version, seed_codex_auth_json succeeds, and a non-JWT raw token is set.
+test_codex_authjson_drops_stale_token() {
+  local proj d out envf home; proj="$(mktemp -d "$WORK/aj-proj.XXXXXX")"; d="$(new_stub_dir)"
+  out="$WORK/aj.out"; envf="$WORK/aj-envfile"; : > "$envf"; home="$WORK/aj-home"; mkdir -p "$home"
+  mkdir -p "$proj/scripts"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$proj/scripts/cc-web-setup.sh"; chmod +x "$proj/scripts/cc-web-setup.sh"
+  # gh pinned so ensure_gh short-circuits with no download.
+  write_stub "$d" gh "echo 'gh version ${GH_PIN} (2026-01-01)'"
+  write_stub "$d" id "echo 0"
+  # codex stub: report the pinned version so ensure_codex_cli short-circuits (no
+  # download), and report "authenticated" for `login status` so seed_codex_auth_json's
+  # post-write probe succeeds.
+  # shellcheck disable=SC2016
+  write_stub "$d" codex \
+    'case "$1 $2" in
+       "--version "*|"--version") echo "codex-cli '"${CODEX_PIN}"'"; exit 0 ;;
+       "login status") exit 0 ;;
+     esac
+     exit 0'
+  # CODEX_AUTH_JSON present => seed_codex_auth_json wins. A stale, NON-JWT raw token is
+  # live; it must be dropped + persisted as `unset CODEX_ACCESS_TOKEN`.
+  # shellcheck disable=SC2030,SC2031
+  if ( export PATH="$d:/usr/bin:/bin" HOME="$home" CLAUDE_CODE_REMOTE=true \
+         CLAUDE_PROJECT_DIR="$proj" CLAUDE_ENV_FILE="$envf" TMPDIR="$WORK" \
+         CODEX_HOME="$home/.codex" CODEX_AUTH_JSON='{"tokens":{"access_token":"x"}}' \
+         CODEX_ACCESS_TOKEN='stale-not-a-jwt'; bash "$SCRIPT" ) >"$out" 2>&1; then
+    ok "codex authjson-drop: main() exits 0 in remote mode"
+  else
+    fail "codex authjson-drop: main() exited non-zero. Out: $(cat "$out" 2>/dev/null)"
+  fi
+  grep -qF 'unset CODEX_ACCESS_TOKEN' "$envf" 2>/dev/null \
+    && ok "codex authjson-drop: stale token unset persisted to CLAUDE_ENV_FILE" \
+    || fail "codex authjson-drop: stale token NOT dropped after auth.json seeded. File: [$(cat "$envf" 2>/dev/null)] Out: $(cat "$out" 2>/dev/null)"
+}
+
 run_configure_codex_sandbox() {
   local home="$1" out_file="$2"
   # shellcheck disable=SC2030,SC2031,SC2034  # LOG is read by configure_codex_sandbox (sourced)
@@ -257,6 +296,41 @@ test_persist_path() {
   [ "$(grep -cF '/opt/x/bin' "$envf")" -eq 1 ] \
     && ok "persist_path: idempotent (no duplicate on re-run)" \
     || fail "persist_path: duplicated the line on re-run"
+}
+
+# Fix B regression: a read-only CLAUDE_ENV_FILE makes the append fail. persist_path
+# must WARN (not falsely log "Persisted"), so later shells are not silently left
+# without the dir on PATH. Run it twice — with $LOG set and with $LOG UNSET — to lock
+# in the ${LOG:-/dev/null} discipline (a bare $LOG would crash under `set -u`).
+test_persist_path_readonly_warns() {
+  local envf out; envf="$WORK/p2-envfile"; : > "$envf"; chmod 0444 "$envf"
+
+  # (1) with $LOG set.
+  out="$WORK/p2-log-set.out"
+  ( export CLAUDE_ENV_FILE="$envf"; LOG="$WORK/p2-LOG"; persist_path "/opt/ro/bin" ) >"$out" 2>&1
+  grep -q 'WARNING: could not append PATH export for /opt/ro/bin' "$out" \
+    && ok "persist_path readonly (LOG set): warned on append failure" \
+    || fail "persist_path readonly (LOG set): no WARNING. Out: $(cat "$out" 2>/dev/null)"
+  grep -q 'Persisted /opt/ro/bin' "$out" \
+    && fail "persist_path readonly (LOG set): falsely claimed success" \
+    || ok "persist_path readonly (LOG set): did NOT falsely claim success"
+
+  # (2) with $LOG UNSET — must not crash under `set -u` (guarded ${LOG:-/dev/null}).
+  out="$WORK/p2-log-unset.out"
+  if ( export CLAUDE_ENV_FILE="$envf"; unset LOG; persist_path "/opt/ro/bin" ) >"$out" 2>&1; then
+    ok "persist_path readonly (LOG unset): ran without crashing under set -u"
+  else
+    fail "persist_path readonly (LOG unset): crashed (likely a bare \$LOG). Out: $(cat "$out" 2>/dev/null)"
+  fi
+  grep -q 'WARNING: could not append PATH export for /opt/ro/bin' "$out" \
+    && ok "persist_path readonly (LOG unset): warned on append failure" \
+    || fail "persist_path readonly (LOG unset): no WARNING. Out: $(cat "$out" 2>/dev/null)"
+
+  chmod 0644 "$envf" 2>/dev/null || true
+  # The unwritable file must remain empty — nothing was appended on either run.
+  [ ! -s "$envf" ] \
+    && ok "persist_path readonly: nothing written to the unwritable file" \
+    || fail "persist_path readonly: unexpectedly wrote to the file. File: [$(cat "$envf" 2>/dev/null)]"
 }
 
 # ---------------------------------------------------------------------------
@@ -307,9 +381,11 @@ test_codex_fresh_login
 test_codex_blank_token
 test_codex_trims_token
 test_codex_clean_token_kept
+test_codex_authjson_drops_stale_token
 test_sandbox_creates
 test_sandbox_respects_existing
 test_persist_path
+test_persist_path_readonly_warns
 test_gate_local_noop
 test_local_hook_sourced
 


### PR DESCRIPTION
Recovers the **`cc-web-setup`** skill — the new skill from the agent-skills **v0.10.0** sync that issue #121 stranded (the sync pushed `chore/sync-skills-v0.10.0` but failed to open the PR, so it never landed). Merging + archiving agent-skills (#123) made this the last un-merged content; this brings it home.

## What it is
`cc-web-setup` bootstraps a repo for **Claude Code on the web** — provisions `.claude/settings.json`, the `web-bootstrap.sh` SessionStart hook, `cc-web-setup.sh` (pre-snapshot setup that pre-seeds the RDL marketplace), and `announce-capabilities.sh`. Includes its own test scripts.

## Mapping
Added to the existing **`claude-code`** bundle as `{source: cc-web-setup, leaf: web-setup}` → invoked as **`/claude-code:web-setup`**, matching the bundle's existing `cc-*` → stripped-leaf convention (`cc-hook`→`hook`, `cc-agent-teams`→`agent-teams`). Bundle description/keywords updated accordingly.

## Generated / validated
- `scripts/sync-plugins.sh claude-code` → `plugins/claude-code/skills/web-setup/` (name: stripped per the grouping contract).
- Regenerated `marketplace.json`, `plugin.json`, `docs/bundles.md`.
- `asctl repo-check` validates **44 skills** (was 43); `check_bundle_refs` · `check_grouping` · `generate_manifests --check` · `generate_bundles_doc --check` · `check_consistency` · `validate-plugins.sh` all pass.

## Source provenance
Files recovered from `origin/chore/sync-skills-v0.10.0` (the orphaned sync branch). Once this merges, that branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)