### PR TITLE
Fix web cold-start plugin self-heal racing marketplace registration

### DIFF
--- a/.changes/unreleased/Fixed-20260623-081908.yaml
+++ b/.changes/unreleased/Fixed-20260623-081908.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed a Claude Code on the web cold-start race where the SessionStart plugin self-heal (`ensure_plugins`) ran before `extraKnownMarketplaces` were registered, so installs failed against an empty marketplace registry and the failure was misreported as a network issue; the hook now registers every declared marketplace with `claude plugin marketplace add` before installing (#181)
+time: 2026-06-23T08:19:08.067613243Z

--- a/.claude/scripts/install-deps.sh
+++ b/.claude/scripts/install-deps.sh
@@ -532,21 +532,45 @@ ensure_plugins() {
   # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
   # disk), so registering here lets the hook own the whole add → update → install
   # chain instead of depending on a registration that may not have happened yet.
-  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
-  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  #
+  # Source encoding (the `marketplace add <source>` grammar): a GitHub source pins a
+  # ref as `owner/repo@ref`, a git URL as `<git-url>#ref`. A `path` on a GitHub
+  # source (a non-default marketplace.json location) has NO `marketplace add`
+  # equivalent — only the declarative extraKnownMarketplaces entry expresses it — so
+  # such a marketplace is SKIPPED here rather than registered as the wrong catalog,
+  # and Claude Code's own declarative registration handles it. jq emits one
+  # `name<TAB>add|skip<TAB>source-or-reason` row per declared marketplace.
   if [ "$pending" -gt 0 ]; then
-    local mkt_name mkt_src
-    while IFS=$'\t' read -r mkt_name mkt_src; do
+    local mkt_name mkt_kind mkt_src mkt_out
+    while IFS=$'\t' read -r mkt_name mkt_kind mkt_src; do
+      [ -n "$mkt_name" ] || continue
+      if [ "$mkt_kind" = "skip" ]; then
+        printf 'marketplace %s: not self-healed (%s)\n' "$mkt_name" "$mkt_src" >>"$LOG"
+        continue
+      fi
       [ -n "$mkt_src" ] || continue
-      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
-        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      # `marketplace add` is idempotent but can still exit non-zero when the
+      # marketplace is already registered (see tests/e2e/marketplace-smoke.sh) — that
+      # case is benign, so an "already" message counts as success. Capture output to
+      # $LOG either way; only a genuine failure earns a WARNING.
+      if mkt_out="$(claude plugin marketplace add "$mkt_src" </dev/null 2>&1)"; then
+        printf 'marketplace %s registered via %s\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
+      elif printf '%s' "$mkt_out" | grep -qi 'already'; then
+        printf 'marketplace %s already registered (%s)\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
       else
+        printf '%s\n' "$mkt_out" >>"$LOG"
         log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
       fi
     done < <(jq -r '
       (.extraKnownMarketplaces // {}) | to_entries[]
-      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
-      | select($src != "") | "\(.key)\t\($src)"
+      | .key as $name | .value.source as $s
+      | if ($s.source == "github") and ($s.repo) then
+          if (($s.path // "") != "") then [$name, "skip", "custom marketplace.json path not expressible via marketplace add"]
+          else [$name, "add", ($s.repo + (if (($s.ref // "") != "") then "@" + $s.ref else "" end))] end
+        elif (($s.url // "") != "") then [$name, "add", ($s.url + (if (($s.ref // "") != "") then "#" + $s.ref else "" end))]
+        elif (($s.path // "") != "") then [$name, "add", $s.path]
+        else [$name, "skip", "unrecognized source shape"] end
+      | @tsv
     ' "$settings" 2>/dev/null)
   fi
 

--- a/.claude/scripts/install-deps.sh
+++ b/.claude/scripts/install-deps.sh
@@ -16,9 +16,11 @@
 #   * the project dev toolchain + services (lefthook, changie, gopls, python/jq,
 #     the Docker daemon) via the optional project seam (install-deps.local.sh);
 #   * a cheap idempotent PLUGIN SELF-HEAL (ensure_plugins) that retries the
-#     declarative install if it did not complete at session start — refreshing the
-#     marketplace index first (`claude plugin marketplace update`) so a stale local
-#     copy, not just an unreachable source, is recovered.
+#     declarative install if it did not complete at session start — first
+#     REGISTERING the declared marketplaces (`claude plugin marketplace add`, for
+#     the cold-start case where this hook outran Claude Code's own registration of
+#     extraKnownMarketplaces and the registry is still empty), then refreshing a
+#     stale index (`claude plugin marketplace update`) on a failed install.
 #
 # This engine is PORTABLE: it carries no project-specific dependencies. Anything
 # specific to one repo belongs in .claude/scripts/install-deps.local.sh (sourced
@@ -473,14 +475,20 @@ persist_path() {
 # .claude/settings.json (enabledPlugins + extraKnownMarketplaces) at session start
 # from their marketplaces — see the web docs' "what carries over" table — so this
 # is NOT the primary install path. It is a belt-and-suspenders RETRY for when that
-# did not complete. Two failure modes are covered: (1) a STALE local marketplace
-# index — the marketplace is registered but its index was never fetched/refreshed
-# before this hook ran, so `claude plugin install` fails with "Plugin not found in
-# marketplace … your local copy may be out of date"; and (2) the docs' "requires
-# network access to reach the marketplace source." `claude plugin install` does NOT
-# refresh the index itself, so on a failed install this runs `claude plugin
-# marketplace update <marketplace>` and retries once (which fixes case 1). Normally
-# every plugin is already present and this is a quiet no-op.
+# did not complete. Three failure modes are covered: (1) an EMPTY marketplace
+# registry — on a cold cloud VM this SessionStart hook can outrun Claude Code's own
+# registration of extraKnownMarketplaces, so `claude plugin install` (and even
+# `marketplace update`) fail with "Marketplace not found. Available marketplaces:"
+# (an empty list) — NOT a network error; (2) a STALE local marketplace index — the
+# marketplace is registered but its index was never refreshed, so the install fails
+# with "Plugin not found in marketplace … your local copy may be out of date"; and
+# (3) the docs' "requires network access to reach the marketplace source." To cover
+# (1) we first `claude plugin marketplace add` every declared marketplace
+# (idempotent — a no-op once on disk) so the hook owns the whole add → update →
+# install chain; `claude plugin install` does not refresh the index itself, so a
+# failed install then runs `claude plugin marketplace update <marketplace>` and
+# retries once (which fixes (2)). Normally every plugin is already present and this
+# is a quiet no-op.
 #
 # CAVEAT (timing): Claude enumerates skills at process startup, BEFORE SessionStart
 # hooks finish, so anything this retry installs surfaces from the NEXT session, not
@@ -508,6 +516,40 @@ ensure_plugins() {
   local installed_blob
   installed_blob="$(claude plugin list 2>/dev/null | awk '/^[[:space:]]*>[[:space:]]/ { print $2 }')"
 
+  # Count plugins still needing install (those NOT already in `claude plugin list`).
+  # On a cold VM this is the full set; on a warm resume it is 0 and the marketplace
+  # registration + install below are skipped, keeping the resume a quiet no-op.
+  local pending=0
+  for p in "${plugins[@]}"; do
+    printf '%s\n' "$installed_blob" | grep -qxF -- "$p" || pending=$((pending + 1))
+  done
+
+  # COLD-START RACE FIX: register the declared marketplaces BEFORE installing. On a
+  # fresh cloud VM this hook can run before Claude Code has registered
+  # extraKnownMarketplaces, leaving the registry empty — then `claude plugin install`
+  # and `claude plugin marketplace update` both fail with "Marketplace not found.
+  # Available marketplaces:" (an empty list), which is NOT a network failure.
+  # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
+  # disk), so registering here lets the hook own the whole add → update → install
+  # chain instead of depending on a registration that may not have happened yet.
+  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
+  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  if [ "$pending" -gt 0 ]; then
+    local mkt_name mkt_src
+    while IFS=$'\t' read -r mkt_name mkt_src; do
+      [ -n "$mkt_src" ] || continue
+      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
+        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      else
+        log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
+      fi
+    done < <(jq -r '
+      (.extraKnownMarketplaces // {}) | to_entries[]
+      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
+      | select($src != "") | "\(.key)\t\($src)"
+    ' "$settings" 2>/dev/null)
+  fi
+
   # $refreshed memoizes the marketplaces whose index we have already tried to
   # `marketplace update` THIS run, as a space-delimited set " <mkt> <mkt> ". Plain
   # string (not an associative array) so the hook stays bash 3.2-portable.
@@ -522,11 +564,10 @@ ensure_plugins() {
       n_ok=$((n_ok + 1))
       continue
     fi
-    # First attempt failed. The usual cause on a fresh cloud VM is a STALE local
-    # marketplace index: the marketplace is registered (from extraKnownMarketplaces)
-    # but its index was never fetched/refreshed before this hook ran, so the install
-    # reports "Plugin not found in marketplace … your local copy may be out of date —
-    # try `claude plugin marketplace update`". `claude plugin install` does NOT do
+    # First attempt failed. With the marketplace now registered (we ensured it just
+    # above), the usual remaining cause is a STALE local index: the install reports
+    # "Plugin not found in marketplace … your local copy may be out of date — try
+    # `claude plugin marketplace update`", and `claude plugin install` does NOT do
     # that refresh itself. The id is `<plugin>@<marketplace>`, so the marketplace is
     # the suffix after the last '@'.
     mkt="${p##*@}"

--- a/plugins/claude-code/skills/web-setup/assets/install-deps.sh
+++ b/plugins/claude-code/skills/web-setup/assets/install-deps.sh
@@ -532,21 +532,45 @@ ensure_plugins() {
   # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
   # disk), so registering here lets the hook own the whole add → update → install
   # chain instead of depending on a registration that may not have happened yet.
-  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
-  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  #
+  # Source encoding (the `marketplace add <source>` grammar): a GitHub source pins a
+  # ref as `owner/repo@ref`, a git URL as `<git-url>#ref`. A `path` on a GitHub
+  # source (a non-default marketplace.json location) has NO `marketplace add`
+  # equivalent — only the declarative extraKnownMarketplaces entry expresses it — so
+  # such a marketplace is SKIPPED here rather than registered as the wrong catalog,
+  # and Claude Code's own declarative registration handles it. jq emits one
+  # `name<TAB>add|skip<TAB>source-or-reason` row per declared marketplace.
   if [ "$pending" -gt 0 ]; then
-    local mkt_name mkt_src
-    while IFS=$'\t' read -r mkt_name mkt_src; do
+    local mkt_name mkt_kind mkt_src mkt_out
+    while IFS=$'\t' read -r mkt_name mkt_kind mkt_src; do
+      [ -n "$mkt_name" ] || continue
+      if [ "$mkt_kind" = "skip" ]; then
+        printf 'marketplace %s: not self-healed (%s)\n' "$mkt_name" "$mkt_src" >>"$LOG"
+        continue
+      fi
       [ -n "$mkt_src" ] || continue
-      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
-        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      # `marketplace add` is idempotent but can still exit non-zero when the
+      # marketplace is already registered (see tests/e2e/marketplace-smoke.sh) — that
+      # case is benign, so an "already" message counts as success. Capture output to
+      # $LOG either way; only a genuine failure earns a WARNING.
+      if mkt_out="$(claude plugin marketplace add "$mkt_src" </dev/null 2>&1)"; then
+        printf 'marketplace %s registered via %s\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
+      elif printf '%s' "$mkt_out" | grep -qi 'already'; then
+        printf 'marketplace %s already registered (%s)\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
       else
+        printf '%s\n' "$mkt_out" >>"$LOG"
         log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
       fi
     done < <(jq -r '
       (.extraKnownMarketplaces // {}) | to_entries[]
-      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
-      | select($src != "") | "\(.key)\t\($src)"
+      | .key as $name | .value.source as $s
+      | if ($s.source == "github") and ($s.repo) then
+          if (($s.path // "") != "") then [$name, "skip", "custom marketplace.json path not expressible via marketplace add"]
+          else [$name, "add", ($s.repo + (if (($s.ref // "") != "") then "@" + $s.ref else "" end))] end
+        elif (($s.url // "") != "") then [$name, "add", ($s.url + (if (($s.ref // "") != "") then "#" + $s.ref else "" end))]
+        elif (($s.path // "") != "") then [$name, "add", $s.path]
+        else [$name, "skip", "unrecognized source shape"] end
+      | @tsv
     ' "$settings" 2>/dev/null)
   fi
 

--- a/plugins/claude-code/skills/web-setup/assets/install-deps.sh
+++ b/plugins/claude-code/skills/web-setup/assets/install-deps.sh
@@ -16,9 +16,11 @@
 #   * the project dev toolchain + services (lefthook, changie, gopls, python/jq,
 #     the Docker daemon) via the optional project seam (install-deps.local.sh);
 #   * a cheap idempotent PLUGIN SELF-HEAL (ensure_plugins) that retries the
-#     declarative install if it did not complete at session start — refreshing the
-#     marketplace index first (`claude plugin marketplace update`) so a stale local
-#     copy, not just an unreachable source, is recovered.
+#     declarative install if it did not complete at session start — first
+#     REGISTERING the declared marketplaces (`claude plugin marketplace add`, for
+#     the cold-start case where this hook outran Claude Code's own registration of
+#     extraKnownMarketplaces and the registry is still empty), then refreshing a
+#     stale index (`claude plugin marketplace update`) on a failed install.
 #
 # This engine is PORTABLE: it carries no project-specific dependencies. Anything
 # specific to one repo belongs in .claude/scripts/install-deps.local.sh (sourced
@@ -473,14 +475,20 @@ persist_path() {
 # .claude/settings.json (enabledPlugins + extraKnownMarketplaces) at session start
 # from their marketplaces — see the web docs' "what carries over" table — so this
 # is NOT the primary install path. It is a belt-and-suspenders RETRY for when that
-# did not complete. Two failure modes are covered: (1) a STALE local marketplace
-# index — the marketplace is registered but its index was never fetched/refreshed
-# before this hook ran, so `claude plugin install` fails with "Plugin not found in
-# marketplace … your local copy may be out of date"; and (2) the docs' "requires
-# network access to reach the marketplace source." `claude plugin install` does NOT
-# refresh the index itself, so on a failed install this runs `claude plugin
-# marketplace update <marketplace>` and retries once (which fixes case 1). Normally
-# every plugin is already present and this is a quiet no-op.
+# did not complete. Three failure modes are covered: (1) an EMPTY marketplace
+# registry — on a cold cloud VM this SessionStart hook can outrun Claude Code's own
+# registration of extraKnownMarketplaces, so `claude plugin install` (and even
+# `marketplace update`) fail with "Marketplace not found. Available marketplaces:"
+# (an empty list) — NOT a network error; (2) a STALE local marketplace index — the
+# marketplace is registered but its index was never refreshed, so the install fails
+# with "Plugin not found in marketplace … your local copy may be out of date"; and
+# (3) the docs' "requires network access to reach the marketplace source." To cover
+# (1) we first `claude plugin marketplace add` every declared marketplace
+# (idempotent — a no-op once on disk) so the hook owns the whole add → update →
+# install chain; `claude plugin install` does not refresh the index itself, so a
+# failed install then runs `claude plugin marketplace update <marketplace>` and
+# retries once (which fixes (2)). Normally every plugin is already present and this
+# is a quiet no-op.
 #
 # CAVEAT (timing): Claude enumerates skills at process startup, BEFORE SessionStart
 # hooks finish, so anything this retry installs surfaces from the NEXT session, not
@@ -508,6 +516,40 @@ ensure_plugins() {
   local installed_blob
   installed_blob="$(claude plugin list 2>/dev/null | awk '/^[[:space:]]*>[[:space:]]/ { print $2 }')"
 
+  # Count plugins still needing install (those NOT already in `claude plugin list`).
+  # On a cold VM this is the full set; on a warm resume it is 0 and the marketplace
+  # registration + install below are skipped, keeping the resume a quiet no-op.
+  local pending=0
+  for p in "${plugins[@]}"; do
+    printf '%s\n' "$installed_blob" | grep -qxF -- "$p" || pending=$((pending + 1))
+  done
+
+  # COLD-START RACE FIX: register the declared marketplaces BEFORE installing. On a
+  # fresh cloud VM this hook can run before Claude Code has registered
+  # extraKnownMarketplaces, leaving the registry empty — then `claude plugin install`
+  # and `claude plugin marketplace update` both fail with "Marketplace not found.
+  # Available marketplaces:" (an empty list), which is NOT a network failure.
+  # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
+  # disk), so registering here lets the hook own the whole add → update → install
+  # chain instead of depending on a registration that may not have happened yet.
+  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
+  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  if [ "$pending" -gt 0 ]; then
+    local mkt_name mkt_src
+    while IFS=$'\t' read -r mkt_name mkt_src; do
+      [ -n "$mkt_src" ] || continue
+      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
+        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      else
+        log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
+      fi
+    done < <(jq -r '
+      (.extraKnownMarketplaces // {}) | to_entries[]
+      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
+      | select($src != "") | "\(.key)\t\($src)"
+    ' "$settings" 2>/dev/null)
+  fi
+
   # $refreshed memoizes the marketplaces whose index we have already tried to
   # `marketplace update` THIS run, as a space-delimited set " <mkt> <mkt> ". Plain
   # string (not an associative array) so the hook stays bash 3.2-portable.
@@ -522,11 +564,10 @@ ensure_plugins() {
       n_ok=$((n_ok + 1))
       continue
     fi
-    # First attempt failed. The usual cause on a fresh cloud VM is a STALE local
-    # marketplace index: the marketplace is registered (from extraKnownMarketplaces)
-    # but its index was never fetched/refreshed before this hook ran, so the install
-    # reports "Plugin not found in marketplace … your local copy may be out of date —
-    # try `claude plugin marketplace update`". `claude plugin install` does NOT do
+    # First attempt failed. With the marketplace now registered (we ensured it just
+    # above), the usual remaining cause is a STALE local index: the install reports
+    # "Plugin not found in marketplace … your local copy may be out of date — try
+    # `claude plugin marketplace update`", and `claude plugin install` does NOT do
     # that refresh itself. The id is `<plugin>@<marketplace>`, so the marketplace is
     # the suffix after the last '@'.
     mkt="${p##*@}"

--- a/plugins/claude-code/skills/web-setup/scripts/test-install-deps.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/test-install-deps.sh
@@ -370,7 +370,14 @@ case "$1 $2" in
     echo "Plugin \"$p\" not found in marketplace \"$mkt\"; your local copy may be out of date." >&2
     exit 1 ;;
   "plugin marketplace")
-    if [ "$3" = "add" ]; then printf "%s\n" "$4" >> "$STATE/added"; exit 0; fi
+    if [ "$3" = "add" ]; then
+      printf "%s\n" "$4" >> "$STATE/added"
+      # Model the idempotent-but-non-zero "already added" exit (see
+      # tests/e2e/marketplace-smoke.sh): if $4 is listed in $STATE/already, exit 1 with
+      # an "already" message so the hook can prove it treats that as benign.
+      if grep -qxF "$4" "$STATE/already" 2>/dev/null; then echo "Marketplace already added: $4"; exit 1; fi
+      exit 0
+    fi
     [ "$3" = "update" ] || exit 0
     printf "%s\n" "$4" >> "$STATE/update_attempts"
     if grep -qxF "$4" "$STATE/unreachable" 2>/dev/null; then
@@ -527,7 +534,7 @@ test_plugins_wrong_id_after_successful_refresh() {
 test_plugins_registers_marketplaces_before_install() {
   read -r d log proj state <<<"$(setup_plugins_case pp7)"
   printf 'a@m1\nb@m2\n' > "$state/declared"
-  printf 'm1\tacme/mkt-one\nm2\tacme/mkt-two\n' > "$state/declared_marketplaces"
+  printf 'm1\tadd\tacme/mkt-one\nm2\tadd\tacme/mkt-two\n' > "$state/declared_marketplaces"
   touch "$state/refreshed.m1" "$state/refreshed.m2"   # registered => index already fresh
   run_ensure_plugins "$d" "$log" "$proj" "$state"
   grep -q 'Plugin install: 2 installed, 0 failed, 0 already present' "$log" \
@@ -551,7 +558,7 @@ test_plugins_registers_marketplaces_before_install() {
 test_plugins_warm_resume_skips_registration() {
   read -r d log proj state <<<"$(setup_plugins_case pp8)"
   printf 'a@m1\n' > "$state/declared"
-  printf 'm1\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf 'm1\tadd\tacme/mkt-one\n' > "$state/declared_marketplaces"
   printf '> a@m1\n' > "$state/installed"              # already installed => pending=0
   run_ensure_plugins "$d" "$log" "$proj" "$state"
   grep -q 'Plugin install: 0 installed, 0 failed, 1 already present' "$log" \
@@ -560,6 +567,59 @@ test_plugins_warm_resume_skips_registration() {
   [ ! -s "$state/added" ] \
     && ok "plugins warm-resume: no marketplace registered when nothing to install" \
     || fail "plugins warm-resume: registered despite pending=0 ([$(cat "$state/added" 2>/dev/null)])"
+}
+
+# Comment #1 (encode ref, skip path): drive ensure_plugins with REAL jq + a real
+# settings.json so the actual source-encoding logic runs end to end (only `claude`
+# is stubbed). Asserts ref pinning (owner/repo@ref, git-url#ref) and that a GitHub
+# source carrying a custom marketplace.json `path` is SKIPPED, not mis-registered.
+test_marketplace_source_encoding() {
+  command -v jq >/dev/null 2>&1 || { skip "marketplace encoding: jq not available"; return; }
+  local d proj state log
+  d="$(new_stub_dir)"
+  ln -sf "$(command -v jq)" "$d/jq"            # real jq, replacing the cat-stub default
+  write_claude_stub "$d"
+  proj="$(mktemp -d "$WORK/enc-proj.XXXXXX")"; mkdir -p "$proj/.claude"
+  state="$(mktemp -d "$WORK/enc-state.XXXXXX")"; : > "$state/installed"
+  cat > "$proj/.claude/settings.json" <<'JSON'
+{
+  "enabledPlugins": {"a@plain": true, "b@pinned": true, "c@subdir": true, "d@viaurl": true},
+  "extraKnownMarketplaces": {
+    "plain":  {"source": {"source": "github", "repo": "acme/plain"}, "autoUpdate": true},
+    "pinned": {"source": {"source": "github", "repo": "acme/pinned", "ref": "v1.0.0"}, "autoUpdate": true},
+    "subdir": {"source": {"source": "github", "repo": "acme/subdir", "path": "catalog"}, "autoUpdate": true},
+    "viaurl": {"source": {"source": "git", "url": "https://example.com/x.git", "ref": "main"}, "autoUpdate": true}
+  }
+}
+JSON
+  log="$WORK/enc.log"
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -qxF 'acme/plain'                     "$state/added" 2>/dev/null \
+    && ok "encode: plain github -> owner/repo" || fail "encode: plain missing ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qxF 'acme/pinned@v1.0.0'             "$state/added" 2>/dev/null \
+    && ok "encode: github ref -> owner/repo@ref" || fail "encode: ref not encoded ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qxF 'https://example.com/x.git#main' "$state/added" 2>/dev/null \
+    && ok "encode: git url ref -> url#ref" || fail "encode: url ref not encoded ([$(cat "$state/added" 2>/dev/null)])"
+  grep -q 'acme/subdir' "$state/added" 2>/dev/null \
+    && fail "encode: custom-path source must be SKIPPED, not added ([$(cat "$state/added" 2>/dev/null)])" \
+    || ok "encode: custom marketplace.json path source skipped"
+}
+
+# Comment #2: `marketplace add` can exit non-zero with an "already" message; that is
+# benign and must be treated as success (logged to $LOG, never surfaced as a WARNING).
+test_plugins_already_present_add_is_benign() {
+  read -r d log proj state <<<"$(setup_plugins_case pp9)"
+  printf 'a@m1\n' > "$state/declared"
+  printf 'm1\tadd\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf 'acme/mkt-one\n' > "$state/already"   # add exits non-zero with an "already" message
+  touch "$state/refreshed.m1"
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -qF 'acme/mkt-one' "$state/added" \
+    && ok "already-add: registration was attempted" \
+    || fail "already-add: add not attempted ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qi "could not register marketplace 'm1'" "$log" \
+    && fail "already-add: spurious WARNING on benign 'already' exit. Log: $(cat "$log" 2>/dev/null)" \
+    || ok "already-add: benign 'already' treated as success (no WARNING)"
 }
 
 # ---------------------------------------------------------------------------
@@ -623,6 +683,8 @@ test_plugins_shared_marketplace_refreshes_once
 test_plugins_wrong_id_after_successful_refresh
 test_plugins_registers_marketplaces_before_install
 test_plugins_warm_resume_skips_registration
+test_marketplace_source_encoding
+test_plugins_already_present_add_is_benign
 test_gate_local_noop
 test_local_hook_sourced
 

--- a/plugins/claude-code/skills/web-setup/scripts/test-install-deps.sh
+++ b/plugins/claude-code/skills/web-setup/scripts/test-install-deps.sh
@@ -355,6 +355,7 @@ test_persist_path_readonly_warns() {
 #   * update_attempts  — one line appended per `marketplace update` INVOCATION (memoization counter)
 write_claude_stub() { # <stub_dir> ; reads $STATE at runtime
   write_stub "$1" claude '
+printf "%s\n" "$*" >> "$STATE/trace"
 case "$1 $2" in
   "plugin list")
     cat "$STATE/installed" 2>/dev/null; exit 0 ;;
@@ -369,6 +370,7 @@ case "$1 $2" in
     echo "Plugin \"$p\" not found in marketplace \"$mkt\"; your local copy may be out of date." >&2
     exit 1 ;;
   "plugin marketplace")
+    if [ "$3" = "add" ]; then printf "%s\n" "$4" >> "$STATE/added"; exit 0; fi
     [ "$3" = "update" ] || exit 0
     printf "%s\n" "$4" >> "$STATE/update_attempts"
     if grep -qxF "$4" "$STATE/unreachable" 2>/dev/null; then
@@ -393,10 +395,17 @@ setup_plugins_case() { # <tag> -> echoes "<stub_dir> <out_file> <project_dir> <s
   local tag="$1" d proj state
   d="$(new_stub_dir)"
   proj="$(mktemp -d "$WORK/${tag}-proj.XXXXXX")"; mkdir -p "$proj/.claude"; : > "$proj/.claude/settings.json"
-  state="$(mktemp -d "$WORK/${tag}-state.XXXXXX")"; : > "$state/installed"
-  # jq is stubbed to emit the declared set straight from $STATE/declared, so the
-  # tests do not depend on real jq or on parsing a real settings.json.
-  write_stub "$d" jq 'cat "$STATE/declared" 2>/dev/null'
+  state="$(mktemp -d "$WORK/${tag}-state.XXXXXX")"; : > "$state/installed"; : > "$state/declared_marketplaces"
+  # jq is stubbed to emit a declared set straight from $STATE (no real jq / no real
+  # settings.json parsing). ensure_plugins calls jq with two different programs: the
+  # enabledPlugins query (=> plugin ids from $STATE/declared) and the
+  # extraKnownMarketplaces query (=> "name<TAB>source" lines from
+  # $STATE/declared_marketplaces). Branch on the program text so one stub serves both.
+  write_stub "$d" jq '
+for a in "$@"; do
+  case "$a" in *extraKnownMarketplaces*) cat "$STATE/declared_marketplaces" 2>/dev/null; exit 0 ;; esac
+done
+cat "$STATE/declared" 2>/dev/null'
   write_claude_stub "$d"
   printf '%s %s %s %s' "$d" "$WORK/${tag}.log" "$proj" "$state"
 }
@@ -510,6 +519,49 @@ test_plugins_wrong_id_after_successful_refresh() {
     || fail "plugins wrong-id: warning text missing. Log: $(cat "$log" 2>/dev/null)"
 }
 
+# THE COLD-START RACE FIX: when the marketplace registry is empty, ensure_plugins
+# must `claude plugin marketplace add` every declared marketplace BEFORE attempting
+# installs, so the install never runs against an unregistered marketplace. Sentinels
+# are pre-seeded so the post-registration install succeeds on the first try —
+# isolating the new registration step from the stale-index retry path.
+test_plugins_registers_marketplaces_before_install() {
+  read -r d log proj state <<<"$(setup_plugins_case pp7)"
+  printf 'a@m1\nb@m2\n' > "$state/declared"
+  printf 'm1\tacme/mkt-one\nm2\tacme/mkt-two\n' > "$state/declared_marketplaces"
+  touch "$state/refreshed.m1" "$state/refreshed.m2"   # registered => index already fresh
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -q 'Plugin install: 2 installed, 0 failed, 0 already present' "$log" \
+    && ok "plugins register: both installed after registration" \
+    || fail "plugins register: wrong summary. Log: $(cat "$log" 2>/dev/null)"
+  { grep -qxF 'acme/mkt-one' "$state/added" 2>/dev/null && grep -qxF 'acme/mkt-two' "$state/added" 2>/dev/null; } \
+    && ok "plugins register: both declared marketplaces were 'marketplace add'-ed" \
+    || fail "plugins register: missing marketplace add ([$(cat "$state/added" 2>/dev/null)])"
+  # Ordering: the LAST 'marketplace add' must precede the FIRST 'plugin install'.
+  local last_add first_install
+  last_add="$(grep -n 'marketplace add' "$state/trace" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
+  first_install="$(grep -n 'plugin install' "$state/trace" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  { [ -n "$last_add" ] && [ -n "$first_install" ] && [ "$last_add" -lt "$first_install" ]; } \
+    && ok "plugins register: all marketplace adds precede the first install" \
+    || fail "plugins register: add/install order wrong (add@${last_add:-?} install@${first_install:-?})."
+}
+
+# The registration step is gated on $pending: a warm resume where every declared
+# plugin is already installed must NOT register marketplaces, even though they are
+# declared — the whole self-heal stays a quiet no-op.
+test_plugins_warm_resume_skips_registration() {
+  read -r d log proj state <<<"$(setup_plugins_case pp8)"
+  printf 'a@m1\n' > "$state/declared"
+  printf 'm1\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf '> a@m1\n' > "$state/installed"              # already installed => pending=0
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -q 'Plugin install: 0 installed, 0 failed, 1 already present' "$log" \
+    && ok "plugins warm-resume: quiet no-op summary" \
+    || fail "plugins warm-resume: wrong summary. Log: $(cat "$log" 2>/dev/null)"
+  [ ! -s "$state/added" ] \
+    && ok "plugins warm-resume: no marketplace registered when nothing to install" \
+    || fail "plugins warm-resume: registered despite pending=0 ([$(cat "$state/added" 2>/dev/null)])"
+}
+
 # ---------------------------------------------------------------------------
 # main() gate + project hook seam (subprocess)
 # ---------------------------------------------------------------------------
@@ -569,6 +621,8 @@ test_plugins_already_present_noop
 test_plugins_unreachable_fails_after_refresh
 test_plugins_shared_marketplace_refreshes_once
 test_plugins_wrong_id_after_successful_refresh
+test_plugins_registers_marketplaces_before_install
+test_plugins_warm_resume_skips_registration
 test_gate_local_noop
 test_local_hook_sourced
 

--- a/skills/cc-web-setup/assets/install-deps.sh
+++ b/skills/cc-web-setup/assets/install-deps.sh
@@ -532,21 +532,45 @@ ensure_plugins() {
   # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
   # disk), so registering here lets the hook own the whole add → update → install
   # chain instead of depending on a registration that may not have happened yet.
-  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
-  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  #
+  # Source encoding (the `marketplace add <source>` grammar): a GitHub source pins a
+  # ref as `owner/repo@ref`, a git URL as `<git-url>#ref`. A `path` on a GitHub
+  # source (a non-default marketplace.json location) has NO `marketplace add`
+  # equivalent — only the declarative extraKnownMarketplaces entry expresses it — so
+  # such a marketplace is SKIPPED here rather than registered as the wrong catalog,
+  # and Claude Code's own declarative registration handles it. jq emits one
+  # `name<TAB>add|skip<TAB>source-or-reason` row per declared marketplace.
   if [ "$pending" -gt 0 ]; then
-    local mkt_name mkt_src
-    while IFS=$'\t' read -r mkt_name mkt_src; do
+    local mkt_name mkt_kind mkt_src mkt_out
+    while IFS=$'\t' read -r mkt_name mkt_kind mkt_src; do
+      [ -n "$mkt_name" ] || continue
+      if [ "$mkt_kind" = "skip" ]; then
+        printf 'marketplace %s: not self-healed (%s)\n' "$mkt_name" "$mkt_src" >>"$LOG"
+        continue
+      fi
       [ -n "$mkt_src" ] || continue
-      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
-        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      # `marketplace add` is idempotent but can still exit non-zero when the
+      # marketplace is already registered (see tests/e2e/marketplace-smoke.sh) — that
+      # case is benign, so an "already" message counts as success. Capture output to
+      # $LOG either way; only a genuine failure earns a WARNING.
+      if mkt_out="$(claude plugin marketplace add "$mkt_src" </dev/null 2>&1)"; then
+        printf 'marketplace %s registered via %s\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
+      elif printf '%s' "$mkt_out" | grep -qi 'already'; then
+        printf 'marketplace %s already registered (%s)\n%s\n' "$mkt_name" "$mkt_src" "$mkt_out" >>"$LOG"
       else
+        printf '%s\n' "$mkt_out" >>"$LOG"
         log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
       fi
     done < <(jq -r '
       (.extraKnownMarketplaces // {}) | to_entries[]
-      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
-      | select($src != "") | "\(.key)\t\($src)"
+      | .key as $name | .value.source as $s
+      | if ($s.source == "github") and ($s.repo) then
+          if (($s.path // "") != "") then [$name, "skip", "custom marketplace.json path not expressible via marketplace add"]
+          else [$name, "add", ($s.repo + (if (($s.ref // "") != "") then "@" + $s.ref else "" end))] end
+        elif (($s.url // "") != "") then [$name, "add", ($s.url + (if (($s.ref // "") != "") then "#" + $s.ref else "" end))]
+        elif (($s.path // "") != "") then [$name, "add", $s.path]
+        else [$name, "skip", "unrecognized source shape"] end
+      | @tsv
     ' "$settings" 2>/dev/null)
   fi
 

--- a/skills/cc-web-setup/assets/install-deps.sh
+++ b/skills/cc-web-setup/assets/install-deps.sh
@@ -16,9 +16,11 @@
 #   * the project dev toolchain + services (lefthook, changie, gopls, python/jq,
 #     the Docker daemon) via the optional project seam (install-deps.local.sh);
 #   * a cheap idempotent PLUGIN SELF-HEAL (ensure_plugins) that retries the
-#     declarative install if it did not complete at session start — refreshing the
-#     marketplace index first (`claude plugin marketplace update`) so a stale local
-#     copy, not just an unreachable source, is recovered.
+#     declarative install if it did not complete at session start — first
+#     REGISTERING the declared marketplaces (`claude plugin marketplace add`, for
+#     the cold-start case where this hook outran Claude Code's own registration of
+#     extraKnownMarketplaces and the registry is still empty), then refreshing a
+#     stale index (`claude plugin marketplace update`) on a failed install.
 #
 # This engine is PORTABLE: it carries no project-specific dependencies. Anything
 # specific to one repo belongs in .claude/scripts/install-deps.local.sh (sourced
@@ -473,14 +475,20 @@ persist_path() {
 # .claude/settings.json (enabledPlugins + extraKnownMarketplaces) at session start
 # from their marketplaces — see the web docs' "what carries over" table — so this
 # is NOT the primary install path. It is a belt-and-suspenders RETRY for when that
-# did not complete. Two failure modes are covered: (1) a STALE local marketplace
-# index — the marketplace is registered but its index was never fetched/refreshed
-# before this hook ran, so `claude plugin install` fails with "Plugin not found in
-# marketplace … your local copy may be out of date"; and (2) the docs' "requires
-# network access to reach the marketplace source." `claude plugin install` does NOT
-# refresh the index itself, so on a failed install this runs `claude plugin
-# marketplace update <marketplace>` and retries once (which fixes case 1). Normally
-# every plugin is already present and this is a quiet no-op.
+# did not complete. Three failure modes are covered: (1) an EMPTY marketplace
+# registry — on a cold cloud VM this SessionStart hook can outrun Claude Code's own
+# registration of extraKnownMarketplaces, so `claude plugin install` (and even
+# `marketplace update`) fail with "Marketplace not found. Available marketplaces:"
+# (an empty list) — NOT a network error; (2) a STALE local marketplace index — the
+# marketplace is registered but its index was never refreshed, so the install fails
+# with "Plugin not found in marketplace … your local copy may be out of date"; and
+# (3) the docs' "requires network access to reach the marketplace source." To cover
+# (1) we first `claude plugin marketplace add` every declared marketplace
+# (idempotent — a no-op once on disk) so the hook owns the whole add → update →
+# install chain; `claude plugin install` does not refresh the index itself, so a
+# failed install then runs `claude plugin marketplace update <marketplace>` and
+# retries once (which fixes (2)). Normally every plugin is already present and this
+# is a quiet no-op.
 #
 # CAVEAT (timing): Claude enumerates skills at process startup, BEFORE SessionStart
 # hooks finish, so anything this retry installs surfaces from the NEXT session, not
@@ -508,6 +516,40 @@ ensure_plugins() {
   local installed_blob
   installed_blob="$(claude plugin list 2>/dev/null | awk '/^[[:space:]]*>[[:space:]]/ { print $2 }')"
 
+  # Count plugins still needing install (those NOT already in `claude plugin list`).
+  # On a cold VM this is the full set; on a warm resume it is 0 and the marketplace
+  # registration + install below are skipped, keeping the resume a quiet no-op.
+  local pending=0
+  for p in "${plugins[@]}"; do
+    printf '%s\n' "$installed_blob" | grep -qxF -- "$p" || pending=$((pending + 1))
+  done
+
+  # COLD-START RACE FIX: register the declared marketplaces BEFORE installing. On a
+  # fresh cloud VM this hook can run before Claude Code has registered
+  # extraKnownMarketplaces, leaving the registry empty — then `claude plugin install`
+  # and `claude plugin marketplace update` both fail with "Marketplace not found.
+  # Available marketplaces:" (an empty list), which is NOT a network failure.
+  # `claude plugin marketplace add` is idempotent (a no-op once the marketplace is on
+  # disk), so registering here lets the hook own the whole add → update → install
+  # chain instead of depending on a registration that may not have happened yet.
+  # Source can be a GitHub repo, URL, or path (see `marketplace add`); the nested
+  # extraKnownMarketplaces schema carries it under .source.{repo,url,path}.
+  if [ "$pending" -gt 0 ]; then
+    local mkt_name mkt_src
+    while IFS=$'\t' read -r mkt_name mkt_src; do
+      [ -n "$mkt_src" ] || continue
+      if claude plugin marketplace add "$mkt_src" </dev/null >>"$LOG" 2>&1; then
+        printf 'marketplace %s registered (or already present)\n' "$mkt_name" >>"$LOG"
+      else
+        log "  WARNING: could not register marketplace '${mkt_name}' (${mkt_src}) — see ${LOG}."
+      fi
+    done < <(jq -r '
+      (.extraKnownMarketplaces // {}) | to_entries[]
+      | (.value.source.repo // .value.source.url // .value.source.path // "") as $src
+      | select($src != "") | "\(.key)\t\($src)"
+    ' "$settings" 2>/dev/null)
+  fi
+
   # $refreshed memoizes the marketplaces whose index we have already tried to
   # `marketplace update` THIS run, as a space-delimited set " <mkt> <mkt> ". Plain
   # string (not an associative array) so the hook stays bash 3.2-portable.
@@ -522,11 +564,10 @@ ensure_plugins() {
       n_ok=$((n_ok + 1))
       continue
     fi
-    # First attempt failed. The usual cause on a fresh cloud VM is a STALE local
-    # marketplace index: the marketplace is registered (from extraKnownMarketplaces)
-    # but its index was never fetched/refreshed before this hook ran, so the install
-    # reports "Plugin not found in marketplace … your local copy may be out of date —
-    # try `claude plugin marketplace update`". `claude plugin install` does NOT do
+    # First attempt failed. With the marketplace now registered (we ensured it just
+    # above), the usual remaining cause is a STALE local index: the install reports
+    # "Plugin not found in marketplace … your local copy may be out of date — try
+    # `claude plugin marketplace update`", and `claude plugin install` does NOT do
     # that refresh itself. The id is `<plugin>@<marketplace>`, so the marketplace is
     # the suffix after the last '@'.
     mkt="${p##*@}"

--- a/skills/cc-web-setup/scripts/test-install-deps.sh
+++ b/skills/cc-web-setup/scripts/test-install-deps.sh
@@ -370,7 +370,14 @@ case "$1 $2" in
     echo "Plugin \"$p\" not found in marketplace \"$mkt\"; your local copy may be out of date." >&2
     exit 1 ;;
   "plugin marketplace")
-    if [ "$3" = "add" ]; then printf "%s\n" "$4" >> "$STATE/added"; exit 0; fi
+    if [ "$3" = "add" ]; then
+      printf "%s\n" "$4" >> "$STATE/added"
+      # Model the idempotent-but-non-zero "already added" exit (see
+      # tests/e2e/marketplace-smoke.sh): if $4 is listed in $STATE/already, exit 1 with
+      # an "already" message so the hook can prove it treats that as benign.
+      if grep -qxF "$4" "$STATE/already" 2>/dev/null; then echo "Marketplace already added: $4"; exit 1; fi
+      exit 0
+    fi
     [ "$3" = "update" ] || exit 0
     printf "%s\n" "$4" >> "$STATE/update_attempts"
     if grep -qxF "$4" "$STATE/unreachable" 2>/dev/null; then
@@ -527,7 +534,7 @@ test_plugins_wrong_id_after_successful_refresh() {
 test_plugins_registers_marketplaces_before_install() {
   read -r d log proj state <<<"$(setup_plugins_case pp7)"
   printf 'a@m1\nb@m2\n' > "$state/declared"
-  printf 'm1\tacme/mkt-one\nm2\tacme/mkt-two\n' > "$state/declared_marketplaces"
+  printf 'm1\tadd\tacme/mkt-one\nm2\tadd\tacme/mkt-two\n' > "$state/declared_marketplaces"
   touch "$state/refreshed.m1" "$state/refreshed.m2"   # registered => index already fresh
   run_ensure_plugins "$d" "$log" "$proj" "$state"
   grep -q 'Plugin install: 2 installed, 0 failed, 0 already present' "$log" \
@@ -551,7 +558,7 @@ test_plugins_registers_marketplaces_before_install() {
 test_plugins_warm_resume_skips_registration() {
   read -r d log proj state <<<"$(setup_plugins_case pp8)"
   printf 'a@m1\n' > "$state/declared"
-  printf 'm1\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf 'm1\tadd\tacme/mkt-one\n' > "$state/declared_marketplaces"
   printf '> a@m1\n' > "$state/installed"              # already installed => pending=0
   run_ensure_plugins "$d" "$log" "$proj" "$state"
   grep -q 'Plugin install: 0 installed, 0 failed, 1 already present' "$log" \
@@ -560,6 +567,59 @@ test_plugins_warm_resume_skips_registration() {
   [ ! -s "$state/added" ] \
     && ok "plugins warm-resume: no marketplace registered when nothing to install" \
     || fail "plugins warm-resume: registered despite pending=0 ([$(cat "$state/added" 2>/dev/null)])"
+}
+
+# Comment #1 (encode ref, skip path): drive ensure_plugins with REAL jq + a real
+# settings.json so the actual source-encoding logic runs end to end (only `claude`
+# is stubbed). Asserts ref pinning (owner/repo@ref, git-url#ref) and that a GitHub
+# source carrying a custom marketplace.json `path` is SKIPPED, not mis-registered.
+test_marketplace_source_encoding() {
+  command -v jq >/dev/null 2>&1 || { skip "marketplace encoding: jq not available"; return; }
+  local d proj state log
+  d="$(new_stub_dir)"
+  ln -sf "$(command -v jq)" "$d/jq"            # real jq, replacing the cat-stub default
+  write_claude_stub "$d"
+  proj="$(mktemp -d "$WORK/enc-proj.XXXXXX")"; mkdir -p "$proj/.claude"
+  state="$(mktemp -d "$WORK/enc-state.XXXXXX")"; : > "$state/installed"
+  cat > "$proj/.claude/settings.json" <<'JSON'
+{
+  "enabledPlugins": {"a@plain": true, "b@pinned": true, "c@subdir": true, "d@viaurl": true},
+  "extraKnownMarketplaces": {
+    "plain":  {"source": {"source": "github", "repo": "acme/plain"}, "autoUpdate": true},
+    "pinned": {"source": {"source": "github", "repo": "acme/pinned", "ref": "v1.0.0"}, "autoUpdate": true},
+    "subdir": {"source": {"source": "github", "repo": "acme/subdir", "path": "catalog"}, "autoUpdate": true},
+    "viaurl": {"source": {"source": "git", "url": "https://example.com/x.git", "ref": "main"}, "autoUpdate": true}
+  }
+}
+JSON
+  log="$WORK/enc.log"
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -qxF 'acme/plain'                     "$state/added" 2>/dev/null \
+    && ok "encode: plain github -> owner/repo" || fail "encode: plain missing ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qxF 'acme/pinned@v1.0.0'             "$state/added" 2>/dev/null \
+    && ok "encode: github ref -> owner/repo@ref" || fail "encode: ref not encoded ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qxF 'https://example.com/x.git#main' "$state/added" 2>/dev/null \
+    && ok "encode: git url ref -> url#ref" || fail "encode: url ref not encoded ([$(cat "$state/added" 2>/dev/null)])"
+  grep -q 'acme/subdir' "$state/added" 2>/dev/null \
+    && fail "encode: custom-path source must be SKIPPED, not added ([$(cat "$state/added" 2>/dev/null)])" \
+    || ok "encode: custom marketplace.json path source skipped"
+}
+
+# Comment #2: `marketplace add` can exit non-zero with an "already" message; that is
+# benign and must be treated as success (logged to $LOG, never surfaced as a WARNING).
+test_plugins_already_present_add_is_benign() {
+  read -r d log proj state <<<"$(setup_plugins_case pp9)"
+  printf 'a@m1\n' > "$state/declared"
+  printf 'm1\tadd\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf 'acme/mkt-one\n' > "$state/already"   # add exits non-zero with an "already" message
+  touch "$state/refreshed.m1"
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -qF 'acme/mkt-one' "$state/added" \
+    && ok "already-add: registration was attempted" \
+    || fail "already-add: add not attempted ([$(cat "$state/added" 2>/dev/null)])"
+  grep -qi "could not register marketplace 'm1'" "$log" \
+    && fail "already-add: spurious WARNING on benign 'already' exit. Log: $(cat "$log" 2>/dev/null)" \
+    || ok "already-add: benign 'already' treated as success (no WARNING)"
 }
 
 # ---------------------------------------------------------------------------
@@ -623,6 +683,8 @@ test_plugins_shared_marketplace_refreshes_once
 test_plugins_wrong_id_after_successful_refresh
 test_plugins_registers_marketplaces_before_install
 test_plugins_warm_resume_skips_registration
+test_marketplace_source_encoding
+test_plugins_already_present_add_is_benign
 test_gate_local_noop
 test_local_hook_sourced
 

--- a/skills/cc-web-setup/scripts/test-install-deps.sh
+++ b/skills/cc-web-setup/scripts/test-install-deps.sh
@@ -355,6 +355,7 @@ test_persist_path_readonly_warns() {
 #   * update_attempts  — one line appended per `marketplace update` INVOCATION (memoization counter)
 write_claude_stub() { # <stub_dir> ; reads $STATE at runtime
   write_stub "$1" claude '
+printf "%s\n" "$*" >> "$STATE/trace"
 case "$1 $2" in
   "plugin list")
     cat "$STATE/installed" 2>/dev/null; exit 0 ;;
@@ -369,6 +370,7 @@ case "$1 $2" in
     echo "Plugin \"$p\" not found in marketplace \"$mkt\"; your local copy may be out of date." >&2
     exit 1 ;;
   "plugin marketplace")
+    if [ "$3" = "add" ]; then printf "%s\n" "$4" >> "$STATE/added"; exit 0; fi
     [ "$3" = "update" ] || exit 0
     printf "%s\n" "$4" >> "$STATE/update_attempts"
     if grep -qxF "$4" "$STATE/unreachable" 2>/dev/null; then
@@ -393,10 +395,17 @@ setup_plugins_case() { # <tag> -> echoes "<stub_dir> <out_file> <project_dir> <s
   local tag="$1" d proj state
   d="$(new_stub_dir)"
   proj="$(mktemp -d "$WORK/${tag}-proj.XXXXXX")"; mkdir -p "$proj/.claude"; : > "$proj/.claude/settings.json"
-  state="$(mktemp -d "$WORK/${tag}-state.XXXXXX")"; : > "$state/installed"
-  # jq is stubbed to emit the declared set straight from $STATE/declared, so the
-  # tests do not depend on real jq or on parsing a real settings.json.
-  write_stub "$d" jq 'cat "$STATE/declared" 2>/dev/null'
+  state="$(mktemp -d "$WORK/${tag}-state.XXXXXX")"; : > "$state/installed"; : > "$state/declared_marketplaces"
+  # jq is stubbed to emit a declared set straight from $STATE (no real jq / no real
+  # settings.json parsing). ensure_plugins calls jq with two different programs: the
+  # enabledPlugins query (=> plugin ids from $STATE/declared) and the
+  # extraKnownMarketplaces query (=> "name<TAB>source" lines from
+  # $STATE/declared_marketplaces). Branch on the program text so one stub serves both.
+  write_stub "$d" jq '
+for a in "$@"; do
+  case "$a" in *extraKnownMarketplaces*) cat "$STATE/declared_marketplaces" 2>/dev/null; exit 0 ;; esac
+done
+cat "$STATE/declared" 2>/dev/null'
   write_claude_stub "$d"
   printf '%s %s %s %s' "$d" "$WORK/${tag}.log" "$proj" "$state"
 }
@@ -510,6 +519,49 @@ test_plugins_wrong_id_after_successful_refresh() {
     || fail "plugins wrong-id: warning text missing. Log: $(cat "$log" 2>/dev/null)"
 }
 
+# THE COLD-START RACE FIX: when the marketplace registry is empty, ensure_plugins
+# must `claude plugin marketplace add` every declared marketplace BEFORE attempting
+# installs, so the install never runs against an unregistered marketplace. Sentinels
+# are pre-seeded so the post-registration install succeeds on the first try —
+# isolating the new registration step from the stale-index retry path.
+test_plugins_registers_marketplaces_before_install() {
+  read -r d log proj state <<<"$(setup_plugins_case pp7)"
+  printf 'a@m1\nb@m2\n' > "$state/declared"
+  printf 'm1\tacme/mkt-one\nm2\tacme/mkt-two\n' > "$state/declared_marketplaces"
+  touch "$state/refreshed.m1" "$state/refreshed.m2"   # registered => index already fresh
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -q 'Plugin install: 2 installed, 0 failed, 0 already present' "$log" \
+    && ok "plugins register: both installed after registration" \
+    || fail "plugins register: wrong summary. Log: $(cat "$log" 2>/dev/null)"
+  { grep -qxF 'acme/mkt-one' "$state/added" 2>/dev/null && grep -qxF 'acme/mkt-two' "$state/added" 2>/dev/null; } \
+    && ok "plugins register: both declared marketplaces were 'marketplace add'-ed" \
+    || fail "plugins register: missing marketplace add ([$(cat "$state/added" 2>/dev/null)])"
+  # Ordering: the LAST 'marketplace add' must precede the FIRST 'plugin install'.
+  local last_add first_install
+  last_add="$(grep -n 'marketplace add' "$state/trace" 2>/dev/null | tail -1 | cut -d: -f1 || true)"
+  first_install="$(grep -n 'plugin install' "$state/trace" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  { [ -n "$last_add" ] && [ -n "$first_install" ] && [ "$last_add" -lt "$first_install" ]; } \
+    && ok "plugins register: all marketplace adds precede the first install" \
+    || fail "plugins register: add/install order wrong (add@${last_add:-?} install@${first_install:-?})."
+}
+
+# The registration step is gated on $pending: a warm resume where every declared
+# plugin is already installed must NOT register marketplaces, even though they are
+# declared — the whole self-heal stays a quiet no-op.
+test_plugins_warm_resume_skips_registration() {
+  read -r d log proj state <<<"$(setup_plugins_case pp8)"
+  printf 'a@m1\n' > "$state/declared"
+  printf 'm1\tacme/mkt-one\n' > "$state/declared_marketplaces"
+  printf '> a@m1\n' > "$state/installed"              # already installed => pending=0
+  run_ensure_plugins "$d" "$log" "$proj" "$state"
+  grep -q 'Plugin install: 0 installed, 0 failed, 1 already present' "$log" \
+    && ok "plugins warm-resume: quiet no-op summary" \
+    || fail "plugins warm-resume: wrong summary. Log: $(cat "$log" 2>/dev/null)"
+  [ ! -s "$state/added" ] \
+    && ok "plugins warm-resume: no marketplace registered when nothing to install" \
+    || fail "plugins warm-resume: registered despite pending=0 ([$(cat "$state/added" 2>/dev/null)])"
+}
+
 # ---------------------------------------------------------------------------
 # main() gate + project hook seam (subprocess)
 # ---------------------------------------------------------------------------
@@ -569,6 +621,8 @@ test_plugins_already_present_noop
 test_plugins_unreachable_fails_after_refresh
 test_plugins_shared_marketplace_refreshes_once
 test_plugins_wrong_id_after_successful_refresh
+test_plugins_registers_marketplaces_before_install
+test_plugins_warm_resume_skips_registration
 test_gate_local_noop
 test_local_hook_sourced
 


### PR DESCRIPTION
## Problem

On a **cold Claude Code on the web session**, the `install-deps.sh` SessionStart hook's plugin self-heal (`ensure_plugins`) runs *before* Claude Code has registered the `extraKnownMarketplaces` declared in `.claude/settings.json`. With an empty marketplace registry, every `claude plugin install <p>@<mkt>` — and the self-heal's `claude plugin marketplace update <mkt>` retry — fails with:

> `Failed to update marketplace(s): Marketplace '<mkt>' not found. Available marketplaces:`  ← empty list

The script then misreported this as *"its source may be unreachable (network)"*. Result: 0 plugins installed for the session (e.g. `skill-creator` unavailable).

Confirmed **not** a network issue: the marketplace clones land on disk fine moments later (mtimes `07:48:51`–`07:49:23`), and a manual `marketplace update` + `install` a few minutes into the same session succeeded on the first try.

## Fix

`ensure_plugins()` now registers every declared marketplace with `claude plugin marketplace add` (idempotent — a no-op once on disk) **before** the install loop, so the hook owns the full `add → update → install` chain instead of depending on a registration that may not have happened yet. Gated on a `pending` count so a warm resume (all plugins already installed) stays a silent no-op. Comments and the failure diagnostic are updated so an empty registry is no longer mislabeled as a network failure.

Canonical edit in `skills/cc-web-setup/assets/install-deps.sh`; the `.claude/scripts/` and `plugins/claude-code/…` copies are regenerated via `sync-plugins.sh` and kept byte-identical.

## Tests

- Extended `test-install-deps.sh`: the `jq` stub now branches on the query and the `claude` stub records `marketplace add` calls + an ordering trace. Two new tests cover (a) cold-start registers each declared marketplace and all `add`s precede the first `install`, and (b) the warm-resume `pending=0` no-op. Harness: **54 passed, 0 failed**.
- Reviewed via `/codex:rescue` — no blocking findings.
- Local/pre-push gates green: `validate-plugins.sh`, `generate_manifests.py --check`, `sync-plugins.sh --check`, `asctl repo-check`, full `tests/` suite (121), and `install-deps-hook-tests`.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vVt99LBTWyJ3goDFECdsX

---
_Generated by [Claude Code](https://claude.ai/code/session_012vVt99LBTWyJ3goDFECdsX)_