### PR TITLE
Add claude-code workflow + pipeline skills

### DIFF
--- a/.changes/unreleased/Added-20260623-095501.yaml
+++ b/.changes/unreleased/Added-20260623-095501.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Add `/claude-code:create-workflow` skill — guides creating, saving, and reusing Claude Code dynamic workflows: a decision gate for workflow vs subagent/skill/agent-team, the `ultracode` author-and-save loop, `.claude/workflows/` distribution rules (including the no-plugin-bundling reality), `args` parameterization, and runtime/permission/cost constraints'
+time: 2026-06-23T09:55:01.161371811Z

--- a/.changes/unreleased/Added-20260623-102513.yaml
+++ b/.changes/unreleased/Added-20260623-102513.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Add `/claude-code:pipeline` skill — a decision framework for reproducible multi-step flows: single ordered skill vs multiple step commands, the marker-file + hook gating pattern for enforced ordering, and when to escalate a step to subagents, an agent team, or a dynamic workflow'
+time: 2026-06-23T10:25:13.988258057Z

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -309,6 +309,7 @@ Claude Code — agent-team coordination, hook authoring, and web-session setup.
 **Skills**
 
 - `/claude-code:agent-teams`
+- `/claude-code:create-workflow`
 - `/claude-code:hook`
 - `/claude-code:web-setup`
 

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -311,6 +311,7 @@ Claude Code — agent-team coordination, hook authoring, and web-session setup.
 - `/claude-code:agent-teams`
 - `/claude-code:create-workflow`
 - `/claude-code:hook`
+- `/claude-code:pipeline`
 - `/claude-code:web-setup`
 
 ---

