### PR TITLE
fix(cc-web-setup): mktemp the web-bootstrap log instead of a predictable /tmp path

### DIFF
--- a/.changes/unreleased/Fixed-20260622-062856.yaml
+++ b/.changes/unreleased/Fixed-20260622-062856.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '`cc-web-setup` skill: create the `web-bootstrap.sh` SessionStart log via `mktemp` under `umask 077` instead of a fixed `/tmp/rdl-web-bootstrap.log`, closing a symlink-truncation and concurrent-session race window on shared hosts'
+time: 2026-06-22T06:28:56.410298103Z

--- a/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
+++ b/plugins/claude-code/skills/web-setup/assets/web-bootstrap.sh
@@ -477,11 +477,14 @@ main() {
   # shellcheck disable=SC2034  # consumed by the sourced project hook, not this file
   [ "$(id -u)" -eq 0 ] || SUDO='sudo -n'
 
-  # Verbose output sink (keeps the model's context clean — see header). Created
-  # 0600 via a subshell umask so the log (which may capture command output) is
-  # not world-readable from the outset.
-  LOG="${TMPDIR:-/tmp}/rdl-web-bootstrap.log"
-  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+  # Verbose output sink (keeps the model's context clean — see header). Use
+  # mktemp for a UNIQUE, unpredictable name: a fixed /tmp/rdl-web-bootstrap.log
+  # could be pre-created as a symlink (truncating an arbitrary target via the
+  # old `: > "$LOG"` redirect) or raced by a concurrent session. mktemp creates
+  # the file safely (O_EXCL, no symlink follow); the subshell umask 077 keeps it
+  # 0600 from the outset. Fall back to /dev/null if mktemp is unavailable/fails.
+  LOG="$(umask 077; mktemp "${TMPDIR:-/tmp}/rdl-web-bootstrap.XXXXXX" 2>/dev/null)" || LOG=/dev/null
+  [ -n "$LOG" ] || LOG=/dev/null
 
   # Resolve the repo root. The hook exports CLAUDE_PROJECT_DIR; fall back to the
   # script's own location so it also works when run by hand.

--- a/skills/cc-web-setup/assets/web-bootstrap.sh
+++ b/skills/cc-web-setup/assets/web-bootstrap.sh
@@ -477,11 +477,14 @@ main() {
   # shellcheck disable=SC2034  # consumed by the sourced project hook, not this file
   [ "$(id -u)" -eq 0 ] || SUDO='sudo -n'
 
-  # Verbose output sink (keeps the model's context clean — see header). Created
-  # 0600 via a subshell umask so the log (which may capture command output) is
-  # not world-readable from the outset.
-  LOG="${TMPDIR:-/tmp}/rdl-web-bootstrap.log"
-  ( umask 077; : > "$LOG" ) 2>/dev/null || LOG=/dev/null
+  # Verbose output sink (keeps the model's context clean — see header). Use
+  # mktemp for a UNIQUE, unpredictable name: a fixed /tmp/rdl-web-bootstrap.log
+  # could be pre-created as a symlink (truncating an arbitrary target via the
+  # old `: > "$LOG"` redirect) or raced by a concurrent session. mktemp creates
+  # the file safely (O_EXCL, no symlink follow); the subshell umask 077 keeps it
+  # 0600 from the outset. Fall back to /dev/null if mktemp is unavailable/fails.
+  LOG="$(umask 077; mktemp "${TMPDIR:-/tmp}/rdl-web-bootstrap.XXXXXX" 2>/dev/null)" || LOG=/dev/null
+  [ -n "$LOG" ] || LOG=/dev/null
 
   # Resolve the repo root. The hook exports CLAUDE_PROJECT_DIR; fall back to the
   # script's own location so it also works when run by hand.


### PR DESCRIPTION
## Summary

Hardens the `cc-web-setup` skill's `web-bootstrap.sh` SessionStart hook. The verbose log was created at a fixed `${TMPDIR:-/tmp}/rdl-web-bootstrap.log` and truncated with `: > "$LOG"`, which **follows a pre-existing symlink** (arbitrary-file truncation on a shared host) and **races concurrent sessions** on the same path. It's now created with `mktemp` (unique name, `O_EXCL`, no symlink follow) under `umask 077`, with a `/dev/null` fallback.

Touches the canonical asset and the generated `plugins/claude-code/skills/web-setup` copy (refreshed via `scripts/sync-plugins.sh`). The template keeps its `scripts/` layout — only the log sink changed.

## Context

Surfaced by a Codex review of #150 (this repo's own web-setup), where the same `mktemp` hardening was applied to the in-repo `.claude/hooks/web-bootstrap.sh`. This PR ports that one finding (codex #6, low-severity) to the **published skill template**, where it has broader benefit for repos that adopt the skill on shared hosts. The review's other findings were either confirmed correct or a false positive (the version-regex "bug" — `${PIN//./\\.}` does escape the dots) — details in #150.

## Test plan

- [x] `bash -n` on canonical + plugin copies
- [x] `scripts/sync-plugins.sh --check` — plugin tree in sync
- [x] `asctl repo-check` — 44 skills valid
- [x] `scripts/validate-plugins.sh` — all plugins/agents valid
- [x] `generate_manifests.py --check` / `generate_bundles_doc.py --check` — in sync
- [x] log creation verified: unique name, mode `0600`, appends work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbmoSZtn1PLNsaKhceraPs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbmoSZtn1PLNsaKhceraPs)_