### PR TITLE
ci: green CI for Dependabot PRs

### DIFF
--- a/.changes/unreleased/Fixed-20260629-dependabot-ci.yaml
+++ b/.changes/unreleased/Fixed-20260629-dependabot-ci.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Skip the changelog-fragment gate and auto-triage job for Dependabot PRs so dependency-bump PRs land with green CI (Dependabot runs cannot read Actions secrets or run `changie new`)
+time: 2026-06-29T00:00:00.000000000+10:00

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -11,7 +11,9 @@ permissions:
 jobs:
   check-changie-fragment:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    # Dependabot PRs never carry a changie fragment; skip the gate for them
+    # (the bot has no way to run `changie new`). Human PRs still require one.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,6 +12,9 @@ permissions: {}
 
 jobs:
   triage:
+    # Dependabot runs cannot read Actions secrets, so the App-token step in the
+    # reusable workflow fails. Dependency-bump PRs don't need triage anyway.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     uses: nq-rdl/.github/.github/workflows/auto-triage.yml@main
     with:
       domain: RSE


### PR DESCRIPTION
## Problem

Every Dependabot PR (e.g. #192, #193) fails two checks for reasons unrelated to the bump:

- **`triage / triage`** — the reusable auto-triage workflow mints a GitHub App token, but Dependabot-triggered runs cannot read Actions secrets (only the Dependabot secrets store), so the private key is empty → `[@octokit/auth-app] privateKey option is required`.
- **`check-changie-fragment`** — Dependabot never runs `changie new`, so no changelog fragment exists, and the gate only had a manual `skip-changelog` label bypass.

## Fix

Gate both jobs to skip the `dependabot[bot]` actor, mirroring the existing job-level `skip-changelog` bypass. Human PRs are unaffected. This greens all future Dependabot PRs automatically.

## Follow-up

After merge, rebase #192 and #193 so they pick up the fixed workflows.