### PR TITLE
chore: remove stale uninstalled plugin entries from .claude/settings.json

### DIFF
--- a/.changes/unreleased/Fixed-cleanup-stale-plugin-entries.yaml
+++ b/.changes/unreleased/Fixed-cleanup-stale-plugin-entries.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Removes broken `codex`, `astral`, `worktrunk`, and `modern-go-guidelines` plugin entries from `.claude/settings.json` — uncached marketplaces `/doctor` flagged
+time: 2026-06-29T07:21:33.260952874+10:00

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,10 +25,6 @@
     "superpowers@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
-    "codex@openai-codex": true,
-    "modern-go-guidelines@goland-claude-marketplace": true,
-    "astral@astral-sh": true,
-    "worktrunk@worktrunk": true,
     "skill-creator@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true
   },
@@ -37,34 +33,6 @@
       "source": {
         "source": "github",
         "repo": "anthropics/claude-plugins-official"
-      },
-      "autoUpdate": true
-    },
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "openai/codex-plugin-cc"
-      },
-      "autoUpdate": true
-    },
-    "goland-claude-marketplace": {
-      "source": {
-        "source": "github",
-        "repo": "JetBrains/go-modern-guidelines"
-      },
-      "autoUpdate": true
-    },
-    "astral-sh": {
-      "source": {
-        "source": "github",
-        "repo": "astral-sh/claude-code-plugins"
-      },
-      "autoUpdate": true
-    },
-    "worktrunk": {
-      "source": {
-        "source": "github",
-        "repo": "max-sixty/worktrunk"
       },
       "autoUpdate": true
     }


### PR DESCRIPTION
## What

Removes four plugin entries from the repo's committed `.claude/settings.json` that were declared but never installed, along with their `extraKnownMarketplaces` declarations:

| Plugin | Marketplace | Source repo |
|---|---|---|
| `codex` | `openai-codex` | `openai/codex-plugin-cc` |
| `modern-go-guidelines` | `goland-claude-marketplace` | `JetBrains/go-modern-guidelines` |
| `astral` | `astral-sh` | `astral-sh/claude-code-plugins` |
| `worktrunk` | `worktrunk` | `max-sixty/worktrunk` |

## Why

`/doctor` flagged all four as **"not cached … run /plugins to refresh"** — their marketplaces never materialized into the local plugin cache. They aren't part of this catalog's maintenance workflow (unlike the kept entries: `superpowers`, `gopls-lsp`, `pr-review-toolkit`, `skill-creator`, `plugin-dev`), so they were removed rather than installed.

## Scope

- `enabledPlugins`: 4 entries removed; the 5 repo-relevant plugins retained.
- `extraKnownMarketplaces`: 4 declarations removed; `claude-plugins-official` retained.
- JSON validated; `32 deletions`.

The matching orphaned marketplace clones were also removed from the local install (`claude plugin marketplace remove`), but that's machine-local state — this PR only changes the committed repo config.