### PR TITLE
fix: register claude-plugins-official marketplace in web settings

### DIFF
--- a/.changes/unreleased/Fixed-20260622-090000.yaml
+++ b/.changes/unreleased/Fixed-20260622-090000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '`.claude/settings.json`: register the `claude-plugins-official` marketplace in `extraKnownMarketplaces` so the enabled `superpowers`, `gopls-lsp`, and `pr-review-toolkit` plugins resolve and install on Claude Code (web) — previously only `openai-codex` was declared, so those plugins'' slash-commands/skills (e.g. `/test-driven-development`) never appeared'
+time: 2026-06-22T09:00:00.000000000Z

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,13 @@
         "repo": "openai/codex-plugin-cc"
       },
       "autoUpdate": false
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      },
+      "autoUpdate": true
     }
   }
 }


### PR DESCRIPTION
The superpowers, gopls-lsp, and pr-review-toolkit plugins are enabled via
enabledPlugins with the @claude-plugins-official suffix, but that marketplace
was never declared in extraKnownMarketplaces. Without the marketplace
registration, Claude Code (web) has no source to install the plugins from, so
their slash-commands/skills (e.g. /test-driven-development) never appear.

Add the claude-plugins-official marketplace (anthropics/claude-plugins-official),
matching the working configuration in nq-rdl/dataops.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cwi1jVGsMUMptyegSAbmk2