--- a/plugins/claude-code/skills/create-workflow/SKILL.md
+++ b/plugins/claude-code/skills/create-workflow/SKILL.md
@@ -1,0 +1,190 @@
+---
+license: CC-BY-4.0
+description: >-
+  Create, save, and reuse Claude Code dynamic workflows — JavaScript
+  orchestration scripts that Claude writes and a runtime executes to fan out to
+  many subagents at scale. Use when the user wants to build a workflow, automate
+  a repeatable multi-agent process, codify an orchestration, or save a run for
+  later. Also triggers on `ultracode`, `/workflows`, `.claude/workflows/`,
+  `/deep-research`, "orchestrate subagents", "codebase audit", "large
+  migration", "cross-checked research", or "make this a reusable command". The
+  skill first decides whether a workflow is even the right tool (vs a subagent,
+  skill, or agent team), then drives the author-and-save loop and the
+  `.claude/workflows/` distribution rules.
+argument-hint: "Describe the task to turn into a workflow (e.g. 'audit every API route for missing auth checks')"
+compatibility: >-
+  Requires Claude Code v2.1.154+ for dynamic workflows. Monorepo path-walking
+  requires v2.1.178+. Before v2.1.160 the trigger keyword was `workflow` instead
+  of `ultracode` (natural-language requests work in both).
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+When the user invokes `/claude-code:create-workflow`, help them produce a saved,
+reusable workflow for the task in `$ARGUMENTS`. If empty, ask what repeatable
+multi-agent task they want to codify.
+
+**Always run the decision gate first** — most tasks should *not* be a workflow.
+Only proceed to authoring when the gate says a workflow is the right tool.
+
+---
+
+## Step 1 — Decision gate (do this before anything else)
+
+A workflow is the heaviest of four primitives. The real difference is **who holds
+the plan**. Steer the user to the lightest tool that fits.
+
+| Use… | When | Plan held by |
+|------|------|--------------|
+| **Skill** | Reusable *instructions* one agent follows | Claude, following the prompt |
+| **Subagent** | Offload one focused side-task; only the summary matters | Claude, turn by turn |
+| **Agent team** | A few workers that must **talk to each other** / challenge findings | Lead + teammates, turn by turn |
+| **Workflow** | **Repeatable, codified** fan-out to **dozens–hundreds** of agents | The **JavaScript script** |
+
+Pick a **workflow** only when *all* of these hold:
+
+- The orchestration is worth **codifying and rerunning** (a per-branch review, a
+  recurring audit), not a one-off.
+- The task needs **more agents than one conversation can coordinate** — bug
+  sweeps across a repo, 500-file migrations, research cross-checked across many
+  sources, drafting a plan from several independent angles.
+- You want intermediate results to stay in **script variables**, keeping Claude's
+  context holding only the final answer.
+
+If the user just needs collaboration between a handful of agents, that's an
+**agent team** (`/claude-code:agent-teams`). If they want reusable instructions,
+that's a **skill** (`/claude-code:...` via the skill catalog). If it's a single
+delegated lookup, that's a **subagent**. Say so and stop.
+
+> Subagents are the worker primitive a workflow orchestrates; an agent team can
+> reuse subagent *definitions* as teammate roles. Workflows don't "call skills" —
+> the agents they spawn load skills by context, the same as any session.
+
+## Step 2 — Frame the task for the runtime
+
+Workflows have a fixed shape you must design *for*, not against:
+
+- **The script coordinates; agents do the work.** The script itself has **no
+  filesystem or shell access** — only its spawned agents read, write, and run
+  commands. Frame the task as "fan out N agents, each does X, collect/compare
+  results," not "the script edits files."
+- **Codify a quality pattern, not just parallelism.** The payoff over plain
+  subagents is repeatable structure: have agents **adversarially review** each
+  other's findings, or draft a plan from several angles and weigh them, before
+  reporting.
+- **Stage gating needs separate workflows.** There is **no mid-run user input** —
+  only agent permission prompts can pause a run. For sign-off between stages, run
+  each stage as its own workflow.
+- **Respect the caps:** up to **16 concurrent agents** (fewer on low-CPU
+  machines) and **1,000 agents total per run**. Design the fan-out to fit.
+
+## Step 3 — Have Claude write it
+
+You don't hand-author the JavaScript — **Claude writes the script** from the task
+description. Trigger it one of two ways:
+
+- **Single task:** include the keyword **`ultracode`** in the prompt (or just say
+  "use a workflow"). Example: `ultracode: audit every API endpoint under
+  src/routes/ for missing auth checks`.
+- **Whole session:** `/effort ultracode` — Claude plans a workflow for every
+  substantive task until the session ends or you drop back with `/effort high`.
+
+Claude shows the planned phases and asks to approve before running (the prompt's
+frequency depends on permission mode; `Ctrl+G` opens the script, `Tab` edits the
+prompt first). Iterate on the task description until a run does what you want.
+
+> The run writes its script to a file under `~/.claude/projects/` and Claude gets
+> the path — ask for it to read, diff, or edit the orchestration directly.
+
+## Step 4 — Save for reuse
+
+Once a run is good, save its script as a command: run `/workflows`, select the
+run, press **`s`**, and `Tab` to pick the location:
+
+| Location | Scope |
+|----------|-------|
+| `.claude/workflows/` | **Project — committed to the repo, shared with everyone who clones it** |
+| `~/.claude/workflows/` | Personal — every project, only you |
+
+Saved workflows run as `/<name>` and appear in `/` autocomplete alongside
+built-ins like `/deep-research`. If a project and personal workflow share a name,
+the **project** one wins.
+
+**Monorepo (v2.1.178+):** saving to the project location writes to the closest
+existing `.claude/workflows/` between your cwd and the repo root (or the repo root
+if none exists). Workflows load from *every* `.claude/workflows/` along that path;
+on a name clash the one nearest your cwd runs.
+
+## Step 5 — Parameterize with `args`
+
+A saved workflow reads invocation input from a global named **`args`**:
+
+```text
+> Run /triage-issues on issues 1024, 1025, and 1030
+```
+
+Claude passes the input as **structured data**, so the script calls array/object
+methods on `args` directly — no parsing. If omitted, `args` is `undefined`.
+
+---
+
+## Distribution reality (important)
+
+**Workflows cannot be bundled into a plugin or installed from a marketplace.**
+The recognized plugin components are skills, agents, hooks, MCP servers, LSP
+servers, monitors, and themes — `workflows/` is not one of them, and plugins are
+copied into a cache that workflow discovery never scans. The **only** sharing
+mechanisms are the two `.claude/workflows/` locations above. To share a workflow
+with a team, **commit it to `.claude/workflows/` in the repo**. To make the
+*authoring* reusable instead, package a skill like this one.
+
+## Cost & model
+
+A run spawns many agents, so it can cost meaningfully more than doing the task in
+conversation; runs count toward plan usage and rate limits. Before a large run:
+
+- **Gauge on a slice first** — one directory, not the whole repo — and watch
+  per-agent token usage in `/workflows`; stop anytime without losing completed work.
+- Every agent uses the **session model** unless the script routes a stage
+  elsewhere. Check `/model` before a big run, and ask Claude to route low-stakes
+  stages to a smaller model.
+
+## Permissions
+
+Your session permission mode controls **only the launch prompt**. The subagents a
+workflow spawns always run in **`acceptEdits`** and inherit your tool allowlist
+regardless of session mode — file edits are auto-approved. Shell commands, web
+fetches, and MCP tools **not** in your allowlist still prompt mid-run, so
+**pre-allowlist what the agents need** before a long run to avoid interruptions.
+In `claude -p` / Agent SDK there's no prompt; runs start immediately.
+
+## Turn workflows off
+
+`disableWorkflows: true` in `~/.claude/settings.json` (or managed settings for an
+org), the `CLAUDE_CODE_DISABLE_WORKFLOWS=1` env var, or the Dynamic workflows
+toggle in `/config`. When disabled, bundled workflow commands vanish and
+`ultracode` no longer triggers.
+
+## Resumption
+
+A paused run resumes **within the same session** (completed agents return cached
+results). **Exiting Claude Code loses progress** — the next session starts the
+workflow fresh.
+
+---
+
+## Verify against canonical source
+
+Dynamic workflows are new and evolving (keyword, monorepo paths, and limits have
+all changed across versions). When being wrong would mislead, verify against the
+canonical docs: <https://code.claude.com/docs/en/workflows>. Related primitives:
+[subagents](https://code.claude.com/docs/en/sub-agents),
+[agent teams](https://code.claude.com/docs/en/agent-teams),
+[plugins reference](https://code.claude.com/docs/en/plugins-reference).

--- a/plugins/claude-code/skills/pipeline/SKILL.md
+++ b/plugins/claude-code/skills/pipeline/SKILL.md
@@ -1,0 +1,148 @@
+---
+license: CC-BY-4.0
+description: >-
+  Design reproducible multi-step flows in Claude Code — decide between a single
+  ordered skill, multiple step commands, hook-gated state, and when to escalate
+  a step to subagents, an agent team, or a dynamic workflow. Use when the user
+  wants a repeatable procedure (step 1 → 2 → 3), a "pipeline", enforced step
+  ordering, a gated process where a later step must check an earlier one, or asks
+  how to package a multi-step process as a plugin. Also triggers on "make this
+  reproducible", "marker file", "state machine", "step 2 needs step 1", "fan
+  out", or "skill vs command vs workflow". Picks the lightest structure that
+  fits and shows the marker-file + hook gating pattern.
+argument-hint: "Describe the multi-step process to make reproducible (e.g. 'lint, then test, then release')"
+compatibility: >-
+  Reflects the Claude Code skills/commands unification (custom commands are
+  skills) and the hooks I/O contract as of v2.1.x. The hook `if` field requires
+  v2.1.85+. Agent-team task dependencies require the experimental
+  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag. Dynamic workflows require v2.1.154+.
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+When the user invokes `/claude-code:pipeline`, help them structure a repeatable
+multi-step process for the task in `$ARGUMENTS`. If empty, ask what procedure
+they want to make reproducible and whether step order must be *enforced* or just
+*documented*.
+
+Pick the **lightest** structure that fits — most pipelines are one skill, not a
+plugin full of gated commands.
+
+---
+
+## Step 1 — Choose the structure
+
+The core question: do steps just need to run **in order**, or must order be
+**enforced** (a later step refuses until an earlier one is done)?
+
+| Your need | Build | Notes |
+|-----------|-------|-------|
+| Steps are instructions Claude follows in sequence | **One skill** with an ordered procedure | The default. Simplest, reproducible, marketplace-shippable. |
+| Each step is heavy (own context, own entry point) | **Multiple step commands** in one plugin (`thing:step-1`, `thing:step-2`) | Split *only* when a single skill would be too large or each step is invoked separately. |
+| Order must be **enforced** | **Skill/commands + hooks + a marker file** | Claude Code has **no native step ordering** — you build it (Step 3). |
+| Native ordered tasks, one session | **Agent team** (task list has dependencies) | A pending task can't be claimed until its deps complete. Experimental, in-session, not a package. |
+
+> **Custom commands are skills now.** `.claude/commands/x.md` and
+> `.claude/skills/x/SKILL.md` both create `/x`. So "a step" = a skill; a plugin
+> just bundles several of them (plus agents, MCP, hooks) under one namespace.
+
+**Default recommendation:** one skill containing the ordered steps + a marker
+file for state. Escalate to multiple commands only when each step is genuinely
+complex. Escalate to hooks only when order must be *guaranteed*, not just
+followed.
+
+## Step 2 — Package as one plugin
+
+A single plugin holds everything the pipeline needs:
+
+```
+plugins/thing/
+  skills/run/SKILL.md     # the ordered procedure (steps 1→3)
+  scripts/*.sh            # write/read .thing/ state markers
+  agents/*.md             # subagent roles a step can delegate to
+  hooks/hooks.json        # the gate (Step 3)
+  .mcp.json               # any MCP servers a step calls
+```
+
+The skill body drives the flow: it runs the bundled scripts to record progress
+(`.thing/step-1.done`) and reads them to decide what's next. Ship subagent
+*definitions* alongside so a step can delegate to them by name.
+
+## Step 3 — Enforce order with a marker file + hook
+
+There is **no built-in prerequisite graph** — hooks give you the *mechanism*
+(block, read state, inject context); you supply the *state*. The pattern:
+
+1. **Step 1 writes a marker** when it completes:
+   ```bash
+   mkdir -p .thing && touch .thing/step-1.done
+   ```
+2. **A hook reads it** before step 2's work runs. `PreToolUse` is the earliest
+   block point; `UserPromptSubmit` gates at the prompt; `Stop` keeps the turn
+   going until done. The hook inspects the filesystem and decides:
+   ```bash
+   #!/usr/bin/env bash
+   # PreToolUse gate: block step-2 work until step-1 is done
+   if [ ! -f .thing/step-1.done ]; then
+     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+       "permissionDecision":"deny",
+       "permissionDecisionReason":"Run /thing:step-1 first."}}'
+     exit 0
+   fi
+   exit 0
+   ```
+3. **Or just nudge** instead of hard-block: return `additionalContext`
+   (`"step 1 is not done yet"`) so Claude self-corrects. Use `exit 2` + stderr,
+   or `{"decision":"block","reason":...}` on events that support it
+   (`UserPromptSubmit`, `PostToolUse`, `Stop`, …).
+
+> For the full hook I/O contract (exit codes, per-event JSON shapes, the
+> prompt-injection trap), use **`/claude-code:hook`** — don't re-derive it here.
+
+## Step 4 — Decide how each step fans out
+
+A skill *advises*; it does not *guarantee*. Bake the fan-out **strategy** into the
+skill body, and choose the primitive by how much determinism you need:
+
+| Per-step need | Use | Bake into the skill? |
+|---------------|-----|----------------------|
+| Offload one noisy side-task; only the summary matters | **Subagent** | ✅ Fully — write the delegation, ship the `agents/*.md` definition in the plugin, reference it by name |
+| A few workers that must talk/challenge each other | **Agent team** | ✅ Guidance only — the skill designs the team + spawn prompt (see `/claude-code:agent-teams`) |
+| **Deterministic, large-scale** fan-out (same orchestration every run) | **Workflow** | ⚠️ Point at it — the skill tells the user to create/run it via `/claude-code:create-workflow`; the JS can't ship in the plugin |
+
+The determinism ladder, in one line:
+
+> **Skill** by default (steps + fan-out strategy) → add **hooks + markers** when
+> order must be enforced → escalate a step to a **workflow** only when it needs
+> *guaranteed* heavy fan-out. The skill holds the plan; hooks hold the gate;
+> a workflow holds a step that must run the same way every time.
+
+## Anti-patterns
+
+- **A plugin of gated commands for a simple 3-step checklist.** Use one skill.
+- **Expecting hooks to "know" step order.** They don't — without a marker file a
+  hook has no idea what ran before.
+- **Relying on a skill for *guaranteed* orchestration.** Skills are followed
+  probabilistically; if a step *must* fan out identically every time, that step
+  is a workflow.
+- **Trying to ship a workflow in the plugin.** Workflows live only in
+  `.claude/workflows/`; package the *authoring guidance*, not the workflow.
+
+---
+
+## Verify against canonical source
+
+Skill/command/hook/orchestration behavior shifts across versions. When being
+wrong would mislead, verify against the canonical docs:
+[skills & commands](https://code.claude.com/docs/en/skills),
+[hooks](https://code.claude.com/docs/en/hooks),
+[subagents](https://code.claude.com/docs/en/sub-agents),
+[agent teams](https://code.claude.com/docs/en/agent-teams),
+[workflows](https://code.claude.com/docs/en/workflows).

--- a/registry/bundles/claude-code.yaml
+++ b/registry/bundles/claude-code.yaml
@@ -11,6 +11,7 @@ skills:
   - {source: cc-agent-teams, leaf: agent-teams}
   - {source: cc-create-workflow, leaf: create-workflow}
   - {source: cc-hook, leaf: hook}
+  - {source: cc-pipeline, leaf: pipeline}
   - {source: cc-web-setup, leaf: web-setup}
 agents: []
 hooks: []

--- a/registry/bundles/claude-code.yaml
+++ b/registry/bundles/claude-code.yaml
@@ -9,6 +9,7 @@ channels:
   - stable
 skills:
   - {source: cc-agent-teams, leaf: agent-teams}
+  - {source: cc-create-workflow, leaf: create-workflow}
   - {source: cc-hook, leaf: hook}
   - {source: cc-web-setup, leaf: web-setup}
 agents: []

--- a/skills/cc-create-workflow/SKILL.md
+++ b/skills/cc-create-workflow/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: cc-create-workflow
+license: CC-BY-4.0
+description: >-
+  Create, save, and reuse Claude Code dynamic workflows — JavaScript
+  orchestration scripts that Claude writes and a runtime executes to fan out to
+  many subagents at scale. Use when the user wants to build a workflow, automate
+  a repeatable multi-agent process, codify an orchestration, or save a run for
+  later. Also triggers on `ultracode`, `/workflows`, `.claude/workflows/`,
+  `/deep-research`, "orchestrate subagents", "codebase audit", "large
+  migration", "cross-checked research", or "make this a reusable command". The
+  skill first decides whether a workflow is even the right tool (vs a subagent,
+  skill, or agent team), then drives the author-and-save loop and the
+  `.claude/workflows/` distribution rules.
+argument-hint: "Describe the task to turn into a workflow (e.g. 'audit every API route for missing auth checks')"
+compatibility: >-
+  Requires Claude Code v2.1.154+ for dynamic workflows. Monorepo path-walking
+  requires v2.1.178+. Before v2.1.160 the trigger keyword was `workflow` instead
+  of `ultracode` (natural-language requests work in both).
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+When the user invokes `/claude-code:create-workflow`, help them produce a saved,
+reusable workflow for the task in `$ARGUMENTS`. If empty, ask what repeatable
+multi-agent task they want to codify.
+
+**Always run the decision gate first** — most tasks should *not* be a workflow.
+Only proceed to authoring when the gate says a workflow is the right tool.
+
+---
+
+## Step 1 — Decision gate (do this before anything else)
+
+A workflow is the heaviest of four primitives. The real difference is **who holds
+the plan**. Steer the user to the lightest tool that fits.
+
+| Use… | When | Plan held by |
+|------|------|--------------|
+| **Skill** | Reusable *instructions* one agent follows | Claude, following the prompt |
+| **Subagent** | Offload one focused side-task; only the summary matters | Claude, turn by turn |
+| **Agent team** | A few workers that must **talk to each other** / challenge findings | Lead + teammates, turn by turn |
+| **Workflow** | **Repeatable, codified** fan-out to **dozens–hundreds** of agents | The **JavaScript script** |
+
+Pick a **workflow** only when *all* of these hold:
+
+- The orchestration is worth **codifying and rerunning** (a per-branch review, a
+  recurring audit), not a one-off.
+- The task needs **more agents than one conversation can coordinate** — bug
+  sweeps across a repo, 500-file migrations, research cross-checked across many
+  sources, drafting a plan from several independent angles.
+- You want intermediate results to stay in **script variables**, keeping Claude's
+  context holding only the final answer.
+
+If the user just needs collaboration between a handful of agents, that's an
+**agent team** (`/claude-code:agent-teams`). If they want reusable instructions,
+that's a **skill** (`/claude-code:...` via the skill catalog). If it's a single
+delegated lookup, that's a **subagent**. Say so and stop.
+
+> Subagents are the worker primitive a workflow orchestrates; an agent team can
+> reuse subagent *definitions* as teammate roles. Workflows don't "call skills" —
+> the agents they spawn load skills by context, the same as any session.
+
+## Step 2 — Frame the task for the runtime
+
+Workflows have a fixed shape you must design *for*, not against:
+
+- **The script coordinates; agents do the work.** The script itself has **no
+  filesystem or shell access** — only its spawned agents read, write, and run
+  commands. Frame the task as "fan out N agents, each does X, collect/compare
+  results," not "the script edits files."
+- **Codify a quality pattern, not just parallelism.** The payoff over plain
+  subagents is repeatable structure: have agents **adversarially review** each
+  other's findings, or draft a plan from several angles and weigh them, before
+  reporting.
+- **Stage gating needs separate workflows.** There is **no mid-run user input** —
+  only agent permission prompts can pause a run. For sign-off between stages, run
+  each stage as its own workflow.
+- **Respect the caps:** up to **16 concurrent agents** (fewer on low-CPU
+  machines) and **1,000 agents total per run**. Design the fan-out to fit.
+
+## Step 3 — Have Claude write it
+
+You don't hand-author the JavaScript — **Claude writes the script** from the task
+description. Trigger it one of two ways:
+
+- **Single task:** include the keyword **`ultracode`** in the prompt (or just say
+  "use a workflow"). Example: `ultracode: audit every API endpoint under
+  src/routes/ for missing auth checks`.
+- **Whole session:** `/effort ultracode` — Claude plans a workflow for every
+  substantive task until the session ends or you drop back with `/effort high`.
+
+Claude shows the planned phases and asks to approve before running (the prompt's
+frequency depends on permission mode; `Ctrl+G` opens the script, `Tab` edits the
+prompt first). Iterate on the task description until a run does what you want.
+
+> The run writes its script to a file under `~/.claude/projects/` and Claude gets
+> the path — ask for it to read, diff, or edit the orchestration directly.
+
+## Step 4 — Save for reuse
+
+Once a run is good, save its script as a command: run `/workflows`, select the
+run, press **`s`**, and `Tab` to pick the location:
+
+| Location | Scope |
+|----------|-------|
+| `.claude/workflows/` | **Project — committed to the repo, shared with everyone who clones it** |
+| `~/.claude/workflows/` | Personal — every project, only you |
+
+Saved workflows run as `/<name>` and appear in `/` autocomplete alongside
+built-ins like `/deep-research`. If a project and personal workflow share a name,
+the **project** one wins.
+
+**Monorepo (v2.1.178+):** saving to the project location writes to the closest
+existing `.claude/workflows/` between your cwd and the repo root (or the repo root
+if none exists). Workflows load from *every* `.claude/workflows/` along that path;
+on a name clash the one nearest your cwd runs.
+
+## Step 5 — Parameterize with `args`
+
+A saved workflow reads invocation input from a global named **`args`**:
+
+```text
+> Run /triage-issues on issues 1024, 1025, and 1030
+```
+
+Claude passes the input as **structured data**, so the script calls array/object
+methods on `args` directly — no parsing. If omitted, `args` is `undefined`.
+
+---
+
+## Distribution reality (important)
+
+**Workflows cannot be bundled into a plugin or installed from a marketplace.**
+The recognized plugin components are skills, agents, hooks, MCP servers, LSP
+servers, monitors, and themes — `workflows/` is not one of them, and plugins are
+copied into a cache that workflow discovery never scans. The **only** sharing
+mechanisms are the two `.claude/workflows/` locations above. To share a workflow
+with a team, **commit it to `.claude/workflows/` in the repo**. To make the
+*authoring* reusable instead, package a skill like this one.
+
+## Cost & model
+
+A run spawns many agents, so it can cost meaningfully more than doing the task in
+conversation; runs count toward plan usage and rate limits. Before a large run:
+
+- **Gauge on a slice first** — one directory, not the whole repo — and watch
+  per-agent token usage in `/workflows`; stop anytime without losing completed work.
+- Every agent uses the **session model** unless the script routes a stage
+  elsewhere. Check `/model` before a big run, and ask Claude to route low-stakes
+  stages to a smaller model.
+
+## Permissions
+
+Your session permission mode controls **only the launch prompt**. The subagents a
+workflow spawns always run in **`acceptEdits`** and inherit your tool allowlist
+regardless of session mode — file edits are auto-approved. Shell commands, web
+fetches, and MCP tools **not** in your allowlist still prompt mid-run, so
+**pre-allowlist what the agents need** before a long run to avoid interruptions.
+In `claude -p` / Agent SDK there's no prompt; runs start immediately.
+
+## Turn workflows off
+
+`disableWorkflows: true` in `~/.claude/settings.json` (or managed settings for an
+org), the `CLAUDE_CODE_DISABLE_WORKFLOWS=1` env var, or the Dynamic workflows
+toggle in `/config`. When disabled, bundled workflow commands vanish and
+`ultracode` no longer triggers.
+
+## Resumption
+
+A paused run resumes **within the same session** (completed agents return cached
+results). **Exiting Claude Code loses progress** — the next session starts the
+workflow fresh.
+
+---
+
+## Verify against canonical source
+
+Dynamic workflows are new and evolving (keyword, monorepo paths, and limits have
+all changed across versions). When being wrong would mislead, verify against the
+canonical docs: <https://code.claude.com/docs/en/workflows>. Related primitives:
+[subagents](https://code.claude.com/docs/en/sub-agents),
+[agent teams](https://code.claude.com/docs/en/agent-teams),
+[plugins reference](https://code.claude.com/docs/en/plugins-reference).

--- a/skills/cc-pipeline/SKILL.md
+++ b/skills/cc-pipeline/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: cc-pipeline
+license: CC-BY-4.0
+description: >-
+  Design reproducible multi-step flows in Claude Code — decide between a single
+  ordered skill, multiple step commands, hook-gated state, and when to escalate
+  a step to subagents, an agent team, or a dynamic workflow. Use when the user
+  wants a repeatable procedure (step 1 → 2 → 3), a "pipeline", enforced step
+  ordering, a gated process where a later step must check an earlier one, or asks
+  how to package a multi-step process as a plugin. Also triggers on "make this
+  reproducible", "marker file", "state machine", "step 2 needs step 1", "fan
+  out", or "skill vs command vs workflow". Picks the lightest structure that
+  fits and shows the marker-file + hook gating pattern.
+argument-hint: "Describe the multi-step process to make reproducible (e.g. 'lint, then test, then release')"
+compatibility: >-
+  Reflects the Claude Code skills/commands unification (custom commands are
+  skills) and the hooks I/O contract as of v2.1.x. The hook `if` field requires
+  v2.1.85+. Agent-team task dependencies require the experimental
+  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag. Dynamic workflows require v2.1.154+.
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+When the user invokes `/claude-code:pipeline`, help them structure a repeatable
+multi-step process for the task in `$ARGUMENTS`. If empty, ask what procedure
+they want to make reproducible and whether step order must be *enforced* or just
+*documented*.
+
+Pick the **lightest** structure that fits — most pipelines are one skill, not a
+plugin full of gated commands.
+
+---
+
+## Step 1 — Choose the structure
+
+The core question: do steps just need to run **in order**, or must order be
+**enforced** (a later step refuses until an earlier one is done)?
+
+| Your need | Build | Notes |
+|-----------|-------|-------|
+| Steps are instructions Claude follows in sequence | **One skill** with an ordered procedure | The default. Simplest, reproducible, marketplace-shippable. |
+| Each step is heavy (own context, own entry point) | **Multiple step commands** in one plugin (`thing:step-1`, `thing:step-2`) | Split *only* when a single skill would be too large or each step is invoked separately. |
+| Order must be **enforced** | **Skill/commands + hooks + a marker file** | Claude Code has **no native step ordering** — you build it (Step 3). |
+| Native ordered tasks, one session | **Agent team** (task list has dependencies) | A pending task can't be claimed until its deps complete. Experimental, in-session, not a package. |
+
+> **Custom commands are skills now.** `.claude/commands/x.md` and
+> `.claude/skills/x/SKILL.md` both create `/x`. So "a step" = a skill; a plugin
+> just bundles several of them (plus agents, MCP, hooks) under one namespace.
+
+**Default recommendation:** one skill containing the ordered steps + a marker
+file for state. Escalate to multiple commands only when each step is genuinely
+complex. Escalate to hooks only when order must be *guaranteed*, not just
+followed.
+
+## Step 2 — Package as one plugin
+
+A single plugin holds everything the pipeline needs:
+
+```
+plugins/thing/
+  skills/run/SKILL.md     # the ordered procedure (steps 1→3)
+  scripts/*.sh            # write/read .thing/ state markers
+  agents/*.md             # subagent roles a step can delegate to
+  hooks/hooks.json        # the gate (Step 3)
+  .mcp.json               # any MCP servers a step calls
+```
+
+The skill body drives the flow: it runs the bundled scripts to record progress
+(`.thing/step-1.done`) and reads them to decide what's next. Ship subagent
+*definitions* alongside so a step can delegate to them by name.
+
+## Step 3 — Enforce order with a marker file + hook
+
+There is **no built-in prerequisite graph** — hooks give you the *mechanism*
+(block, read state, inject context); you supply the *state*. The pattern:
+
+1. **Step 1 writes a marker** when it completes:
+   ```bash
+   mkdir -p .thing && touch .thing/step-1.done
+   ```
+2. **A hook reads it** before step 2's work runs. `PreToolUse` is the earliest
+   block point; `UserPromptSubmit` gates at the prompt; `Stop` keeps the turn
+   going until done. The hook inspects the filesystem and decides:
+   ```bash
+   #!/usr/bin/env bash
+   # PreToolUse gate: block step-2 work until step-1 is done
+   if [ ! -f .thing/step-1.done ]; then
+     echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+       "permissionDecision":"deny",
+       "permissionDecisionReason":"Run /thing:step-1 first."}}'
+     exit 0
+   fi
+   exit 0
+   ```
+3. **Or just nudge** instead of hard-block: return `additionalContext`
+   (`"step 1 is not done yet"`) so Claude self-corrects. Use `exit 2` + stderr,
+   or `{"decision":"block","reason":...}` on events that support it
+   (`UserPromptSubmit`, `PostToolUse`, `Stop`, …).
+
+> For the full hook I/O contract (exit codes, per-event JSON shapes, the
+> prompt-injection trap), use **`/claude-code:hook`** — don't re-derive it here.
+
+## Step 4 — Decide how each step fans out
+
+A skill *advises*; it does not *guarantee*. Bake the fan-out **strategy** into the
+skill body, and choose the primitive by how much determinism you need:
+
+| Per-step need | Use | Bake into the skill? |
+|---------------|-----|----------------------|
+| Offload one noisy side-task; only the summary matters | **Subagent** | ✅ Fully — write the delegation, ship the `agents/*.md` definition in the plugin, reference it by name |
+| A few workers that must talk/challenge each other | **Agent team** | ✅ Guidance only — the skill designs the team + spawn prompt (see `/claude-code:agent-teams`) |
+| **Deterministic, large-scale** fan-out (same orchestration every run) | **Workflow** | ⚠️ Point at it — the skill tells the user to create/run it via `/claude-code:create-workflow`; the JS can't ship in the plugin |
+
+The determinism ladder, in one line:
+
+> **Skill** by default (steps + fan-out strategy) → add **hooks + markers** when
+> order must be enforced → escalate a step to a **workflow** only when it needs
+> *guaranteed* heavy fan-out. The skill holds the plan; hooks hold the gate;
+> a workflow holds a step that must run the same way every time.
+
+## Anti-patterns
+
+- **A plugin of gated commands for a simple 3-step checklist.** Use one skill.
+- **Expecting hooks to "know" step order.** They don't — without a marker file a
+  hook has no idea what ran before.
+- **Relying on a skill for *guaranteed* orchestration.** Skills are followed
+  probabilistically; if a step *must* fan out identically every time, that step
+  is a workflow.
+- **Trying to ship a workflow in the plugin.** Workflows live only in
+  `.claude/workflows/`; package the *authoring guidance*, not the workflow.
+
+---
+
+## Verify against canonical source
+
+Skill/command/hook/orchestration behavior shifts across versions. When being
+wrong would mislead, verify against the canonical docs:
+[skills & commands](https://code.claude.com/docs/en/skills),
+[hooks](https://code.claude.com/docs/en/hooks),
+[subagents](https://code.claude.com/docs/en/sub-agents),
+[agent teams](https://code.claude.com/docs/en/agent-teams),
+[workflows](https://code.claude.com/docs/en/workflows).


### PR DESCRIPTION
## Summary

Adds two new skills to the **`claude-code`** bundle that help users design reproducible, multi-agent processes — and correct a common misconception about what Claude Code "workflows" actually are.

| Skill | Invoked as | Purpose |
|-------|-----------|---------|
| `cc-create-workflow` | `/claude-code:create-workflow` | Create, save, and reuse **dynamic workflows** (JS orchestration scripts Claude writes) |
| `cc-pipeline` | `/claude-code:pipeline` | Decision framework for **reproducible multi-step flows** — skill vs commands, hook-gated state, and when to escalate |

The bundle now ships 5 skills: `agent-teams`, `create-workflow`, `hook`, `pipeline`, `web-setup`.

## Why

Two facts, verified against the official docs, drive these skills:

1. **Workflows can't be bundled in plugins / installed from a marketplace.** They are JS scripts Claude authors via `ultracode` and you save into `.claude/workflows/` (git-shared) or `~/.claude/workflows/`. The recognized plugin components are skills, agents, hooks, MCP/LSP servers, monitors, and themes — `workflows/` is not one. So the reusable, marketplace-distributable artifact is a **skill that guides authoring**, which is what `create-workflow` is.
2. **Claude Code has no native step-ordering / prerequisite graph.** Hooks provide the mechanism (block, read state, inject context) but not the state. `pipeline` documents the marker-file + hook pattern and the determinism ladder (skill → hooks+markers → workflow), steering users to the lightest structure that fits.

## What's in each skill

**`create-workflow`** — leads with a *"should this even be a workflow?"* decision gate (vs subagent/skill/agent-team), then the `ultracode` author-and-save loop, `.claude/workflows/` distribution rules (incl. the no-plugin-bundling reality and monorepo path-walking), `args` parameterization, and the runtime/permission/cost constraints (16 concurrent / 1,000 total agents, `acceptEdits` subagents, slice-first cost gauging).

**`pipeline`** — picks single ordered skill vs multiple step commands, shows the copy-paste marker-file + `PreToolUse` gate (cross-referencing `/claude-code:hook` for the full I/O contract), the per-step fan-out table (subagents/teams/workflows), and an anti-patterns section.

Both pin compatibility versions and include a verify-canonical guard per `CONTRIBUTING.md`.

## Changes

- `skills/cc-create-workflow/SKILL.md`, `skills/cc-pipeline/SKILL.md` — canonical content
- `plugins/claude-code/skills/{create-workflow,pipeline}/` — synced plugin copies (`name:` stripped → namespaced labels)
- `registry/bundles/claude-code.yaml` — two new `{source, leaf}` members
- `docs/bundles.md` — regenerated
- two changie `Added` fragments

## Validation

All CI-parity checks pass locally (`check_bundle_refs`, `check_grouping`, `check_consistency`, `generate_manifests --check`, `generate_bundles_doc --check`, `validate-plugins.sh`, `asctl repo-check` — 47 skills), plus the pre-push gates (changie-fragment, skillspector, unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)