### PR TITLE
docs(cc-web-setup): capture the cold-start marketplace-registration lesson

### DIFF
--- a/.changes/unreleased/Fixed-20260623-100838.yaml
+++ b/.changes/unreleased/Fixed-20260623-100838.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'cc-web-setup: documented the cold-start marketplace-registration race and the self-heal''s add → update → install chain in SKILL.md and the reference doc, corrected the stale single-failure-mode guidance, and added a matching anti-pattern (follow-up to #181)'
+time: 2026-06-23T10:08:38.004400113Z

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -51,9 +51,13 @@ and provisions only what the declarative path does not:
 - **The project dev toolchain + services** (language toolchains, the Docker daemon,
   git-hook wiring) via the optional `install-deps.local.sh` seam.
 - **A plugin self-heal** (`ensure_plugins`): a cheap, idempotent retry that reinstalls the
-  declared set **only if** the platform's session-start install didn't complete (the docs'
-  *"requires network access to reach the marketplace source"* failure mode). Normally a
-  no-op.
+  declared set **only if** the platform's session-start install didn't complete. It first
+  **registers** the declared marketplaces (`claude plugin marketplace add`) — on a cold VM
+  this hook can outrun Claude Code's own registration of `extraKnownMarketplaces`, leaving
+  the registry empty, which is a **race**, not the docs' *"requires network access to reach
+  the marketplace source"* failure — then refreshes a stale index on a failed install,
+  owning the whole add → update → install chain. Gated on a pending count, so a warm resume
+  stays a no-op.
 
 `announce-capabilities.sh` (the second SessionStart hook) cross-checks the declared set
 against `claude plugin list` and reports **"Enabled plugins (installed)"** vs a

--- a/plugins/claude-code/skills/web-setup/references/web-setup.rst
+++ b/plugins/claude-code/skills/web-setup/references/web-setup.rst
@@ -31,8 +31,10 @@ Consequences that drive every design choice here:
   Setup-script field, no** ``make``\ **, no** ``.claude/skills/`` **bake** needed for
   plugins. ``github.com`` is on the default *Trusted* allowlist, so a github-sourced
   marketplace is reachable by default.
-- The only failure mode is the marketplace source being unreachable, or its local
-  index being stale on a cold VM. Both are handled by the self-heal (below).
+- The failure modes are: the marketplace registry still **empty** because this hook
+  outran the platform's registration of ``extraKnownMarketplaces`` on a cold VM (a
+  **race**, not a network error — issue #181); the local index being **stale**; or the
+  source genuinely **unreachable**. All three are handled by the self-heal (below).
 - A cloud session is a **fresh VM with only a clone of the repo** — anything not in
   git (or not installed by the SessionStart hook) is absent.
 
@@ -71,10 +73,18 @@ The self-heal (``ensure_plugins``)
 Declarative install is primary; the self-heal is the backstop kept **deliberately**
 (it has empirically rescued installs). It reads ``enabledPlugins`` from
 ``settings.json`` via ``jq``, skips ids already in ``claude plugin list``, and
