### PR TITLE
feat(cc-web-setup): portable web-setup + marketplace-consistency guards (#149, #157)

### DIFF
--- a/.changes/unreleased/Added-20260623-013635.yaml
+++ b/.changes/unreleased/Added-20260623-013635.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'cc-web-setup: portable plugin provisioning for other repos — a curated team-externals settings template (`settings.externals.json.tmpl`) alongside the rdl baseline, an `assets/marketplaces.json` source of truth, and a `web-settings.sh` guard helper that enforces marketplace-consistency (every enabled plugin''s marketplace declared, #157) and strips self-referential marketplaces (#149); plus a `references/web-setup.rst` platform/architecture/anti-patterns reference'
+time: 2026-06-23T01:36:35.421536019Z

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -115,6 +115,12 @@ absolute path once and reuse it:
 WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
 ```
 
+`strip-self` and `ensure` are **stdout filters** — they print the corrected document and
+do **not** edit `.claude/settings.json` in place (so you can review the diff first). Capture
+the output to a temp file and move it into place; the `&&` leaves the original untouched if
+the guard exits non-zero (e.g. `ensure`'s stop-and-ask on an unknown marketplace), which is
+exactly what you want. `cover` is a read-only assertion (no redirect needed).
+
 | Base | File | Use for |
 |---|---|---|
 | **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
@@ -131,13 +137,15 @@ Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`
    (worktrunk) as desired. Present the menu and let the user confirm — do not silently decide.
 3. **Strip self-references (Phase 0 enforcement):**
    ```bash
-   bash "$WS" strip-self "$PWD" .claude/settings.json
+   tmp="$(mktemp)"
+   bash "$WS" strip-self "$PWD" .claude/settings.json > "$tmp" && mv "$tmp" .claude/settings.json
    ```
    Removes any `enabledPlugins`/marketplace that resolves to *this* repo's own
    `.claude-plugin/marketplace.json`; a no-op passthrough when there is none.
 4. **Guarantee marketplace coverage (#157):**
    ```bash
-   bash "$WS" ensure .claude/settings.json
+   tmp="$(mktemp)"
+   bash "$WS" ensure .claude/settings.json > "$tmp" && mv "$tmp" .claude/settings.json
    ```
    Auto-adds every missing-but-known marketplace from `marketplaces.json`. If it exits
    non-zero it printed an **unknown** marketplace to stderr and wrote **nothing** — **stop and

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -112,7 +112,11 @@ not on `PATH` — so the model's cwd (the target repo root) cannot find it by na
 absolute path once and reuse it:
 
 ```bash
-WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
+# Resolve this skill's own scripts/ dir. On an installed plugin the skill lives in
+# the plugin cache — locate the helper rather than guessing the path:
+WS="$(find "$HOME/.claude/plugins" -path '*/web-setup/scripts/web-settings.sh' 2>/dev/null | head -1)"
+# Fallback: the absolute path of the scripts/ directory beside this SKILL.md.
+WS="${WS:-<absolute path to this skill>/scripts/web-settings.sh}"
 ```
 
 `strip-self` and `ensure` are **stdout filters** — they print the corrected document and

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -66,13 +66,23 @@ surfaced, never masked. Keep the chain in mind: **declared ≠ installed ≠ sur
 > the Setup-script field is for caching heavy *packages*, not plugins, and this skill does
 > not use it.
 
+> Authoritative platform facts (the web docs' "what carries over" table), the three-layer
+> architecture (declarative settings ↔ `install-deps.sh` engine ↔ `install-deps.local.sh`
+> project seam), and the hard-won anti-patterns live in
+> [`references/web-setup.rst`](references/web-setup.rst). Read it before bootstrapping an
+> unfamiliar repo, and to debug a "declared but not installed" plugin.
+
 ## Phase 0 — Confirm context
 
 - Confirm you are at the **repo root** of the repo to bootstrap (a `.git` dir is present).
 - Check whether `.claude/settings.json` and `.claude/scripts/` already exist — this decides
   create-fresh vs. merge for each.
-- Confirm the **target is not `agent-extensions` itself** (see the anti-pattern note in
-  Phase 2).
+- **Self-marketplace check.** If the target repo has a `.claude-plugin/marketplace.json`, it
+  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl`
+  inside `nq-rdl/agent-extensions`) installs `main`'s *published* copy into the plugin cache,
+  silently **shadowing the working-tree edits** under development. Pick the **externals** base
+  (not rdl) in Phase 2; the bundled `web-settings.sh strip-self` enforces this
+  deterministically for any marketplace repo, not just this one.
 - Ask the user only if something is ambiguous (e.g. a pre-existing `settings.json` with a
   conflicting `model`/`hooks` block). Otherwise proceed with the defaults below.
 
@@ -91,33 +101,65 @@ project. Project specifics go in the optional `install-deps.local.sh` seam (Phas
 
 If a target file already exists and differs, show the diff and ask before overwriting.
 
-## Phase 2 — Merge `.claude/settings.json`
+## Phase 2 — Choose a base template and merge `.claude/settings.json`
 
-The template is `assets/settings.json.tmpl`. It registers the **`rdl`** marketplace
-(`nq-rdl/agent-extensions`), enables **`rdl@rdl`** (the meta-plugin that installs every RDL
-subject plugin), wires the two SessionStart hooks
-(`.claude/scripts/install-deps.sh` and `.claude/scripts/announce-capabilities.sh`), and sets
-opinionated defaults (`model: opus`, `alwaysThinkingEnabled`, `effortLevel: xhigh`,
-`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+Two complete templates ship in `assets/`. The skill **composes** the right `enabledPlugins`
+on a chosen base and lets the bundled helper `scripts/web-settings.sh` make the marketplace
+wiring deterministic — it never concatenates two templates. `web-settings.sh` is a
+**setup-time** tool; it is **not** copied into the target repo. It lives in **this skill's
+own `scripts/` directory** (the directory this `SKILL.md` is in) — not in the target repo and
+not on `PATH` — so the model's cwd (the target repo root) cannot find it by name. Resolve its
+absolute path once and reuse it:
 
-- **If `.claude/settings.json` is absent:** create `.claude/` and write the template verbatim.
-- **If it exists:** perform an **idempotent JSON-aware deep-merge** (use `jq` or a careful
-  read-modify-write), and **show the diff before writing**:
-  - `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
-  - `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the
-    two hook commands **only if not already present** (dedupe by exact command string).
-  - `enabledPlugins`: add `"rdl@rdl": true` (or specific RDL subjects the repo wants).
-  - `extraKnownMarketplaces`: add the `rdl` entry; leave any existing marketplaces intact.
-  - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never
-    override a deliberate user choice. Mention they are opinionated defaults.
+```bash
+WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
+```
 
-> **Anti-pattern — never enable a self-referential marketplace in its own dev env.**
-> `rdl@rdl` is fine for a *consumer* repo (the platform installs the catalog from a remote
-> marketplace). It is **not** fine inside `agent-extensions` itself: there it re-clones the
-> repo and fans out to dozens of dependency plugins — and since the docs require the install
-> to *reach its marketplace source*, that self-cloning batch breaks the session-start
-> install so **nothing** surfaces. If you ever bootstrap the catalog repo itself, declare a
-> small set of **external** dev-helper plugins instead.
+| Base | File | Use for |
+|---|---|---|
+| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
+| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
+
+Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
+`alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+
+1. **Pick the base** per the table. For *rdl + externals* (a consumer wanting both), start
+   from the externals base and add `"rdl@rdl": true` to `enabledPlugins`.
+2. **Tailor the external set** from `assets/marketplaces.json` (`teamExternals`) by the
+   repo's language: always offer the `agnostic`-tagged (superpowers, pr-review-toolkit,
+   codex); add `go`-tagged for a Go repo, `python`-tagged (astral) for Python, `workflow`
+   (worktrunk) as desired. Present the menu and let the user confirm — do not silently decide.
+3. **Strip self-references (Phase 0 enforcement):**
+   ```bash
+   bash "$WS" strip-self "$PWD" .claude/settings.json
+   ```
+   Removes any `enabledPlugins`/marketplace that resolves to *this* repo's own
+   `.claude-plugin/marketplace.json`; a no-op passthrough when there is none.
+4. **Guarantee marketplace coverage (#157):**
+   ```bash
+   bash "$WS" ensure .claude/settings.json
+   ```
+   Auto-adds every missing-but-known marketplace from `marketplaces.json`. If it exits
+   non-zero it printed an **unknown** marketplace to stderr and wrote **nothing** — **stop and
+   ask** the user for that marketplace's source, declare it, and re-run. Always keep
+   `claude-plugins-official` declared explicitly (auto-known on the local CLI, unreliable on
+   the web).
+
+**Merging into an existing `.claude/settings.json`** (idempotent; **show the diff before
+writing**):
+- `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
+- `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the two
+  hook commands **only if not already present** (dedupe by exact command string).
+- `enabledPlugins` / `extraKnownMarketplaces`: union the chosen set in, leave existing entries
+  intact, then run `strip-self` + `ensure` (steps 3–4) over the merged result.
+- `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never override a
+  deliberate user choice.
+
+> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl` inside
+> `nq-rdl/agent-extensions` installs `main`'s published catalog into the plugin cache,
+> shadowing your working-tree edits, and the self-cloning batch can break the whole
+> session-start install so **nothing** surfaces. `strip-self` removes it deterministically;
+> the externals base avoids it by construction.
 
 ## Phase 3 — Offer the project extension seam
 
@@ -151,6 +193,10 @@ are handled declaratively by the platform.
 - `bash .claude/scripts/install-deps.sh` (no env var) → an immediate no-op (exit 0, no
   output): the committed hook never disturbs a local session.
 - Validate `.claude/settings.json` parses (`jq . .claude/settings.json`).
+- **Marketplace coverage (#157):** `bash "$WS" cover .claude/settings.json` (this skill's
+  bundled helper — `$WS` from Phase 2, an absolute path) exits 0. Any line it prints is an
+  enabled plugin whose marketplace is undeclared — it would install **nothing, silently** —
+  so fix Phase 2. This checks *configuration* only; it cannot prove a cloud install succeeded.
 
 ## Phase 5 — Summarize for the user
 

--- a/plugins/claude-code/skills/web-setup/assets/marketplaces.json
+++ b/plugins/claude-code/skills/web-setup/assets/marketplaces.json
@@ -1,0 +1,72 @@
+{
+  "marketplaces": {
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-plugins-official" },
+      "autoUpdate": true
+    },
+    "openai-codex": {
+      "source": { "source": "github", "repo": "openai/codex-plugin-cc" },
+      "autoUpdate": true
+    },
+    "goland-claude-marketplace": {
+      "source": { "source": "github", "repo": "JetBrains/go-modern-guidelines" },
+      "autoUpdate": true
+    },
+    "astral-sh": {
+      "source": { "source": "github", "repo": "astral-sh/claude-code-plugins" },
+      "autoUpdate": true
+    },
+    "worktrunk": {
+      "source": { "source": "github", "repo": "max-sixty/worktrunk" },
+      "autoUpdate": true
+    },
+    "rdl": {
+      "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
+      "autoUpdate": true
+    }
+  },
+  "teamExternals": [
+    {
+      "id": "superpowers@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "agnostic",
+      "purpose": "brainstorming, TDD, writing-plans, systematic-debugging workflows"
+    },
+    {
+      "id": "pr-review-toolkit@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "agnostic",
+      "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.)"
+    },
+    {
+      "id": "codex@openai-codex",
+      "marketplace": "openai-codex",
+      "tag": "agnostic",
+      "purpose": "Codex bridge — /codex:rescue second-opinion reviews and rescues"
+    },
+    {
+      "id": "gopls-lsp@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "go",
+      "purpose": "gopls language server integration"
+    },
+    {
+      "id": "modern-go-guidelines@goland-claude-marketplace",
+      "marketplace": "goland-claude-marketplace",
+      "tag": "go",
+      "purpose": "modern Go syntax guidance"
+    },
+    {
+      "id": "astral@astral-sh",
+      "marketplace": "astral-sh",
+      "tag": "python",
+      "purpose": "ruff / ty / uv guidance for Python repos"
+    },
+    {
+      "id": "worktrunk@worktrunk",
+      "marketplace": "worktrunk",
+      "tag": "workflow",
+      "purpose": "git worktree management via the wt CLI"
+    }
+  ]
+}

--- a/plugins/claude-code/skills/web-setup/assets/settings.externals.json.tmpl
+++ b/plugins/claude-code/skills/web-setup/assets/settings.externals.json.tmpl
@@ -1,0 +1,71 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/install-deps.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/announce-capabilities.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "codex@openai-codex": true,
+    "gopls-lsp@claude-plugins-official": true,
+    "modern-go-guidelines@goland-claude-marketplace": true,
+    "astral@astral-sh": true,
+    "worktrunk@worktrunk": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      },
+      "autoUpdate": true
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      },
+      "autoUpdate": true
+    },
+    "goland-claude-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "JetBrains/go-modern-guidelines"
+      },
+      "autoUpdate": true
+    },
+    "astral-sh": {
+      "source": {
+        "source": "github",
+        "repo": "astral-sh/claude-code-plugins"
+      },
+      "autoUpdate": true
+    },
+    "worktrunk": {
+      "source": {
+        "source": "github",
+        "repo": "max-sixty/worktrunk"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/plugins/claude-code/skills/web-setup/references/web-setup.rst
+++ b/plugins/claude-code/skills/web-setup/references/web-setup.rst
@@ -78,7 +78,8 @@ and retries once, refreshing each marketplace at most once per run.
 
 A plugin the self-heal installs **surfaces from the *next* session**: Claude
 enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
-re-scans only loose ``~/.claude/skills/``, **not** the plugin install cache.
+empirically *appears* to re-scan only loose ``~/.claude/skills/``, not the plugin
+install cache (unconfirmed upstream — see ``docs/notes/claude-code-web-issues.md``).
 
 
 The two guards this skill enforces

--- a/plugins/claude-code/skills/web-setup/references/web-setup.rst
+++ b/plugins/claude-code/skills/web-setup/references/web-setup.rst
@@ -1,0 +1,127 @@
+======================================
+Claude Code on the web — setup reference
+======================================
+
+Authoritative facts, the layered architecture, and the anti-patterns behind the
+``cc-web-setup`` skill. Read this before bootstrapping an unfamiliar repo or when
+debugging a plugin that is *declared* but never *installs*.
+
+The two source-of-truth notes this distills from live in the repo and should be
+read for the full story:
+
+- ``docs/notes/claude-code-web-issues.md`` — the investigation log (why declarative
+  won, why the self-heal stays, the ``reloadSkills`` finding, the Docker note).
+- ``CONTRIBUTING.md`` § "Claude Code on the web" — why a catalog-dev session enables
+  *external* dev-helper plugins, never the catalog itself.
+
+Official docs: https://code.claude.com/docs/en/claude-code-on-the-web
+
+
+What carries over (the platform contract)
+=========================================
+
+Per the web docs' "what carries over" table, **plugins declared in**
+``.claude/settings.json`` (``extraKnownMarketplaces`` + ``enabledPlugins``) are
+*"installed at session start from the marketplace you declared. Requires network
+access to reach the marketplace source."*
+
+Consequences that drive every design choice here:
+
+- Declaring the marketplace + plugin **is the whole mechanism**. There is **no
+  Setup-script field, no** ``make``\ **, no** ``.claude/skills/`` **bake** needed for
+  plugins. ``github.com`` is on the default *Trusted* allowlist, so a github-sourced
+  marketplace is reachable by default.
+- The only failure mode is the marketplace source being unreachable, or its local
+  index being stale on a cold VM. Both are handled by the self-heal (below).
+- A cloud session is a **fresh VM with only a clone of the repo** — anything not in
+  git (or not installed by the SessionStart hook) is absent.
+
+
+The three layers
+================
+
+1. **Declarative settings (plugins).** ``.claude/settings.json`` carries
+   ``extraKnownMarketplaces`` (sources, ``autoUpdate``) and ``enabledPlugins``. The
+   platform installs them at session start. This skill ships two bases —
+   ``assets/settings.json.tmpl`` (rdl) and ``assets/settings.externals.json.tmpl``
+   (team externals, no rdl) — and ``assets/marketplaces.json`` as the single source
+   of truth for marketplace sources + the curated team-externals set.
+
+2. **The portable engine** — ``.claude/scripts/install-deps.sh``, a SessionStart
+   hook **gated on** ``CLAUDE_CODE_REMOTE=true`` (a no-op on a contributor's laptop).
+   It provisions only what the declarative path does not: per-session CLIs (``gh``,
+   and Codex when ``CODEX_AUTH_JSON`` is set), the project dev toolchain via the
+   ``install-deps.local.sh`` seam, and a cheap idempotent **plugin self-heal**
+   (``ensure_plugins``). Every step is non-fatal; the hook always exits 0.
+
+3. **The project seam** — ``.claude/scripts/install-deps.local.sh`` (optional,
+   per-repo). Language toolchains, git-hook wiring, and **starting** ``dockerd``
+   (the web runner ships the docker CLI + daemon binary but **no running daemon and
+   no systemd**, so a repo that needs containers must start it here).
+
+The chain to keep in mind: **declared ≠ installed ≠ surfaced.**
+``announce-capabilities.sh`` (the second SessionStart hook) cross-checks
+``claude plugin list`` and reports **"Enabled plugins (installed)"** vs **"⚠️
+Declared but NOT installed"**, so a reachability failure is surfaced, never masked.
+
+
+The self-heal (``ensure_plugins``)
+==================================
+
+Declarative install is primary; the self-heal is the backstop kept **deliberately**
+(it has empirically rescued installs). It reads ``enabledPlugins`` from
+``settings.json`` via ``jq``, skips ids already in ``claude plugin list``, and
+installs the rest idempotently. On a failed install it derives the marketplace from
+the ``@`` suffix, runs ``claude plugin marketplace update <mkt>`` (the refresh
+``claude plugin install`` does **not** do itself — the stale-index failure mode),
+and retries once, refreshing each marketplace at most once per run.
+
+A plugin the self-heal installs **surfaces from the *next* session**: Claude
+enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
+re-scans only loose ``~/.claude/skills/``, **not** the plugin install cache.
+
+
+The two guards this skill enforces
+==================================
+
+Run from the skill's ``scripts/web-settings.sh`` (a setup-time tool, never copied
+into the target repo):
+
+- **Self-marketplace (Phase 0)** — ``strip-self <repo-root> <settings>`` removes any
+  ``enabledPlugins``/marketplace that resolves to this repo's own
+  ``.claude-plugin/marketplace.json``. Prevents shadowing working-tree edits with the
+  published copy.
+- **Marketplace coverage (Phase 2/5, issue #157)** — ``ensure <settings>`` auto-adds
+  every missing-but-known marketplace from ``marketplaces.json`` and **stops and
+  asks** on an unknown one (it writes nothing and exits non-zero). ``cover
+  <settings>`` is the read-only assertion that every enabled plugin's ``@marketplace``
+  is declared.
+
+
+Anti-patterns — do not repeat these
+===================================
+
+These each cost a PR (or several) to learn:
+
+- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl``
+  inside ``nq-rdl/agent-extensions`` re-clones the repo and fans out to dozens of
+  dependency plugins; that oversized self-cloning batch broke the whole session-start
+  install so **nothing** surfaced. A catalog-dev env enables *external* dev-helper
+  plugins, not the catalog.
+- **A pre-snapshot Setup-script field for plugins** (``make install-deps`` / ``make
+  cc-web-setup``). Plugins already auto-install declaratively; worse, a ``make``
+  Setup-script field hard-failed *environment startup* on a CWD hiccup. The
+  Setup-script field is only worth it for heavy **non-plugin** caching.
+- **Believing "the platform registers marketplaces but does not install
+  enabledPlugins."** It does install them. An empty ``claude plugin list`` is the
+  stale-index / unreachable-source failure, not a missing platform feature.
+- **Reporting *declared* plugins as installed.** Build the banner from ``claude plugin
+  list``, not from ``settings.json``, or a missing marketplace looks healthy while the
+  slash menu is empty.
+- **A naive ``claude plugin install`` retry without ``marketplace update``.** On a
+  cold VM the index is empty; the retry re-hits the same stale index forever.
+- **Leaving ``CODEX_ACCESS_TOKEN`` set.** Codex parses it as a JWT at runtime; a
+  blob/blank value breaks every later ``codex exec`` even with a valid ``auth.json``.
+  Unset it in-process and via ``CLAUDE_ENV_FILE``.
+- **Predictable ``/tmp`` log paths.** A symlink-truncation/race vector — use ``mktemp``
+  with ``umask 077``.

--- a/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# web-settings.sh — deterministic guards for the .claude/settings.json that
+# cc-web-setup provisions. The skill (SKILL.md Phases 0/2/5) runs these instead of
+# hand-editing JSON, so the marketplace-consistency (#157) and self-marketplace
+# (#149) guards are mechanical, not prose the model might skip.
+#
+# Three subcommands, all PATH-ARG in -> STDOUT out (no stdin), VALIDATE-BEFORE-EMIT
+# (a full document is computed and only printed on success — a failure prints
+# nothing to stdout, so a caller piping the output never gets partial/corrupt JSON):
+#
+#   cover <settings.json>
+#       Phase 5 assertion. Print every enabled plugin whose @marketplace is not a
+#       key in extraKnownMarketplaces (it would install nothing, silently). Exit 1
+#       if any orphan, 0 if fully covered. Read-only.
+#
+#   ensure <settings.json>
+#       Phase 2 guard. Emit <settings.json> with every missing-but-KNOWN marketplace
+#       added from assets/marketplaces.json. If any referenced marketplace is UNKNOWN
+#       (not already declared and not in the lookup), print those marketplace names to
+#       stderr and exit 4 with NO stdout — the skill then stops and asks the user.
+#
+#   strip-self <repo-root> <settings.json>
+#       Phase 0 guard. If <repo-root>/.claude-plugin/marketplace.json exists, the repo
+#       IS a marketplace; remove every enabledPlugins entry whose @marketplace equals
+#       this repo's marketplace name and drop that marketplace from
+#       extraKnownMarketplaces (enabling it would shadow working-tree edits with main's
+#       published copy). Passthrough (emit unchanged) when the file is absent.
+#
+# Portability: POSIX-leaning bash, safe on macOS bash 3.2 — no associative arrays
+# (declare -A), no mapfile/readarray, no GNU-only flags. Requires jq.
+#
+# Asset resolution: the marketplaces lookup is found relative to THIS script, so it
+# works from both the canonical skills/cc-web-setup/scripts/ and the synced
+# plugins/claude-code/skills/web-setup/scripts/ copy. Override with
+# WEB_SETTINGS_MARKETPLACES for tests.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+MARKETPLACES="${WEB_SETTINGS_MARKETPLACES:-${SCRIPT_DIR}/../assets/marketplaces.json}"
+
+die() { printf '%s\n' "$1" >&2; exit "${2:-1}"; }
+
+command -v jq >/dev/null 2>&1 || die "web-settings.sh: jq is required but not on PATH" 3
+
+# Fail fast (exit 2, no stdout) if a settings file is not valid JSON, so every
+# subcommand has a known-good document and set -e cannot mask a parse failure as
+# an empty (and thus falsely "covered" / "no unknowns") result.
+require_json() { jq empty "$1" >/dev/null 2>&1 || die "$2: not valid JSON: $1" 2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  web-settings.sh cover <settings.json>
+  web-settings.sh ensure <settings.json>
+  web-settings.sh strip-self <repo-root> <settings.json>
+EOF
+}
+
+# List enabled plugins whose @marketplace is undeclared (or missing entirely).
+cmd_cover() {
+  [ "$#" -eq 1 ] || die "cover: expected <settings.json>" 2
+  settings="$1"
+  [ -f "$settings" ] || die "cover: no such file: $settings" 2
+  require_json "$settings" cover
+  orphans="$(jq -r '
+    (.extraKnownMarketplaces // {} | keys) as $known
+    | (.enabledPlugins // {}) | to_entries[]
+    | select(.value == true)
+    | .key as $id
+    | ($id | split("@")[1]) as $mkt
+    | select($mkt == null or ($known | index($mkt) | not))
+    | $id
+  ' "$settings")"
+  if [ -n "$orphans" ]; then
+    printf '%s\n' "$orphans"
+    exit 1
+  fi
+}
+
+# Add missing-but-known marketplaces; refuse (exit 4, no stdout) on unknowns.
+cmd_ensure() {
+  [ "$#" -eq 1 ] || die "ensure: expected <settings.json>" 2
+  settings="$1"
+  [ -f "$settings" ] || die "ensure: no such file: $settings" 2
+  [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
+  require_json "$settings" ensure
+
+  lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
+
+  # Unresolved = an enabled plugin id with NO @marketplace, or one whose marketplace
+  # is neither already declared nor in the known lookup. Report the plugin ids (so a
+  # malformed bare id surfaces too — matching cover, not silently ignored).
+  unresolved="$(jq -r --argjson lk "$lookup" '
+    (.extraKnownMarketplaces // {} | keys) as $known
+    | (.enabledPlugins // {}) | to_entries[]
+    | select(.value == true) | .key as $id
+    | ($id | split("@")[1]) as $mkt
+    | select($mkt == null or (($known | index($mkt) | not) and ($lk | has($mkt) | not)))
+    | $id
+  ' "$settings")"
+  if [ -n "$unresolved" ]; then
+    {
+      printf 'web-settings.sh ensure: enabled plugin(s) with an unresolved marketplace.\n'
+      printf 'Each id below has no @marketplace or an unknown one — fix the id or declare\n'
+      printf 'the marketplace in extraKnownMarketplaces, then re-run:\n'
+      printf '%s\n' "$unresolved"
+    } >&2
+    exit 4
+  fi
+
+  # Validate-before-emit: jq builds the complete document or errors (nothing to stdout).
+  jq --argjson lk "$lookup" '
+    . as $root
+    | ([ $root.enabledPlugins // {} | to_entries[] | select(.value == true) | .key | split("@")[1] ]
+        | map(select(. != null)) | unique) as $needed
+    | .extraKnownMarketplaces = (
+        reduce $needed[] as $mkt (($root.extraKnownMarketplaces // {});
+          if (.[$mkt] != null) then .
+          elif ($lk[$mkt] != null) then . + { ($mkt): $lk[$mkt] }
+          else . end)
+      )
+  ' "$settings"
+}
+
+# Drop self-referential plugins/marketplace when the target repo is itself a marketplace.
+cmd_strip_self() {
+  [ "$#" -eq 2 ] || die "strip-self: expected <repo-root> <settings.json>" 2
+  repo_root="$1"
+  settings="$2"
+  [ -f "$settings" ] || die "strip-self: no such file: $settings" 2
+  require_json "$settings" strip-self
+
+  mkfile="${repo_root}/.claude-plugin/marketplace.json"
+  if [ ! -f "$mkfile" ]; then
+    jq '.' "$settings"   # not a marketplace repo — passthrough (still validated)
+    return 0
+  fi
+  self="$(jq -r '.name // empty' "$mkfile")"
+  if [ -z "$self" ]; then
+    jq '.' "$settings"   # marketplace file without a name — nothing to strip (validated)
+    return 0
+  fi
+
+  jq --arg self "$self" '
+    .enabledPlugins = ((.enabledPlugins // {})
+        | with_entries(select((.key | split("@")[1]) != $self)))
+    | if (.extraKnownMarketplaces // {} | has($self))
+      then del(.extraKnownMarketplaces[$self])
+      else . end
+  ' "$settings"
+}
+
+[ "$#" -ge 1 ] || { usage; exit 2; }
+sub="$1"; shift
+case "$sub" in
+  cover)      cmd_cover "$@" ;;
+  ensure)     cmd_ensure "$@" ;;
+  strip-self) cmd_strip_self "$@" ;;
+  -h|--help|help) usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
@@ -86,6 +86,7 @@ cmd_ensure() {
   [ -f "$settings" ] || die "ensure: no such file: $settings" 2
   [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
   require_json "$settings" ensure
+  require_json "$MARKETPLACES" ensure
 
   lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
 
@@ -129,6 +130,8 @@ cmd_strip_self() {
   [ "$#" -eq 2 ] || die "strip-self: expected <repo-root> <settings.json>" 2
   repo_root="$1"
   settings="$2"
+  # Fail fast on a bad repo-root rather than silently skipping the Phase 0 guard.
+  [ -d "$repo_root" ] || die "strip-self: not a directory: $repo_root" 2
   [ -f "$settings" ] || die "strip-self: no such file: $settings" 2
   require_json "$settings" strip-self
 
@@ -137,9 +140,11 @@ cmd_strip_self() {
     jq '.' "$settings"   # not a marketplace repo — passthrough (still validated)
     return 0
   fi
+  # A present marketplace file must be valid JSON, or we cannot trust the guard.
+  require_json "$mkfile" strip-self
   self="$(jq -r '.name // empty' "$mkfile")"
   if [ -z "$self" ]; then
-    jq '.' "$settings"   # marketplace file without a name — nothing to strip (validated)
+    jq '.' "$settings"   # valid marketplace file but no name — nothing to strip
     return 0
   fi
 

--- a/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/web-settings.sh
@@ -44,10 +44,21 @@ die() { printf '%s\n' "$1" >&2; exit "${2:-1}"; }
 
 command -v jq >/dev/null 2>&1 || die "web-settings.sh: jq is required but not on PATH" 3
 
-# Fail fast (exit 2, no stdout) if a settings file is not valid JSON, so every
-# subcommand has a known-good document and set -e cannot mask a parse failure as
-# an empty (and thus falsely "covered" / "no unknowns") result.
-require_json() { jq empty "$1" >/dev/null 2>&1 || die "$2: not valid JSON: $1" 2; }
+# Fail fast (exit 2, no stdout) unless the file is a JSON OBJECT with object-typed
+# enabledPlugins/extraKnownMarketplaces when present. `jq empty` alone accepts ANY
+# well-formed JSON (null, [], scalars), which would let a non-object slip the guard:
+# a `null` settings file reads as "fully covered", and ensure's documented
+# `> tmp && mv` could overwrite the user's file with a stub; a wrong-typed field
+# would leak a bare jq exit 5. Asserting shape collapses every malformed input into
+# the advertised exit 2.
+require_json() {
+  jq -e '
+    type == "object"
+    and ((.enabledPlugins // {})        | type == "object")
+    and ((.extraKnownMarketplaces // {}) | type == "object")
+  ' "$1" >/dev/null 2>&1 \
+    || die "$2: must be a JSON object with object-typed enabledPlugins/extraKnownMarketplaces: $1" 2
+}
 
 usage() {
   cat >&2 <<'EOF'
@@ -86,7 +97,10 @@ cmd_ensure() {
   [ -f "$settings" ] || die "ensure: no such file: $settings" 2
   [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
   require_json "$settings" ensure
-  require_json "$MARKETPLACES" ensure
+  # The lookup must itself be an object with an object .marketplaces, or the reduce
+  # below would leak a bare jq exit 5 instead of the advertised exit 2.
+  jq -e 'type == "object" and (.marketplaces | type == "object")' "$MARKETPLACES" >/dev/null 2>&1 \
+    || die "ensure: marketplaces lookup must be an object with an object .marketplaces: $MARKETPLACES" 2
 
   lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
 

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -67,13 +67,23 @@ surfaced, never masked. Keep the chain in mind: **declared ≠ installed ≠ sur
 > the Setup-script field is for caching heavy *packages*, not plugins, and this skill does
 > not use it.
 
+> Authoritative platform facts (the web docs' "what carries over" table), the three-layer
+> architecture (declarative settings ↔ `install-deps.sh` engine ↔ `install-deps.local.sh`
+> project seam), and the hard-won anti-patterns live in
+> [`references/web-setup.rst`](references/web-setup.rst). Read it before bootstrapping an
+> unfamiliar repo, and to debug a "declared but not installed" plugin.
+
 ## Phase 0 — Confirm context
 
 - Confirm you are at the **repo root** of the repo to bootstrap (a `.git` dir is present).
 - Check whether `.claude/settings.json` and `.claude/scripts/` already exist — this decides
   create-fresh vs. merge for each.
-- Confirm the **target is not `agent-extensions` itself** (see the anti-pattern note in
-  Phase 2).
+- **Self-marketplace check.** If the target repo has a `.claude-plugin/marketplace.json`, it
+  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl`
+  inside `nq-rdl/agent-extensions`) installs `main`'s *published* copy into the plugin cache,
+  silently **shadowing the working-tree edits** under development. Pick the **externals** base
+  (not rdl) in Phase 2; the bundled `web-settings.sh strip-self` enforces this
+  deterministically for any marketplace repo, not just this one.
 - Ask the user only if something is ambiguous (e.g. a pre-existing `settings.json` with a
   conflicting `model`/`hooks` block). Otherwise proceed with the defaults below.
 
@@ -92,33 +102,65 @@ project. Project specifics go in the optional `install-deps.local.sh` seam (Phas
 
 If a target file already exists and differs, show the diff and ask before overwriting.
 
-## Phase 2 — Merge `.claude/settings.json`
+## Phase 2 — Choose a base template and merge `.claude/settings.json`
 
-The template is `assets/settings.json.tmpl`. It registers the **`rdl`** marketplace
-(`nq-rdl/agent-extensions`), enables **`rdl@rdl`** (the meta-plugin that installs every RDL
-subject plugin), wires the two SessionStart hooks
-(`.claude/scripts/install-deps.sh` and `.claude/scripts/announce-capabilities.sh`), and sets
-opinionated defaults (`model: opus`, `alwaysThinkingEnabled`, `effortLevel: xhigh`,
-`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+Two complete templates ship in `assets/`. The skill **composes** the right `enabledPlugins`
+on a chosen base and lets the bundled helper `scripts/web-settings.sh` make the marketplace
+wiring deterministic — it never concatenates two templates. `web-settings.sh` is a
+**setup-time** tool; it is **not** copied into the target repo. It lives in **this skill's
+own `scripts/` directory** (the directory this `SKILL.md` is in) — not in the target repo and
+not on `PATH` — so the model's cwd (the target repo root) cannot find it by name. Resolve its
+absolute path once and reuse it:
 
-- **If `.claude/settings.json` is absent:** create `.claude/` and write the template verbatim.
-- **If it exists:** perform an **idempotent JSON-aware deep-merge** (use `jq` or a careful
-  read-modify-write), and **show the diff before writing**:
-  - `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
-  - `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the
-    two hook commands **only if not already present** (dedupe by exact command string).
-  - `enabledPlugins`: add `"rdl@rdl": true` (or specific RDL subjects the repo wants).
-  - `extraKnownMarketplaces`: add the `rdl` entry; leave any existing marketplaces intact.
-  - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never
-    override a deliberate user choice. Mention they are opinionated defaults.
+```bash
+WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
+```
 
-> **Anti-pattern — never enable a self-referential marketplace in its own dev env.**
-> `rdl@rdl` is fine for a *consumer* repo (the platform installs the catalog from a remote
-> marketplace). It is **not** fine inside `agent-extensions` itself: there it re-clones the
-> repo and fans out to dozens of dependency plugins — and since the docs require the install
-> to *reach its marketplace source*, that self-cloning batch breaks the session-start
-> install so **nothing** surfaces. If you ever bootstrap the catalog repo itself, declare a
-> small set of **external** dev-helper plugins instead.
+| Base | File | Use for |
+|---|---|---|
+| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
+| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
+
+Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
+`alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
+
+1. **Pick the base** per the table. For *rdl + externals* (a consumer wanting both), start
+   from the externals base and add `"rdl@rdl": true` to `enabledPlugins`.
+2. **Tailor the external set** from `assets/marketplaces.json` (`teamExternals`) by the
+   repo's language: always offer the `agnostic`-tagged (superpowers, pr-review-toolkit,
+   codex); add `go`-tagged for a Go repo, `python`-tagged (astral) for Python, `workflow`
+   (worktrunk) as desired. Present the menu and let the user confirm — do not silently decide.
+3. **Strip self-references (Phase 0 enforcement):**
+   ```bash
+   bash "$WS" strip-self "$PWD" .claude/settings.json
+   ```
+   Removes any `enabledPlugins`/marketplace that resolves to *this* repo's own
+   `.claude-plugin/marketplace.json`; a no-op passthrough when there is none.
+4. **Guarantee marketplace coverage (#157):**
+   ```bash
+   bash "$WS" ensure .claude/settings.json
+   ```
+   Auto-adds every missing-but-known marketplace from `marketplaces.json`. If it exits
+   non-zero it printed an **unknown** marketplace to stderr and wrote **nothing** — **stop and
+   ask** the user for that marketplace's source, declare it, and re-run. Always keep
+   `claude-plugins-official` declared explicitly (auto-known on the local CLI, unreliable on
+   the web).
+
+**Merging into an existing `.claude/settings.json`** (idempotent; **show the diff before
+writing**):
+- `env`: add `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` without clobbering other keys.
+- `hooks.SessionStart`: find (or create) the `startup|resume` matcher group; append the two
+  hook commands **only if not already present** (dedupe by exact command string).
+- `enabledPlugins` / `extraKnownMarketplaces`: union the chosen set in, leave existing entries
+  intact, then run `strip-self` + `ensure` (steps 3–4) over the merged result.
+- `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never override a
+  deliberate user choice.
+
+> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl` inside
+> `nq-rdl/agent-extensions` installs `main`'s published catalog into the plugin cache,
+> shadowing your working-tree edits, and the self-cloning batch can break the whole
+> session-start install so **nothing** surfaces. `strip-self` removes it deterministically;
+> the externals base avoids it by construction.
 
 ## Phase 3 — Offer the project extension seam
 
@@ -152,6 +194,10 @@ are handled declaratively by the platform.
 - `bash .claude/scripts/install-deps.sh` (no env var) → an immediate no-op (exit 0, no
   output): the committed hook never disturbs a local session.
 - Validate `.claude/settings.json` parses (`jq . .claude/settings.json`).
+- **Marketplace coverage (#157):** `bash "$WS" cover .claude/settings.json` (this skill's
+  bundled helper — `$WS` from Phase 2, an absolute path) exits 0. Any line it prints is an
+  enabled plugin whose marketplace is undeclared — it would install **nothing, silently** —
+  so fix Phase 2. This checks *configuration* only; it cannot prove a cloud install succeeded.
 
 ## Phase 5 — Summarize for the user
 

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -116,6 +116,12 @@ absolute path once and reuse it:
 WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
 ```
 
+`strip-self` and `ensure` are **stdout filters** — they print the corrected document and
+do **not** edit `.claude/settings.json` in place (so you can review the diff first). Capture
+the output to a temp file and move it into place; the `&&` leaves the original untouched if
+the guard exits non-zero (e.g. `ensure`'s stop-and-ask on an unknown marketplace), which is
+exactly what you want. `cover` is a read-only assertion (no redirect needed).
+
 | Base | File | Use for |
 |---|---|---|
 | **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
@@ -132,13 +138,15 @@ Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`
    (worktrunk) as desired. Present the menu and let the user confirm — do not silently decide.
 3. **Strip self-references (Phase 0 enforcement):**
    ```bash
-   bash "$WS" strip-self "$PWD" .claude/settings.json
+   tmp="$(mktemp)"
+   bash "$WS" strip-self "$PWD" .claude/settings.json > "$tmp" && mv "$tmp" .claude/settings.json
    ```
    Removes any `enabledPlugins`/marketplace that resolves to *this* repo's own
    `.claude-plugin/marketplace.json`; a no-op passthrough when there is none.
 4. **Guarantee marketplace coverage (#157):**
    ```bash
-   bash "$WS" ensure .claude/settings.json
+   tmp="$(mktemp)"
+   bash "$WS" ensure .claude/settings.json > "$tmp" && mv "$tmp" .claude/settings.json
    ```
    Auto-adds every missing-but-known marketplace from `marketplaces.json`. If it exits
    non-zero it printed an **unknown** marketplace to stderr and wrote **nothing** — **stop and

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -113,7 +113,11 @@ not on `PATH` — so the model's cwd (the target repo root) cannot find it by na
 absolute path once and reuse it:
 
 ```bash
-WS="<absolute path to this skill>/scripts/web-settings.sh"   # the scripts/ next to this SKILL.md
+# Resolve this skill's own scripts/ dir. On an installed plugin the skill lives in
+# the plugin cache — locate the helper rather than guessing the path:
+WS="$(find "$HOME/.claude/plugins" -path '*/web-setup/scripts/web-settings.sh' 2>/dev/null | head -1)"
+# Fallback: the absolute path of the scripts/ directory beside this SKILL.md.
+WS="${WS:-<absolute path to this skill>/scripts/web-settings.sh}"
 ```
 
 `strip-self` and `ensure` are **stdout filters** — they print the corrected document and

--- a/skills/cc-web-setup/assets/marketplaces.json
+++ b/skills/cc-web-setup/assets/marketplaces.json
@@ -1,0 +1,72 @@
+{
+  "marketplaces": {
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-plugins-official" },
+      "autoUpdate": true
+    },
+    "openai-codex": {
+      "source": { "source": "github", "repo": "openai/codex-plugin-cc" },
+      "autoUpdate": true
+    },
+    "goland-claude-marketplace": {
+      "source": { "source": "github", "repo": "JetBrains/go-modern-guidelines" },
+      "autoUpdate": true
+    },
+    "astral-sh": {
+      "source": { "source": "github", "repo": "astral-sh/claude-code-plugins" },
+      "autoUpdate": true
+    },
+    "worktrunk": {
+      "source": { "source": "github", "repo": "max-sixty/worktrunk" },
+      "autoUpdate": true
+    },
+    "rdl": {
+      "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
+      "autoUpdate": true
+    }
+  },
+  "teamExternals": [
+    {
+      "id": "superpowers@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "agnostic",
+      "purpose": "brainstorming, TDD, writing-plans, systematic-debugging workflows"
+    },
+    {
+      "id": "pr-review-toolkit@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "agnostic",
+      "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.)"
+    },
+    {
+      "id": "codex@openai-codex",
+      "marketplace": "openai-codex",
+      "tag": "agnostic",
+      "purpose": "Codex bridge — /codex:rescue second-opinion reviews and rescues"
+    },
+    {
+      "id": "gopls-lsp@claude-plugins-official",
+      "marketplace": "claude-plugins-official",
+      "tag": "go",
+      "purpose": "gopls language server integration"
+    },
+    {
+      "id": "modern-go-guidelines@goland-claude-marketplace",
+      "marketplace": "goland-claude-marketplace",
+      "tag": "go",
+      "purpose": "modern Go syntax guidance"
+    },
+    {
+      "id": "astral@astral-sh",
+      "marketplace": "astral-sh",
+      "tag": "python",
+      "purpose": "ruff / ty / uv guidance for Python repos"
+    },
+    {
+      "id": "worktrunk@worktrunk",
+      "marketplace": "worktrunk",
+      "tag": "workflow",
+      "purpose": "git worktree management via the wt CLI"
+    }
+  ]
+}

--- a/skills/cc-web-setup/assets/settings.externals.json.tmpl
+++ b/skills/cc-web-setup/assets/settings.externals.json.tmpl
@@ -1,0 +1,71 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/install-deps.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/announce-capabilities.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "codex@openai-codex": true,
+    "gopls-lsp@claude-plugins-official": true,
+    "modern-go-guidelines@goland-claude-marketplace": true,
+    "astral@astral-sh": true,
+    "worktrunk@worktrunk": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      },
+      "autoUpdate": true
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      },
+      "autoUpdate": true
+    },
+    "goland-claude-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "JetBrains/go-modern-guidelines"
+      },
+      "autoUpdate": true
+    },
+    "astral-sh": {
+      "source": {
+        "source": "github",
+        "repo": "astral-sh/claude-code-plugins"
+      },
+      "autoUpdate": true
+    },
+    "worktrunk": {
+      "source": {
+        "source": "github",
+        "repo": "max-sixty/worktrunk"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/skills/cc-web-setup/references/web-setup.rst
+++ b/skills/cc-web-setup/references/web-setup.rst
@@ -78,7 +78,8 @@ and retries once, refreshing each marketplace at most once per run.
 
 A plugin the self-heal installs **surfaces from the *next* session**: Claude
 enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
-re-scans only loose ``~/.claude/skills/``, **not** the plugin install cache.
+empirically *appears* to re-scan only loose ``~/.claude/skills/``, not the plugin
+install cache (unconfirmed upstream — see ``docs/notes/claude-code-web-issues.md``).
 
 
 The two guards this skill enforces

--- a/skills/cc-web-setup/references/web-setup.rst
+++ b/skills/cc-web-setup/references/web-setup.rst
@@ -1,0 +1,127 @@
+======================================
+Claude Code on the web — setup reference
+======================================
+
+Authoritative facts, the layered architecture, and the anti-patterns behind the
+``cc-web-setup`` skill. Read this before bootstrapping an unfamiliar repo or when
+debugging a plugin that is *declared* but never *installs*.
+
+The two source-of-truth notes this distills from live in the repo and should be
+read for the full story:
+
+- ``docs/notes/claude-code-web-issues.md`` — the investigation log (why declarative
+  won, why the self-heal stays, the ``reloadSkills`` finding, the Docker note).
+- ``CONTRIBUTING.md`` § "Claude Code on the web" — why a catalog-dev session enables
+  *external* dev-helper plugins, never the catalog itself.
+
+Official docs: https://code.claude.com/docs/en/claude-code-on-the-web
+
+
+What carries over (the platform contract)
+=========================================
+
+Per the web docs' "what carries over" table, **plugins declared in**
+``.claude/settings.json`` (``extraKnownMarketplaces`` + ``enabledPlugins``) are
+*"installed at session start from the marketplace you declared. Requires network
+access to reach the marketplace source."*
+
+Consequences that drive every design choice here:
+
+- Declaring the marketplace + plugin **is the whole mechanism**. There is **no
+  Setup-script field, no** ``make``\ **, no** ``.claude/skills/`` **bake** needed for
+  plugins. ``github.com`` is on the default *Trusted* allowlist, so a github-sourced
+  marketplace is reachable by default.
+- The only failure mode is the marketplace source being unreachable, or its local
+  index being stale on a cold VM. Both are handled by the self-heal (below).
+- A cloud session is a **fresh VM with only a clone of the repo** — anything not in
+  git (or not installed by the SessionStart hook) is absent.
+
+
+The three layers
+================
+
+1. **Declarative settings (plugins).** ``.claude/settings.json`` carries
+   ``extraKnownMarketplaces`` (sources, ``autoUpdate``) and ``enabledPlugins``. The
+   platform installs them at session start. This skill ships two bases —
+   ``assets/settings.json.tmpl`` (rdl) and ``assets/settings.externals.json.tmpl``
+   (team externals, no rdl) — and ``assets/marketplaces.json`` as the single source
+   of truth for marketplace sources + the curated team-externals set.
+
+2. **The portable engine** — ``.claude/scripts/install-deps.sh``, a SessionStart
+   hook **gated on** ``CLAUDE_CODE_REMOTE=true`` (a no-op on a contributor's laptop).
+   It provisions only what the declarative path does not: per-session CLIs (``gh``,
+   and Codex when ``CODEX_AUTH_JSON`` is set), the project dev toolchain via the
+   ``install-deps.local.sh`` seam, and a cheap idempotent **plugin self-heal**
+   (``ensure_plugins``). Every step is non-fatal; the hook always exits 0.
+
+3. **The project seam** — ``.claude/scripts/install-deps.local.sh`` (optional,
+   per-repo). Language toolchains, git-hook wiring, and **starting** ``dockerd``
+   (the web runner ships the docker CLI + daemon binary but **no running daemon and
+   no systemd**, so a repo that needs containers must start it here).
+
+The chain to keep in mind: **declared ≠ installed ≠ surfaced.**
+``announce-capabilities.sh`` (the second SessionStart hook) cross-checks
+``claude plugin list`` and reports **"Enabled plugins (installed)"** vs **"⚠️
+Declared but NOT installed"**, so a reachability failure is surfaced, never masked.
+
+
+The self-heal (``ensure_plugins``)
+==================================
+
+Declarative install is primary; the self-heal is the backstop kept **deliberately**
+(it has empirically rescued installs). It reads ``enabledPlugins`` from
+``settings.json`` via ``jq``, skips ids already in ``claude plugin list``, and
+installs the rest idempotently. On a failed install it derives the marketplace from
+the ``@`` suffix, runs ``claude plugin marketplace update <mkt>`` (the refresh
+``claude plugin install`` does **not** do itself — the stale-index failure mode),
+and retries once, refreshing each marketplace at most once per run.
+
+A plugin the self-heal installs **surfaces from the *next* session**: Claude
+enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
+re-scans only loose ``~/.claude/skills/``, **not** the plugin install cache.
+
+
+The two guards this skill enforces
+==================================
+
+Run from the skill's ``scripts/web-settings.sh`` (a setup-time tool, never copied
+into the target repo):
+
+- **Self-marketplace (Phase 0)** — ``strip-self <repo-root> <settings>`` removes any
+  ``enabledPlugins``/marketplace that resolves to this repo's own
+  ``.claude-plugin/marketplace.json``. Prevents shadowing working-tree edits with the
+  published copy.
+- **Marketplace coverage (Phase 2/5, issue #157)** — ``ensure <settings>`` auto-adds
+  every missing-but-known marketplace from ``marketplaces.json`` and **stops and
+  asks** on an unknown one (it writes nothing and exits non-zero). ``cover
+  <settings>`` is the read-only assertion that every enabled plugin's ``@marketplace``
+  is declared.
+
+
+Anti-patterns — do not repeat these
+===================================
+
+These each cost a PR (or several) to learn:
+
+- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl``
+  inside ``nq-rdl/agent-extensions`` re-clones the repo and fans out to dozens of
+  dependency plugins; that oversized self-cloning batch broke the whole session-start
+  install so **nothing** surfaced. A catalog-dev env enables *external* dev-helper
+  plugins, not the catalog.
+- **A pre-snapshot Setup-script field for plugins** (``make install-deps`` / ``make
+  cc-web-setup``). Plugins already auto-install declaratively; worse, a ``make``
+  Setup-script field hard-failed *environment startup* on a CWD hiccup. The
+  Setup-script field is only worth it for heavy **non-plugin** caching.
+- **Believing "the platform registers marketplaces but does not install
+  enabledPlugins."** It does install them. An empty ``claude plugin list`` is the
+  stale-index / unreachable-source failure, not a missing platform feature.
+- **Reporting *declared* plugins as installed.** Build the banner from ``claude plugin
+  list``, not from ``settings.json``, or a missing marketplace looks healthy while the
+  slash menu is empty.
+- **A naive ``claude plugin install`` retry without ``marketplace update``.** On a
+  cold VM the index is empty; the retry re-hits the same stale index forever.
+- **Leaving ``CODEX_ACCESS_TOKEN`` set.** Codex parses it as a JWT at runtime; a
+  blob/blank value breaks every later ``codex exec`` even with a valid ``auth.json``.
+  Unset it in-process and via ``CLAUDE_ENV_FILE``.
+- **Predictable ``/tmp`` log paths.** A symlink-truncation/race vector — use ``mktemp``
+  with ``umask 077``.

--- a/skills/cc-web-setup/scripts/web-settings.sh
+++ b/skills/cc-web-setup/scripts/web-settings.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# web-settings.sh — deterministic guards for the .claude/settings.json that
+# cc-web-setup provisions. The skill (SKILL.md Phases 0/2/5) runs these instead of
+# hand-editing JSON, so the marketplace-consistency (#157) and self-marketplace
+# (#149) guards are mechanical, not prose the model might skip.
+#
+# Three subcommands, all PATH-ARG in -> STDOUT out (no stdin), VALIDATE-BEFORE-EMIT
+# (a full document is computed and only printed on success — a failure prints
+# nothing to stdout, so a caller piping the output never gets partial/corrupt JSON):
+#
+#   cover <settings.json>
+#       Phase 5 assertion. Print every enabled plugin whose @marketplace is not a
+#       key in extraKnownMarketplaces (it would install nothing, silently). Exit 1
+#       if any orphan, 0 if fully covered. Read-only.
+#
+#   ensure <settings.json>
+#       Phase 2 guard. Emit <settings.json> with every missing-but-KNOWN marketplace
+#       added from assets/marketplaces.json. If any referenced marketplace is UNKNOWN
+#       (not already declared and not in the lookup), print those marketplace names to
+#       stderr and exit 4 with NO stdout — the skill then stops and asks the user.
+#
+#   strip-self <repo-root> <settings.json>
+#       Phase 0 guard. If <repo-root>/.claude-plugin/marketplace.json exists, the repo
+#       IS a marketplace; remove every enabledPlugins entry whose @marketplace equals
+#       this repo's marketplace name and drop that marketplace from
+#       extraKnownMarketplaces (enabling it would shadow working-tree edits with main's
+#       published copy). Passthrough (emit unchanged) when the file is absent.
+#
+# Portability: POSIX-leaning bash, safe on macOS bash 3.2 — no associative arrays
+# (declare -A), no mapfile/readarray, no GNU-only flags. Requires jq.
+#
+# Asset resolution: the marketplaces lookup is found relative to THIS script, so it
+# works from both the canonical skills/cc-web-setup/scripts/ and the synced
+# plugins/claude-code/skills/web-setup/scripts/ copy. Override with
+# WEB_SETTINGS_MARKETPLACES for tests.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+MARKETPLACES="${WEB_SETTINGS_MARKETPLACES:-${SCRIPT_DIR}/../assets/marketplaces.json}"
+
+die() { printf '%s\n' "$1" >&2; exit "${2:-1}"; }
+
+command -v jq >/dev/null 2>&1 || die "web-settings.sh: jq is required but not on PATH" 3
+
+# Fail fast (exit 2, no stdout) if a settings file is not valid JSON, so every
+# subcommand has a known-good document and set -e cannot mask a parse failure as
+# an empty (and thus falsely "covered" / "no unknowns") result.
+require_json() { jq empty "$1" >/dev/null 2>&1 || die "$2: not valid JSON: $1" 2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage:
+  web-settings.sh cover <settings.json>
+  web-settings.sh ensure <settings.json>
+  web-settings.sh strip-self <repo-root> <settings.json>
+EOF
+}
+
+# List enabled plugins whose @marketplace is undeclared (or missing entirely).
+cmd_cover() {
+  [ "$#" -eq 1 ] || die "cover: expected <settings.json>" 2
+  settings="$1"
+  [ -f "$settings" ] || die "cover: no such file: $settings" 2
+  require_json "$settings" cover
+  orphans="$(jq -r '
+    (.extraKnownMarketplaces // {} | keys) as $known
+    | (.enabledPlugins // {}) | to_entries[]
+    | select(.value == true)
+    | .key as $id
+    | ($id | split("@")[1]) as $mkt
+    | select($mkt == null or ($known | index($mkt) | not))
+    | $id
+  ' "$settings")"
+  if [ -n "$orphans" ]; then
+    printf '%s\n' "$orphans"
+    exit 1
+  fi
+}
+
+# Add missing-but-known marketplaces; refuse (exit 4, no stdout) on unknowns.
+cmd_ensure() {
+  [ "$#" -eq 1 ] || die "ensure: expected <settings.json>" 2
+  settings="$1"
+  [ -f "$settings" ] || die "ensure: no such file: $settings" 2
+  [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
+  require_json "$settings" ensure
+
+  lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
+
+  # Unresolved = an enabled plugin id with NO @marketplace, or one whose marketplace
+  # is neither already declared nor in the known lookup. Report the plugin ids (so a
+  # malformed bare id surfaces too — matching cover, not silently ignored).
+  unresolved="$(jq -r --argjson lk "$lookup" '
+    (.extraKnownMarketplaces // {} | keys) as $known
+    | (.enabledPlugins // {}) | to_entries[]
+    | select(.value == true) | .key as $id
+    | ($id | split("@")[1]) as $mkt
+    | select($mkt == null or (($known | index($mkt) | not) and ($lk | has($mkt) | not)))
+    | $id
+  ' "$settings")"
+  if [ -n "$unresolved" ]; then
+    {
+      printf 'web-settings.sh ensure: enabled plugin(s) with an unresolved marketplace.\n'
+      printf 'Each id below has no @marketplace or an unknown one — fix the id or declare\n'
+      printf 'the marketplace in extraKnownMarketplaces, then re-run:\n'
+      printf '%s\n' "$unresolved"
+    } >&2
+    exit 4
+  fi
+
+  # Validate-before-emit: jq builds the complete document or errors (nothing to stdout).
+  jq --argjson lk "$lookup" '
+    . as $root
+    | ([ $root.enabledPlugins // {} | to_entries[] | select(.value == true) | .key | split("@")[1] ]
+        | map(select(. != null)) | unique) as $needed
+    | .extraKnownMarketplaces = (
+        reduce $needed[] as $mkt (($root.extraKnownMarketplaces // {});
+          if (.[$mkt] != null) then .
+          elif ($lk[$mkt] != null) then . + { ($mkt): $lk[$mkt] }
+          else . end)
+      )
+  ' "$settings"
+}
+
+# Drop self-referential plugins/marketplace when the target repo is itself a marketplace.
+cmd_strip_self() {
+  [ "$#" -eq 2 ] || die "strip-self: expected <repo-root> <settings.json>" 2
+  repo_root="$1"
+  settings="$2"
+  [ -f "$settings" ] || die "strip-self: no such file: $settings" 2
+  require_json "$settings" strip-self
+
+  mkfile="${repo_root}/.claude-plugin/marketplace.json"
+  if [ ! -f "$mkfile" ]; then
+    jq '.' "$settings"   # not a marketplace repo — passthrough (still validated)
+    return 0
+  fi
+  self="$(jq -r '.name // empty' "$mkfile")"
+  if [ -z "$self" ]; then
+    jq '.' "$settings"   # marketplace file without a name — nothing to strip (validated)
+    return 0
+  fi
+
+  jq --arg self "$self" '
+    .enabledPlugins = ((.enabledPlugins // {})
+        | with_entries(select((.key | split("@")[1]) != $self)))
+    | if (.extraKnownMarketplaces // {} | has($self))
+      then del(.extraKnownMarketplaces[$self])
+      else . end
+  ' "$settings"
+}
+
+[ "$#" -ge 1 ] || { usage; exit 2; }
+sub="$1"; shift
+case "$sub" in
+  cover)      cmd_cover "$@" ;;
+  ensure)     cmd_ensure "$@" ;;
+  strip-self) cmd_strip_self "$@" ;;
+  -h|--help|help) usage ;;
+  *) usage; exit 2 ;;
+esac

--- a/skills/cc-web-setup/scripts/web-settings.sh
+++ b/skills/cc-web-setup/scripts/web-settings.sh
@@ -86,6 +86,7 @@ cmd_ensure() {
   [ -f "$settings" ] || die "ensure: no such file: $settings" 2
   [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
   require_json "$settings" ensure
+  require_json "$MARKETPLACES" ensure
 
   lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
 
@@ -129,6 +130,8 @@ cmd_strip_self() {
   [ "$#" -eq 2 ] || die "strip-self: expected <repo-root> <settings.json>" 2
   repo_root="$1"
   settings="$2"
+  # Fail fast on a bad repo-root rather than silently skipping the Phase 0 guard.
+  [ -d "$repo_root" ] || die "strip-self: not a directory: $repo_root" 2
   [ -f "$settings" ] || die "strip-self: no such file: $settings" 2
   require_json "$settings" strip-self
 
@@ -137,9 +140,11 @@ cmd_strip_self() {
     jq '.' "$settings"   # not a marketplace repo — passthrough (still validated)
     return 0
   fi
+  # A present marketplace file must be valid JSON, or we cannot trust the guard.
+  require_json "$mkfile" strip-self
   self="$(jq -r '.name // empty' "$mkfile")"
   if [ -z "$self" ]; then
-    jq '.' "$settings"   # marketplace file without a name — nothing to strip (validated)
+    jq '.' "$settings"   # valid marketplace file but no name — nothing to strip
     return 0
   fi
 

--- a/skills/cc-web-setup/scripts/web-settings.sh
+++ b/skills/cc-web-setup/scripts/web-settings.sh
@@ -44,10 +44,21 @@ die() { printf '%s\n' "$1" >&2; exit "${2:-1}"; }
 
 command -v jq >/dev/null 2>&1 || die "web-settings.sh: jq is required but not on PATH" 3
 
-# Fail fast (exit 2, no stdout) if a settings file is not valid JSON, so every
-# subcommand has a known-good document and set -e cannot mask a parse failure as
-# an empty (and thus falsely "covered" / "no unknowns") result.
-require_json() { jq empty "$1" >/dev/null 2>&1 || die "$2: not valid JSON: $1" 2; }
+# Fail fast (exit 2, no stdout) unless the file is a JSON OBJECT with object-typed
+# enabledPlugins/extraKnownMarketplaces when present. `jq empty` alone accepts ANY
+# well-formed JSON (null, [], scalars), which would let a non-object slip the guard:
+# a `null` settings file reads as "fully covered", and ensure's documented
+# `> tmp && mv` could overwrite the user's file with a stub; a wrong-typed field
+# would leak a bare jq exit 5. Asserting shape collapses every malformed input into
+# the advertised exit 2.
+require_json() {
+  jq -e '
+    type == "object"
+    and ((.enabledPlugins // {})        | type == "object")
+    and ((.extraKnownMarketplaces // {}) | type == "object")
+  ' "$1" >/dev/null 2>&1 \
+    || die "$2: must be a JSON object with object-typed enabledPlugins/extraKnownMarketplaces: $1" 2
+}
 
 usage() {
   cat >&2 <<'EOF'
@@ -86,7 +97,10 @@ cmd_ensure() {
   [ -f "$settings" ] || die "ensure: no such file: $settings" 2
   [ -f "$MARKETPLACES" ] || die "ensure: marketplaces lookup not found: $MARKETPLACES" 2
   require_json "$settings" ensure
-  require_json "$MARKETPLACES" ensure
+  # The lookup must itself be an object with an object .marketplaces, or the reduce
+  # below would leak a bare jq exit 5 instead of the advertised exit 2.
+  jq -e 'type == "object" and (.marketplaces | type == "object")' "$MARKETPLACES" >/dev/null 2>&1 \
+    || die "ensure: marketplaces lookup must be an object with an object .marketplaces: $MARKETPLACES" 2
 
   lookup="$(jq -c '.marketplaces' "$MARKETPLACES")"
 

--- a/tests/test_web_setup_templates.py
+++ b/tests/test_web_setup_templates.py
@@ -305,6 +305,34 @@ class TestWebSettingsHelper(unittest.TestCase):
         # Whole document unchanged (not just enabledPlugins) for the passthrough path.
         self.assertEqual(json.loads(res.stdout), self.externals)
 
+    def test_strip_self_rejects_nonexistent_repo_root(self):
+        # A bad repo-root must fail fast, not silently skip the Phase 0 guard.
+        path = self._write(self.externals)
+        res = run_helper(HELPER, "strip-self", os.path.join(self.tmp, "nope"), path)
+        self.assertEqual(res.returncode, 2)
+        self.assertEqual(res.stdout, "")
+
+    def test_strip_self_rejects_malformed_marketplace_json(self):
+        root = tempfile.mkdtemp(dir=self.tmp)
+        plugin_dir = Path(root) / ".claude-plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "marketplace.json").write_text("{not valid json,,}")
+        path = self._write(self.externals)
+        res = run_helper(HELPER, "strip-self", root, path)
+        self.assertEqual(res.returncode, 2)
+        self.assertEqual(res.stdout, "")
+
+    def test_ensure_rejects_malformed_marketplaces_lookup(self):
+        bad = os.path.join(self.tmp, "bad-marketplaces.json")
+        with open(bad, "w") as fh:
+            fh.write("{not valid json")
+        path = self._write(
+            {"enabledPlugins": {"superpowers@claude-plugins-official": True}, "extraKnownMarketplaces": {}}
+        )
+        res = run_helper(HELPER, "ensure", path, env={"WEB_SETTINGS_MARKETPLACES": bad})
+        self.assertEqual(res.returncode, 2)
+        self.assertEqual(res.stdout, "")
+
     # --- dual-path asset resolution ---
     @unittest.skipUnless(SYNCED_HELPER.is_file(), "synced plugin copy not present (run sync-plugins)")
     def test_synced_copy_resolves_marketplaces(self):

--- a/tests/test_web_setup_templates.py
+++ b/tests/test_web_setup_templates.py
@@ -1,0 +1,320 @@
+"""Tests for the cc-web-setup portable web-bootstrap assets.
+
+These guard the data and helper that `/claude-code:web-setup` ships into other
+repos: the two settings templates, the `marketplaces.json` single source of
+truth, and the `web-settings.sh` guard helper (cover/ensure/strip-self). They are
+the durable defence against regressing #157 (every enabled plugin's marketplace
+must be declared in extraKnownMarketplaces) and against the templates drifting
+from the marketplace source of truth or the engine assets being silently edited.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILL = REPO / "skills" / "cc-web-setup"
+ASSETS = SKILL / "assets"
+SCRIPTS = SKILL / "scripts"
+
+MARKETPLACES = ASSETS / "marketplaces.json"
+RDL_TMPL = ASSETS / "settings.json.tmpl"
+EXT_TMPL = ASSETS / "settings.externals.json.tmpl"
+HELPER = SCRIPTS / "web-settings.sh"
+SYNCED_HELPER = REPO / "plugins" / "claude-code" / "skills" / "web-setup" / "scripts" / "web-settings.sh"
+LIVE_SCRIPTS = REPO / ".claude" / "scripts"
+
+# The two SessionStart hook commands, in the exact order the platform must run them.
+HOOK_CMDS = [
+    '"$CLAUDE_PROJECT_DIR"/.claude/scripts/install-deps.sh',
+    '"$CLAUDE_PROJECT_DIR"/.claude/scripts/announce-capabilities.sh',
+]
+
+HAVE_JQ = shutil.which("jq") is not None
+
+
+def load(path):
+    return json.loads(path.read_text())
+
+
+def session_start_commands(settings):
+    """Return the ordered list of SessionStart command strings in a settings dict."""
+    groups = settings.get("hooks", {}).get("SessionStart", [])
+    cmds = []
+    for group in groups:
+        for hook in group.get("hooks", []):
+            cmds.append(hook.get("command"))
+    return cmds
+
+
+def run_helper(helper, *args, env=None):
+    extra = dict(os.environ)
+    if env:
+        extra.update(env)
+    return subprocess.run(
+        ["bash", str(helper), *args],
+        capture_output=True,
+        text=True,
+        env=extra,
+    )
+
+
+class TestMarketplacesJson(unittest.TestCase):
+    """assets/marketplaces.json is the source of truth; it must be internally sound."""
+
+    def setUp(self):
+        self.data = load(MARKETPLACES)
+        self.marketplaces = self.data["marketplaces"]
+        self.externals = self.data["teamExternals"]
+
+    def test_marketplace_entries_use_nested_schema(self):
+        for name, entry in self.marketplaces.items():
+            with self.subTest(marketplace=name):
+                src = entry["source"]
+                self.assertIsInstance(src, dict, "source must be a nested object")
+                self.assertEqual(src["source"], "github")
+                self.assertIsInstance(src["repo"], str)
+                self.assertRegex(src["repo"], r"^[^/]+/[^/]+$")
+                self.assertIsInstance(entry["autoUpdate"], bool)
+
+    def test_every_external_references_a_known_marketplace(self):
+        for ext in self.externals:
+            with self.subTest(plugin=ext["id"]):
+                name, _, mkt = ext["id"].partition("@")
+                self.assertTrue(name and mkt, f"id must be name@marketplace: {ext['id']}")
+                self.assertEqual(mkt, ext["marketplace"], "id suffix must match marketplace field")
+                self.assertIn(ext["marketplace"], self.marketplaces)
+
+    def test_externals_have_tags(self):
+        for ext in self.externals:
+            with self.subTest(plugin=ext["id"]):
+                self.assertIn(ext["tag"], {"agnostic", "go", "python", "workflow"})
+
+    def test_rdl_is_lookup_only_not_a_team_external(self):
+        # rdl is in the lookup (for the rdl+externals composition path) but must never be
+        # a curated team external, or strip-self's self-marketplace target would reappear.
+        for ext in self.externals:
+            with self.subTest(plugin=ext["id"]):
+                self.assertNotEqual(ext["marketplace"], "rdl")
+                self.assertNotEqual(ext["id"], "rdl@rdl")
+
+
+class TestTemplates(unittest.TestCase):
+    """The contract every shipped settings template must satisfy (both checked)."""
+
+    TEMPLATES = {"rdl": RDL_TMPL, "externals": EXT_TMPL}
+
+    def test_two_session_start_hooks_in_order(self):
+        for label, path in self.TEMPLATES.items():
+            with self.subTest(template=label):
+                self.assertEqual(session_start_commands(load(path)), HOOK_CMDS)
+
+    def test_enabled_plugins_are_true_and_qualified(self):
+        for label, path in self.TEMPLATES.items():
+            enabled = load(path).get("enabledPlugins", {})
+            self.assertTrue(enabled, f"{label}: must enable at least one plugin")
+            for pid, val in enabled.items():
+                with self.subTest(template=label, plugin=pid):
+                    self.assertIs(val, True)
+                    name, _, mkt = pid.partition("@")
+                    self.assertTrue(name and mkt, f"plugin id must be name@marketplace: {pid}")
+
+    def test_every_enabled_marketplace_is_declared(self):
+        # The #157 invariant: no enabled plugin may reference an undeclared marketplace.
+        for label, path in self.TEMPLATES.items():
+            settings = load(path)
+            declared = set(settings.get("extraKnownMarketplaces", {}))
+            for pid in settings.get("enabledPlugins", {}):
+                mkt = pid.split("@", 1)[1]
+                with self.subTest(template=label, plugin=pid):
+                    self.assertIn(mkt, declared, f"{pid} references undeclared marketplace {mkt}")
+
+    def test_marketplace_schema_and_source_of_truth(self):
+        lookup = load(MARKETPLACES)["marketplaces"]
+        for label, path in self.TEMPLATES.items():
+            for name, entry in load(path).get("extraKnownMarketplaces", {}).items():
+                with self.subTest(template=label, marketplace=name):
+                    src = entry["source"]
+                    self.assertIsInstance(src, dict)
+                    self.assertEqual(src["source"], "github")
+                    self.assertIsInstance(src["repo"], str)
+                    self.assertIsInstance(entry["autoUpdate"], bool)
+                    # Must match the single source of truth.
+                    self.assertIn(name, lookup, f"{name} absent from marketplaces.json")
+                    # Full-entry match (source object + autoUpdate), not just repo, so an
+                    # autoUpdate flip or a nested-shape typo can't drift from the SoT.
+                    self.assertEqual(
+                        entry, lookup[name],
+                        f"{name} in {label} template drifted from marketplaces.json",
+                    )
+
+
+class TestTemplateExactSets(unittest.TestCase):
+    def test_rdl_template_enables_exactly_rdl(self):
+        self.assertEqual(load(RDL_TMPL)["enabledPlugins"], {"rdl@rdl": True})
+
+    def test_externals_template_matches_team_externals_and_excludes_rdl(self):
+        external_ids = {e["id"] for e in load(MARKETPLACES)["teamExternals"]}
+        enabled = load(EXT_TMPL)["enabledPlugins"]
+        self.assertEqual(set(enabled), external_ids)
+        self.assertNotIn("rdl@rdl", enabled)
+
+
+class TestEngineByteIdentity(unittest.TestCase):
+    """Invariant 0.1: the proven engine assets are never edited by this work."""
+
+    @unittest.skipUnless(LIVE_SCRIPTS.is_dir(), "no live .claude/scripts to compare")
+    def test_engine_assets_match_live_copies(self):
+        for name in ("install-deps.sh", "announce-capabilities.sh"):
+            with self.subTest(asset=name):
+                self.assertEqual(
+                    (ASSETS / name).read_bytes(),
+                    (LIVE_SCRIPTS / name).read_bytes(),
+                    f"{name} drifted from the live .claude/scripts copy",
+                )
+
+
+class TestPortabilityLint(unittest.TestCase):
+    """web-settings.sh must stay bash-3.2 / macOS safe (no GNU/bash-4-only constructs)."""
+
+    def test_no_bash4_or_gnu_only_constructs(self):
+        # Scan code only — the header comment legitimately names these constructs.
+        code = "\n".join(
+            ln for ln in HELPER.read_text().splitlines() if not ln.lstrip().startswith("#")
+        )
+        for bad in ("declare -A", "mapfile", "readarray"):
+            self.assertNotIn(bad, code, f"web-settings.sh uses non-portable {bad!r}")
+
+
+@unittest.skipUnless(HAVE_JQ, "jq not available")
+class TestWebSettingsHelper(unittest.TestCase):
+    """Behavioural tests for the cover/ensure/strip-self guard helper."""
+
+    def _write(self, obj):
+        fd, path = tempfile.mkstemp(suffix=".json", dir=self.tmp)
+        with os.fdopen(fd, "w") as fh:
+            json.dump(obj, fh)
+        return path
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.externals = load(EXT_TMPL)
+
+    # --- cover ---
+    def test_cover_passes_on_covered_template(self):
+        res = run_helper(HELPER, "cover", str(EXT_TMPL))
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "")
+
+    def test_cover_flags_orphan(self):
+        path = self._write({"enabledPlugins": {"foo@bar": True}, "extraKnownMarketplaces": {}})
+        res = run_helper(HELPER, "cover", path)
+        self.assertEqual(res.returncode, 1)
+        self.assertIn("foo@bar", res.stdout)
+
+    # --- ensure ---
+    def test_ensure_adds_known_marketplace(self):
+        both = dict(self.externals)
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        path = self._write(both)
+        res = run_helper(HELPER, "ensure", path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        out = json.loads(res.stdout)
+        self.assertEqual(len(out["extraKnownMarketplaces"]), 6)
+        self.assertIn("rdl", out["extraKnownMarketplaces"])
+
+    def test_ensure_is_noop_when_complete(self):
+        res = run_helper(HELPER, "ensure", str(EXT_TMPL))
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(len(json.loads(res.stdout)["extraKnownMarketplaces"]), 5)
+
+    def test_ensure_unknown_emits_no_stdout_and_exits_4(self):
+        path = self._write({"enabledPlugins": {"x@mystery": True}, "extraKnownMarketplaces": {}})
+        res = run_helper(HELPER, "ensure", path)
+        self.assertEqual(res.returncode, 4)
+        self.assertEqual(res.stdout, "", "must not emit partial JSON on failure")
+        self.assertIn("mystery", res.stderr)
+
+    def test_ensure_rejects_unqualified_plugin_id(self):
+        # A bare id with no @marketplace can never install; ensure must flag it (exit 4,
+        # no stdout) rather than silently ignore it.
+        path = self._write({"enabledPlugins": {"superpowers": True}, "extraKnownMarketplaces": {}})
+        res = run_helper(HELPER, "ensure", path)
+        self.assertEqual(res.returncode, 4)
+        self.assertEqual(res.stdout, "")
+        self.assertIn("superpowers", res.stderr)
+
+    def test_cover_rejects_malformed_json(self):
+        path = os.path.join(self.tmp, "bad.json")
+        with open(path, "w") as fh:
+            fh.write("{not valid json,,}")
+        res = run_helper(HELPER, "cover", path)
+        self.assertEqual(res.returncode, 2)
+        self.assertEqual(res.stdout, "")
+
+    def test_composed_rdl_plus_externals(self):
+        # The 'rdl + externals' outcome: externals template + the single rdl line,
+        # reconciled by ensure. No duplicate hooks, exactly one rdl@rdl, all 8
+        # plugins, 6 marketplaces.
+        both = dict(self.externals)
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        path = self._write(both)
+        res = run_helper(HELPER, "ensure", path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        out = json.loads(res.stdout)
+        self.assertEqual(session_start_commands(out), HOOK_CMDS)
+        self.assertEqual(len(out["enabledPlugins"]), 8)
+        self.assertIs(out["enabledPlugins"]["rdl@rdl"], True)
+        self.assertEqual(len(out["extraKnownMarketplaces"]), 6)
+
+    # --- strip-self ---
+    def _marketplace_repo(self, name="rdl"):
+        root = tempfile.mkdtemp(dir=self.tmp)
+        plugin_dir = Path(root) / ".claude-plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "marketplace.json").write_text(
+            json.dumps({"name": name, "plugins": [{"name": "go", "source": "./plugins/go"}]})
+        )
+        return root
+
+    def test_strip_self_removes_self_reference(self):
+        both = dict(self.externals)
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        both["extraKnownMarketplaces"] = dict(
+            both["extraKnownMarketplaces"],
+            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+        )
+        path = self._write(both)
+        root = self._marketplace_repo("rdl")
+        res = run_helper(HELPER, "strip-self", root, path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        out = json.loads(res.stdout)
+        self.assertNotIn("rdl@rdl", out["enabledPlugins"])
+        self.assertNotIn("rdl", out["extraKnownMarketplaces"])
+        self.assertEqual(len(out["enabledPlugins"]), 7)
+
+    def test_strip_self_passthrough_when_not_a_marketplace(self):
+        path = self._write(self.externals)
+        res = run_helper(HELPER, "strip-self", self.tmp, path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        # Whole document unchanged (not just enabledPlugins) for the passthrough path.
+        self.assertEqual(json.loads(res.stdout), self.externals)
+
+    # --- dual-path asset resolution ---
+    @unittest.skipUnless(SYNCED_HELPER.is_file(), "synced plugin copy not present (run sync-plugins)")
+    def test_synced_copy_resolves_marketplaces(self):
+        both = dict(self.externals)
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        path = self._write(both)
+        res = run_helper(SYNCED_HELPER, "ensure", path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(len(json.loads(res.stdout)["extraKnownMarketplaces"]), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_setup_templates.py
+++ b/tests/test_web_setup_templates.py
@@ -205,6 +205,12 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.tmp)
         self.externals = load(EXT_TMPL)
 
+    def _externals_plus_rdl(self):
+        """The 'rdl + externals' composition: the 7 externals + rdl@rdl enabled."""
+        both = dict(self.externals)
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        return both
+
     # --- cover ---
     def test_cover_passes_on_covered_template(self):
         res = run_helper(HELPER, "cover", str(EXT_TMPL))
@@ -219,19 +225,26 @@ class TestWebSettingsHelper(unittest.TestCase):
 
     # --- ensure ---
     def test_ensure_adds_known_marketplace(self):
-        both = dict(self.externals)
-        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
-        path = self._write(both)
+        path = self._write(self._externals_plus_rdl())
         res = run_helper(HELPER, "ensure", path)
         self.assertEqual(res.returncode, 0, res.stderr)
         out = json.loads(res.stdout)
-        self.assertEqual(len(out["extraKnownMarketplaces"]), 6)
-        self.assertIn("rdl", out["extraKnownMarketplaces"])
+        # Assert the exact key set, so "right count, wrong marketplace" can't pass.
+        self.assertEqual(
+            set(out["extraKnownMarketplaces"]),
+            {
+                "claude-plugins-official", "openai-codex", "goland-claude-marketplace",
+                "astral-sh", "worktrunk", "rdl",
+            },
+        )
 
     def test_ensure_is_noop_when_complete(self):
         res = run_helper(HELPER, "ensure", str(EXT_TMPL))
         self.assertEqual(res.returncode, 0, res.stderr)
-        self.assertEqual(len(json.loads(res.stdout)["extraKnownMarketplaces"]), 5)
+        self.assertEqual(
+            set(json.loads(res.stdout)["extraKnownMarketplaces"]),
+            set(self.externals["extraKnownMarketplaces"]),
+        )
 
     def test_ensure_unknown_emits_no_stdout_and_exits_4(self):
         path = self._write({"enabledPlugins": {"x@mystery": True}, "extraKnownMarketplaces": {}})
@@ -260,17 +273,20 @@ class TestWebSettingsHelper(unittest.TestCase):
     def test_composed_rdl_plus_externals(self):
         # The 'rdl + externals' outcome: externals template + the single rdl line,
         # reconciled by ensure. No duplicate hooks, exactly one rdl@rdl, all 8
-        # plugins, 6 marketplaces.
-        both = dict(self.externals)
-        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        # plugins, 6 marketplaces, and top-level keys preserved.
+        both = self._externals_plus_rdl()
         path = self._write(both)
         res = run_helper(HELPER, "ensure", path)
         self.assertEqual(res.returncode, 0, res.stderr)
         out = json.loads(res.stdout)
         self.assertEqual(session_start_commands(out), HOOK_CMDS)
-        self.assertEqual(len(out["enabledPlugins"]), 8)
+        self.assertEqual(set(out["enabledPlugins"]), set(both["enabledPlugins"]))
         self.assertIs(out["enabledPlugins"]["rdl@rdl"], True)
+        self.assertIn("rdl", out["extraKnownMarketplaces"])
         self.assertEqual(len(out["extraKnownMarketplaces"]), 6)
+        # ensure must only touch extraKnownMarketplaces — model/env/effortLevel survive.
+        for key in ("model", "env", "effortLevel"):
+            self.assertEqual(out.get(key), both.get(key))
 
     # --- strip-self ---
     def _marketplace_repo(self, name="rdl"):
@@ -283,8 +299,7 @@ class TestWebSettingsHelper(unittest.TestCase):
         return root
 
     def test_strip_self_removes_self_reference(self):
-        both = dict(self.externals)
-        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        both = self._externals_plus_rdl()
         both["extraKnownMarketplaces"] = dict(
             both["extraKnownMarketplaces"],
             rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
@@ -296,7 +311,24 @@ class TestWebSettingsHelper(unittest.TestCase):
         out = json.loads(res.stdout)
         self.assertNotIn("rdl@rdl", out["enabledPlugins"])
         self.assertNotIn("rdl", out["extraKnownMarketplaces"])
-        self.assertEqual(len(out["enabledPlugins"]), 7)
+        self.assertEqual(set(out["enabledPlugins"]), set(self.externals["enabledPlugins"]))
+
+    def test_strip_self_keeps_a_differently_named_marketplace(self):
+        # strip-self must remove ONLY its own marketplace name, never a foreign one.
+        settings = {
+            "enabledPlugins": {"rdl@rdl": True, "foo@other": True},
+            "extraKnownMarketplaces": {
+                "rdl": {"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+                "other": {"source": {"source": "github", "repo": "acme/other"}, "autoUpdate": True},
+            },
+        }
+        path = self._write(settings)
+        root = self._marketplace_repo("someothermarket")  # self-name matches neither
+        res = run_helper(HELPER, "strip-self", root, path)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        out = json.loads(res.stdout)
+        self.assertEqual(set(out["enabledPlugins"]), {"rdl@rdl", "foo@other"})
+        self.assertEqual(set(out["extraKnownMarketplaces"]), {"rdl", "other"})
 
     def test_strip_self_passthrough_when_not_a_marketplace(self):
         path = self._write(self.externals)
@@ -333,12 +365,74 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.assertEqual(res.returncode, 2)
         self.assertEqual(res.stdout, "")
 
+    def test_ensure_rejects_lookup_without_marketplaces_object(self):
+        # A well-formed lookup that lacks an object .marketplaces must be exit 2, not a bare jq 5.
+        bad = os.path.join(self.tmp, "no-marketplaces.json")
+        with open(bad, "w") as fh:
+            fh.write('{"teamExternals": []}')
+        path = self._write({"enabledPlugins": {"x@y": True}, "extraKnownMarketplaces": {}})
+        res = run_helper(HELPER, "ensure", path, env={"WEB_SETTINGS_MARKETPLACES": bad})
+        self.assertEqual(res.returncode, 2)
+        self.assertEqual(res.stdout, "")
+
+    # --- shape gate: valid-JSON-but-wrong-shape must collapse to exit 2, no stdout ---
+    def test_shape_gate_rejects_non_object_inputs(self):
+        for sub in ("cover", "ensure", "strip-self"):
+            for blob in ("null", "[]", '{"enabledPlugins": []}', '{"enabledPlugins": true}'):
+                with self.subTest(sub=sub, blob=blob):
+                    path = os.path.join(self.tmp, "shape.json")
+                    with open(path, "w") as fh:
+                        fh.write(blob)
+                    args = [sub, self.tmp, path] if sub == "strip-self" else [sub, path]
+                    res = run_helper(HELPER, *args)
+                    self.assertEqual(res.returncode, 2, f"{sub} {blob}: {res.stderr}")
+                    self.assertEqual(res.stdout, "", f"{sub} {blob} leaked stdout")
+
+    # --- composition: the headline #157 / Phase 0→2→5 invariants under round-trip ---
+    def test_cover_passes_on_ensure_output(self):
+        # The literal #157 invariant: ensure's result is fully covered.
+        path = self._write(self._externals_plus_rdl())
+        ensured = run_helper(HELPER, "ensure", path)
+        self.assertEqual(ensured.returncode, 0, ensured.stderr)
+        out_path = self._write(json.loads(ensured.stdout))
+        covered = run_helper(HELPER, "cover", out_path)
+        self.assertEqual(covered.returncode, 0, covered.stderr)
+        self.assertEqual(covered.stdout.strip(), "")
+
+    def test_strip_self_then_ensure_then_cover_pipeline(self):
+        # Full Phase 0→2→5 on a marketplace repo: strip the self ref, reconcile, assert covered.
+        both = self._externals_plus_rdl()
+        both["extraKnownMarketplaces"] = dict(
+            both["extraKnownMarketplaces"],
+            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+        )
+        path = self._write(both)
+        root = self._marketplace_repo("rdl")
+        stripped = run_helper(HELPER, "strip-self", root, path)
+        self.assertEqual(stripped.returncode, 0, stripped.stderr)
+        p2 = self._write(json.loads(stripped.stdout))
+        ensured = run_helper(HELPER, "ensure", p2)
+        self.assertEqual(ensured.returncode, 0, ensured.stderr)
+        p3 = self._write(json.loads(ensured.stdout))
+        covered = run_helper(HELPER, "cover", p3)
+        self.assertEqual(covered.returncode, 0, covered.stderr)
+        self.assertEqual(covered.stdout.strip(), "")
+        # No rdl left anywhere after the pipeline.
+        final = json.loads(ensured.stdout)
+        self.assertNotIn("rdl@rdl", final["enabledPlugins"])
+        self.assertNotIn("rdl", final["extraKnownMarketplaces"])
+
+    # --- dispatch contract ---
+    def test_dispatch_errors_exit_2(self):
+        for args in ([], ["bogus-subcommand"], ["cover"], ["cover", "a", "b"], ["strip-self", "only-one"]):
+            with self.subTest(args=args):
+                res = run_helper(HELPER, *args)
+                self.assertEqual(res.returncode, 2, f"{args}: rc={res.returncode}")
+
     # --- dual-path asset resolution ---
     @unittest.skipUnless(SYNCED_HELPER.is_file(), "synced plugin copy not present (run sync-plugins)")
     def test_synced_copy_resolves_marketplaces(self):
-        both = dict(self.externals)
-        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
-        path = self._write(both)
+        path = self._write(self._externals_plus_rdl())
         res = run_helper(SYNCED_HELPER, "ensure", path)
         self.assertEqual(res.returncode, 0, res.stderr)
         self.assertEqual(len(json.loads(res.stdout)["extraKnownMarketplaces"]), 6)

--- a/tests/test_web_setup_templates.py
+++ b/tests/test_web_setup_templates.py
@@ -422,6 +422,33 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.assertNotIn("rdl@rdl", final["enabledPlugins"])
         self.assertNotIn("rdl", final["extraKnownMarketplaces"])
 
+    def test_ensure_is_idempotent(self):
+        # ensure∘ensure is a fixed point: a second pass over ensure's own output is a no-op.
+        path = self._write(self._externals_plus_rdl())
+        first = run_helper(HELPER, "ensure", path)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        second = run_helper(HELPER, "ensure", self._write(json.loads(first.stdout)))
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(json.loads(second.stdout), json.loads(first.stdout))
+
+    def test_strip_self_is_idempotent_and_preserves_top_level_keys(self):
+        # strip-self∘strip-self is a fixed point, and unrelated top-level keys
+        # (model/env/effortLevel) survive the transform — not only enabledPlugins.
+        both = self._externals_plus_rdl()
+        both["extraKnownMarketplaces"] = dict(
+            both["extraKnownMarketplaces"],
+            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+        )
+        root = self._marketplace_repo("rdl")
+        first = run_helper(HELPER, "strip-self", root, self._write(both))
+        self.assertEqual(first.returncode, 0, first.stderr)
+        out = json.loads(first.stdout)
+        for key in ("model", "env", "effortLevel"):
+            self.assertEqual(out.get(key), both.get(key), f"strip-self dropped top-level {key}")
+        second = run_helper(HELPER, "strip-self", root, self._write(out))
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertEqual(json.loads(second.stdout), out)
+
     # --- dispatch contract ---
     def test_dispatch_errors_exit_2(self):
         for args in ([], ["bogus-subcommand"], ["cover"], ["cover", "a", "b"], ["strip-self", "only-one"]):


### PR DESCRIPTION
## What & why

Make the `cc-web-setup` skill reproduce the working v0.13.0 *Claude Code on the web* setup on **any team repo**, and add deterministic guards so a bootstrapped `.claude/settings.json` can't ship the silent-plugin-failure footguns #149/#157 describe. Encodes the learnings from the #135→#147→#150→#160→#162→#163→#165 arc so future repos don't re-pay that two-night cost.

## Changes

- **`assets/marketplaces.json`** — single source of truth for marketplace sources + the curated, language-tagged team-externals set.
- **`assets/settings.externals.json.tmpl`** — externals-only base (no `rdl`) beside the existing rdl baseline; the skill composes *rdl + externals* from these (no fragile template-merge).
- **`scripts/web-settings.sh`** — `cover` / `ensure` / `strip-self` guards (validate-before-emit, bash-3.2-safe). `ensure` auto-adds known marketplaces and refuses unresolved ones (**#157**); `strip-self` drops self-referential marketplaces for *any* marketplace repo, generalising the old hardcoded check (**#149**).
- **`SKILL.md`** — Phase 0 self-marketplace detection via `.claude-plugin/marketplace.json`, Phase 2 template choice + `ensure` guard, Phase 5 coverage assertion.
- **`references/web-setup.rst`** — platform "what carries over" facts, the layered architecture, and the hard-won anti-patterns.
- **`tests/test_web_setup_templates.py`** — template / source-of-truth validation + helper behaviour.

Engine assets (`install-deps.sh`, `announce-capabilities.sh`) are **deliberately unchanged** (byte-identity asserted by a test; the 49 engine hook tests still pass).

## Supersedes #159

#159 targeted a file layout (`web-bootstrap.sh` / `cc-web-setup.sh` / `Makefile.snippet`) that `main` refactored away in #161/#162/#163; its diff no longer applies. The valuable Phase 0/2/5 guard prose was salvaged here (with the Copilot-flagged `extraKnownMarketplaces` schema corrected to the nested form). #159 is being closed as superseded.

## Review trail

- Implementation plan reviewed twice by `/codex:rescue`; blockers folded into the design (asset-not-`references` for machine data, externals-only template, deterministic helper, validate-before-emit).
- `/code-review` (high) findings fixed before commit: `die()` exit-code leak, `ensure` ignoring malformed (no-`@`) ids, missing JSON validation that could falsely report "covered", `strip-self` passthrough bypassing validation, and un-runnable doc commands (now an absolute `$WS` path).

Verification: **101 unit tests pass**, `validate-plugins`, `asctl repo-check` + `asctl test`, `generate_manifests --check`, and `check_consistency` all green; canonical ↔ plugin copy in lockstep.

Closes #149
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016cV4VBBZoBTLoRYL1yCva9)_