-installs the rest idempotently. On a failed install it derives the marketplace from
-the ``@`` suffix, runs ``claude plugin marketplace update <mkt>`` (the refresh
-``claude plugin install`` does **not** do itself — the stale-index failure mode),
-and retries once, refreshing each marketplace at most once per run.
+installs the rest idempotently. When any plugin is still pending it **first registers
+every declared marketplace** with ``claude plugin marketplace add`` (idempotent — a
+no-op once on disk), so it never depends on the platform having registered
+``extraKnownMarketplaces`` first (the cold-start race, issue #181). A github source
+pins its ref as ``owner/repo@ref`` (a git URL as ``<git-url>#ref``); a source carrying
+a custom ``path`` (a non-default ``marketplace.json``) has no ``marketplace add``
+equivalent and is **skipped**, left to declarative registration. On a failed install
+it then derives the marketplace from the ``@`` suffix, runs ``claude plugin marketplace
+update <mkt>`` (the refresh ``claude plugin install`` does **not** do itself — the
+stale-index failure mode), and retries once, refreshing each marketplace at most once
+per run. The hook owns the whole **add → update → install** chain so it assumes no
+platform-side state; gated on a pending count, a warm resume is a silent no-op.
 
 A plugin the self-heal installs **surfaces from the *next* session**: Claude
 enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
@@ -114,13 +124,22 @@ These each cost a PR (or several) to learn:
   Setup-script field hard-failed *environment startup* on a CWD hiccup. The
   Setup-script field is only worth it for heavy **non-plugin** caching.
 - **Believing "the platform registers marketplaces but does not install
-  enabledPlugins."** It does install them. An empty ``claude plugin list`` is the
-  stale-index / unreachable-source failure, not a missing platform feature.
+  enabledPlugins."** It does install them. An empty ``claude plugin list`` is a
+  stale-index / unreachable-source failure **or the cold-start race below** — not a
+  missing platform feature.
 - **Reporting *declared* plugins as installed.** Build the banner from ``claude plugin
   list``, not from ``settings.json``, or a missing marketplace looks healthy while the
   slash menu is empty.
 - **A naive ``claude plugin install`` retry without ``marketplace update``.** On a
-  cold VM the index is empty; the retry re-hits the same stale index forever.
+  cold VM the index can be stale; the retry re-hits the same stale index forever unless
+  it refreshes.
+- **Assuming ``extraKnownMarketplaces`` is already registered when the SessionStart
+  hook runs (issue #181).** On a cold VM this hook can outrun that registration, so the
+  registry is **empty** and ``claude plugin install`` *and* ``claude plugin marketplace
+  update`` both fail with ``Marketplace not found. Available marketplaces:`` (an empty
+  list) — **not** a network failure, and it must not be reported as one. The self-heal
+  must ``claude plugin marketplace add`` every declared marketplace itself and own the
+  whole add → update → install chain, assuming no platform-side state.
 - **Leaving ``CODEX_ACCESS_TOKEN`` set.** Codex parses it as a JWT at runtime; a
   blob/blank value breaks every later ``codex exec`` even with a valid ``auth.json``.
   Unset it in-process and via ``CLAUDE_ENV_FILE``.

--- a/plugins/claude-code/skills/web-setup/references/web-setup.rst
+++ b/plugins/claude-code/skills/web-setup/references/web-setup.rst
@@ -76,7 +76,7 @@ Declarative install is primary; the self-heal is the backstop kept **deliberatel
 installs the rest idempotently. When any plugin is still pending it **first registers
 every declared marketplace** with ``claude plugin marketplace add`` (idempotent — a
 no-op once on disk), so it never depends on the platform having registered
-``extraKnownMarketplaces`` first (the cold-start race, issue #181). A github source
+``extraKnownMarketplaces`` first (the cold-start race, issue #181). A GitHub source
 pins its ref as ``owner/repo@ref`` (a git URL as ``<git-url>#ref``); a source carrying
 a custom ``path`` (a non-default ``marketplace.json``) has no ``marketplace add``
 equivalent and is **skipped**, left to declarative registration. On a failed install

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -52,9 +52,13 @@ and provisions only what the declarative path does not:
 - **The project dev toolchain + services** (language toolchains, the Docker daemon,
   git-hook wiring) via the optional `install-deps.local.sh` seam.
 - **A plugin self-heal** (`ensure_plugins`): a cheap, idempotent retry that reinstalls the
-  declared set **only if** the platform's session-start install didn't complete (the docs'
-  *"requires network access to reach the marketplace source"* failure mode). Normally a
-  no-op.
+  declared set **only if** the platform's session-start install didn't complete. It first
+  **registers** the declared marketplaces (`claude plugin marketplace add`) — on a cold VM
+  this hook can outrun Claude Code's own registration of `extraKnownMarketplaces`, leaving
+  the registry empty, which is a **race**, not the docs' *"requires network access to reach
+  the marketplace source"* failure — then refreshes a stale index on a failed install,
+  owning the whole add → update → install chain. Gated on a pending count, so a warm resume
+  stays a no-op.
 
 `announce-capabilities.sh` (the second SessionStart hook) cross-checks the declared set
 against `claude plugin list` and reports **"Enabled plugins (installed)"** vs a

--- a/skills/cc-web-setup/references/web-setup.rst
+++ b/skills/cc-web-setup/references/web-setup.rst
@@ -31,8 +31,10 @@ Consequences that drive every design choice here:
   Setup-script field, no** ``make``\ **, no** ``.claude/skills/`` **bake** needed for
   plugins. ``github.com`` is on the default *Trusted* allowlist, so a github-sourced
   marketplace is reachable by default.
-- The only failure mode is the marketplace source being unreachable, or its local
-  index being stale on a cold VM. Both are handled by the self-heal (below).
+- The failure modes are: the marketplace registry still **empty** because this hook
+  outran the platform's registration of ``extraKnownMarketplaces`` on a cold VM (a
+  **race**, not a network error — issue #181); the local index being **stale**; or the
+  source genuinely **unreachable**. All three are handled by the self-heal (below).
 - A cloud session is a **fresh VM with only a clone of the repo** — anything not in
   git (or not installed by the SessionStart hook) is absent.
 
@@ -71,10 +73,18 @@ The self-heal (``ensure_plugins``)
 Declarative install is primary; the self-heal is the backstop kept **deliberately**
 (it has empirically rescued installs). It reads ``enabledPlugins`` from
 ``settings.json`` via ``jq``, skips ids already in ``claude plugin list``, and
-installs the rest idempotently. On a failed install it derives the marketplace from
-the ``@`` suffix, runs ``claude plugin marketplace update <mkt>`` (the refresh
-``claude plugin install`` does **not** do itself — the stale-index failure mode),
-and retries once, refreshing each marketplace at most once per run.
+installs the rest idempotently. When any plugin is still pending it **first registers
+every declared marketplace** with ``claude plugin marketplace add`` (idempotent — a
+no-op once on disk), so it never depends on the platform having registered
+``extraKnownMarketplaces`` first (the cold-start race, issue #181). A github source
+pins its ref as ``owner/repo@ref`` (a git URL as ``<git-url>#ref``); a source carrying
+a custom ``path`` (a non-default ``marketplace.json``) has no ``marketplace add``
+equivalent and is **skipped**, left to declarative registration. On a failed install
+it then derives the marketplace from the ``@`` suffix, runs ``claude plugin marketplace
+update <mkt>`` (the refresh ``claude plugin install`` does **not** do itself — the
+stale-index failure mode), and retries once, refreshing each marketplace at most once
+per run. The hook owns the whole **add → update → install** chain so it assumes no
+platform-side state; gated on a pending count, a warm resume is a silent no-op.
 
 A plugin the self-heal installs **surfaces from the *next* session**: Claude
 enumerates skills at startup, *before* SessionStart hooks run, and ``reloadSkills``
@@ -114,13 +124,22 @@ These each cost a PR (or several) to learn:
   Setup-script field hard-failed *environment startup* on a CWD hiccup. The
   Setup-script field is only worth it for heavy **non-plugin** caching.
 - **Believing "the platform registers marketplaces but does not install
-  enabledPlugins."** It does install them. An empty ``claude plugin list`` is the
-  stale-index / unreachable-source failure, not a missing platform feature.
+  enabledPlugins."** It does install them. An empty ``claude plugin list`` is a
+  stale-index / unreachable-source failure **or the cold-start race below** — not a
+  missing platform feature.
 - **Reporting *declared* plugins as installed.** Build the banner from ``claude plugin
   list``, not from ``settings.json``, or a missing marketplace looks healthy while the
   slash menu is empty.
 - **A naive ``claude plugin install`` retry without ``marketplace update``.** On a
-  cold VM the index is empty; the retry re-hits the same stale index forever.
+  cold VM the index can be stale; the retry re-hits the same stale index forever unless
+  it refreshes.
+- **Assuming ``extraKnownMarketplaces`` is already registered when the SessionStart
+  hook runs (issue #181).** On a cold VM this hook can outrun that registration, so the
+  registry is **empty** and ``claude plugin install`` *and* ``claude plugin marketplace
+  update`` both fail with ``Marketplace not found. Available marketplaces:`` (an empty
+  list) — **not** a network failure, and it must not be reported as one. The self-heal
+  must ``claude plugin marketplace add`` every declared marketplace itself and own the
+  whole add → update → install chain, assuming no platform-side state.
 - **Leaving ``CODEX_ACCESS_TOKEN`` set.** Codex parses it as a JWT at runtime; a
   blob/blank value breaks every later ``codex exec`` even with a valid ``auth.json``.
   Unset it in-process and via ``CLAUDE_ENV_FILE``.

--- a/skills/cc-web-setup/references/web-setup.rst
+++ b/skills/cc-web-setup/references/web-setup.rst
@@ -76,7 +76,7 @@ Declarative install is primary; the self-heal is the backstop kept **deliberatel
 installs the rest idempotently. When any plugin is still pending it **first registers
 every declared marketplace** with ``claude plugin marketplace add`` (idempotent — a
 no-op once on disk), so it never depends on the platform having registered
-``extraKnownMarketplaces`` first (the cold-start race, issue #181). A github source
+``extraKnownMarketplaces`` first (the cold-start race, issue #181). A GitHub source
 pins its ref as ``owner/repo@ref`` (a git URL as ``<git-url>#ref``); a source carrying
 a custom ``path`` (a non-default ``marketplace.json``) has no ``marketplace add``
 equivalent and is **skipped**, left to declarative registration. On a failed install


### PR DESCRIPTION
## What & why

Follow-up to #183, which fixed the cold-start marketplace-registration race in the `install-deps.sh` **engine**. The engine was fixed, but the `cc-web-setup` skill's *teaching surfaces* still described the old mental model — a single *"network"* failure mode — and even carried an anti-pattern that **contradicted** the root cause of #181. A future author/debugger reading the skill would have re-derived the original misdiagnosis. This PR brings the docs in line with the shipped behavior.

**Documentation only — no code or behavior change.**

## Changes

**`SKILL.md`** — the self-heal bullet now states it *registers* marketplaces (`claude plugin marketplace add`) before installing and owns the **add → update → install** chain; an empty registry on a cold VM is a *race*, not the docs' "network" failure.

**`references/web-setup.rst`**
- *"The only failure mode is …"* → now lists all **three** (empty-registry race / stale index / unreachable).
- The self-heal section documents the new `marketplace add` registration step, including the `owner/repo@ref` / `<git-url>#ref` encoding and why a custom `path` source is skipped.
- Anti-patterns corrected: an empty `claude plugin list` is no longer pinned to *stale/unreachable*, and a new entry — *"don't assume `extraKnownMarketplaces` is registered when the SessionStart hook runs (#181)"* — captures the generalizable lesson: **the self-heal must assume zero platform-side state and own the full idempotent chain.**

Plugin-tree copies (`plugins/claude-code/skills/web-setup/…`) refreshed via `sync-plugins.sh`.

## Validation

- `sync-plugins.sh --check`, `validate-plugins.sh`, `asctl repo-check` (45 skills), `generate_manifests.py --check`, and the three consistency checks (`check_bundle_refs` / `check_grouping` / `check_consistency`) — all green.
- changie `Fixed` fragment added.
- pre-push hook suite green (`install-deps` 60/60; SkillSpector is non-gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vVt99LBTWyJ3goDFECdsX

---
_Generated by [Claude Code](https://claude.ai/code/session_012vVt99LBTWyJ3goDFECdsX)_