### PR TITLE
feat(opencode-dev): add OpenCode development plugin (7 skills + doc-review hook)

### DIFF
--- a/.changes/unreleased/Added-20260629-182015.yaml
+++ b/.changes/unreleased/Added-20260629-182015.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add the opencode-dev plugin — 7 skills for developing OpenCode (opencode.ai) solutions (plugin, sdk, agent, tools, skill, policies, delegate) plus a UserPromptSubmit doc-review hook
+time: 2026-06-29T18:20:15.398272056+10:00

--- a/.changes/unreleased/Fixed-20260629-194956.yaml
+++ b/.changes/unreleased/Fixed-20260629-194956.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'opencode-dev: fix reference pointers (.md → .rst) in opencode-sdk/agent skills, and harden the opencode-delegate companion skeleton (create cache dir before save, use fileURLToPath instead of import.meta.filename, correct SDK session.create body/data shape, handle unknown job ids in result/cancel)'
+time: 2026-06-29T19:49:56.265745382Z

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -292,6 +292,21 @@
       ]
     },
     {
+      "name": "opencode-dev",
+      "source": "./plugins/opencode-dev",
+      "description": "OpenCode development toolkit — author plugins, agents, the SDK, custom tools, skills, governance policies, and delegation harnesses",
+      "version": "0.18.0",
+      "keywords": [
+        "opencode",
+        "plugins",
+        "sdk",
+        "agents",
+        "mcp",
+        "policies",
+        "acp"
+      ]
+    },
+    {
       "name": "rdl-team",
       "source": "./plugins/rdl-team",
       "description": "RDL team workflows — Claude Code onboarding, setup, and config management",

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -314,6 +314,24 @@ Claude Code — agent-team coordination, hook authoring, and web-session setup.
 
 ---
 
+## opencode-dev
+
+OpenCode development toolkit — author plugins, agents, the SDK, custom tools, skills, governance policies, and delegation harnesses.
+
+**Skills**
+
+- `/opencode-dev:plugin`
+- `/opencode-dev:sdk`
+- `/opencode-dev:agent`
+- `/opencode-dev:tools`
+- `/opencode-dev:skill`
+- `/opencode-dev:policies`
+- `/opencode-dev:delegate`
+
+**Hooks:** `opencode-doc-review`
+
+---
+
 ## rdl-team
 
 RDL team workflows — Claude Code onboarding, setup, and config management.

--- a/hooks/opencode-doc-review.sh
+++ b/hooks/opencode-doc-review.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook (opencode-dev plugin) — nudges canonical-doc verification
+# when the user is developing an OpenCode solution.
+#
+# OpenCode (opencode.ai, SST's open-source coding agent — NOT OpenAI Codex) has a
+# young, fast-moving API that predates the model's training cutoff. This hook fires
+# only when the prompt mentions OpenCode and injects advisory context steering the
+# agent to the opencode-dev skills' verbatim references/ and the live docs before
+# writing plugin / agent / config / SDK code. Silent no-op otherwise.
+#
+# Framing is DECLARATIVE and fenced (<opencode-dev-guidance>) so it reads as
+# hook-provided context, not an injected instruction (see AGENTS.md / cc-hook's
+# safe-context-injection pattern). Emitted via the UserPromptSubmit
+# additionalContext channel (jq); falls back to plain stdout when jq is absent.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the prompt text (jq → python3 → grep), mirroring forced-eval-hook.sh.
+if command -v jq >/dev/null 2>&1; then
+  prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+elif command -v python3 >/dev/null 2>&1; then
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt") or "")' 2>/dev/null || true)
+else
+  prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
+fi
+
+# Gate: fire only on OpenCode markers. `\bopencode\b` matches "OpenCode"/"opencode"
+# as a token (not "open code"); the path and package markers catch config/SDK work.
+# "OpenAI Codex" matches none of these, so the two stay disambiguated.
+if ! printf '%s' "$prompt" | grep -qiE '\bopencode\b|\.opencode/|@opencode-ai'; then
+  exit 0
+fi
+
+read -r -d '' payload <<'CTX' || true
+<opencode-dev-guidance>
+This prompt looks like OpenCode development work. OpenCode (opencode.ai — SST's
+open-source coding agent, NOT OpenAI Codex) has a young API that moves fast and
+predates the model's training cutoff, so memory is an unreliable source here.
+
+The opencode-dev plugin ships skills for each surface — invoke the matching one:
+  /opencode-dev:plugin    plugins & hooks (the Hooks interface)
+  /opencode-dev:sdk       @opencode-ai/sdk, opencode-sdk-go, `opencode serve`
+  /opencode-dev:agent     agents, commands, AGENTS.md rules
+  /opencode-dev:tools     custom tools, MCP servers, LSP servers
+  /opencode-dev:skill     OpenCode Agent Skills + references
+  /opencode-dev:policies  experimental.policies + permissions
+  /opencode-dev:delegate  drive OpenCode from a Claude Code plugin (ACP/serve/run)
+
+Before writing any plugin / agent / config / SDK code, the reliable path is:
+  - load the matching skill and read its references/ (verbatim canonical docs),
+  - re-check the cited opencode.ai/docs/<page> for drift,
+  - prefer primary sources over recall; record version pins (Go SDK v0.19.2, Go 1.22+).
+Advisory only.
+</opencode-dev-guidance>
+CTX
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg ctx "$payload" '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: $ctx
+    }
+  }'
+else
+  printf '%s\n' "$payload"
+fi

--- a/hooks/opencode-doc-review.sh
+++ b/hooks/opencode-doc-review.sh
@@ -26,10 +26,10 @@ else
   prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
 fi
 
-# Gate: fire only on OpenCode markers. `\bopencode\b` matches "OpenCode"/"opencode"
-# as a token (not "open code"); the path and package markers catch config/SDK work.
-# "OpenAI Codex" matches none of these, so the two stay disambiguated.
-if ! printf '%s' "$prompt" | grep -qiE '\bopencode\b|\.opencode/|@opencode-ai'; then
+# Gate: fire only on OpenCode markers. Match `opencode` as a standalone token (not "open code"),
+# plus config/package markers. "OpenAI Codex" matches none of these, so the two stay disambiguated.
+# NOTE: `\b` isn't portable in grep ERE, so we use an explicit non-word boundary pattern.
+if ! printf '%s' "$prompt" | grep -qiE '(^|[^[:alnum:]_])opencode([^[:alnum:]_]|$)|\.opencode/|@opencode-ai'; then
   exit 0
 fi
 

--- a/plugins/opencode-dev/.claude-plugin/plugin.json
+++ b/plugins/opencode-dev/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "opencode-dev",
+  "version": "0.18.0",
+  "description": "OpenCode development toolkit — author plugins, agents, the SDK, custom tools, skills, governance policies, and delegation harnesses",
+  "author": {
+    "name": "nq-rdl"
+  },
+  "repository": "https://github.com/nq-rdl/agent-extensions",
+  "license": "MIT"
+}

--- a/plugins/opencode-dev/hooks/hooks.json
+++ b/plugins/opencode-dev/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Nudge canonical-doc verification when developing OpenCode solutions with opencode-dev (UserPromptSubmit, fires only on OpenCode markers)",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-doc-review.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/opencode-dev/scripts/opencode-doc-review.sh
+++ b/plugins/opencode-dev/scripts/opencode-doc-review.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook (opencode-dev plugin) — nudges canonical-doc verification
+# when the user is developing an OpenCode solution.
+#
+# OpenCode (opencode.ai, SST's open-source coding agent — NOT OpenAI Codex) has a
+# young, fast-moving API that predates the model's training cutoff. This hook fires
+# only when the prompt mentions OpenCode and injects advisory context steering the
+# agent to the opencode-dev skills' verbatim references/ and the live docs before
+# writing plugin / agent / config / SDK code. Silent no-op otherwise.
+#
+# Framing is DECLARATIVE and fenced (<opencode-dev-guidance>) so it reads as
+# hook-provided context, not an injected instruction (see AGENTS.md / cc-hook's
+# safe-context-injection pattern). Emitted via the UserPromptSubmit
+# additionalContext channel (jq); falls back to plain stdout when jq is absent.
+
+set -euo pipefail
+
+input=$(cat)
+
+# Extract the prompt text (jq → python3 → grep), mirroring forced-eval-hook.sh.
+if command -v jq >/dev/null 2>&1; then
+  prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+elif command -v python3 >/dev/null 2>&1; then
+  prompt=$(printf '%s' "$input" | python3 -c 'import sys, json; print(json.load(sys.stdin).get("prompt") or "")' 2>/dev/null || true)
+else
+  prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
+fi
+
+# Gate: fire only on OpenCode markers. `\bopencode\b` matches "OpenCode"/"opencode"
+# as a token (not "open code"); the path and package markers catch config/SDK work.
+# "OpenAI Codex" matches none of these, so the two stay disambiguated.
+if ! printf '%s' "$prompt" | grep -qiE '\bopencode\b|\.opencode/|@opencode-ai'; then
+  exit 0
+fi
+
+read -r -d '' payload <<'CTX' || true
+<opencode-dev-guidance>
+This prompt looks like OpenCode development work. OpenCode (opencode.ai — SST's
+open-source coding agent, NOT OpenAI Codex) has a young API that moves fast and
+predates the model's training cutoff, so memory is an unreliable source here.
+
+The opencode-dev plugin ships skills for each surface — invoke the matching one:
+  /opencode-dev:plugin    plugins & hooks (the Hooks interface)
+  /opencode-dev:sdk       @opencode-ai/sdk, opencode-sdk-go, `opencode serve`
+  /opencode-dev:agent     agents, commands, AGENTS.md rules
+  /opencode-dev:tools     custom tools, MCP servers, LSP servers
+  /opencode-dev:skill     OpenCode Agent Skills + references
+  /opencode-dev:policies  experimental.policies + permissions
+  /opencode-dev:delegate  drive OpenCode from a Claude Code plugin (ACP/serve/run)
+
+Before writing any plugin / agent / config / SDK code, the reliable path is:
+  - load the matching skill and read its references/ (verbatim canonical docs),
+  - re-check the cited opencode.ai/docs/<page> for drift,
+  - prefer primary sources over recall; record version pins (Go SDK v0.19.2, Go 1.22+).
+Advisory only.
+</opencode-dev-guidance>
+CTX
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg ctx "$payload" '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: $ctx
+    }
+  }'
+else
+  printf '%s\n' "$payload"
+fi

--- a/plugins/opencode-dev/scripts/opencode-doc-review.sh
+++ b/plugins/opencode-dev/scripts/opencode-doc-review.sh
@@ -26,10 +26,10 @@ else
   prompt=$(printf '%s' "$input" | grep -oP '"prompt"\s*:\s*"\K[^"]+' || true)
 fi
 
-# Gate: fire only on OpenCode markers. `\bopencode\b` matches "OpenCode"/"opencode"
-# as a token (not "open code"); the path and package markers catch config/SDK work.
-# "OpenAI Codex" matches none of these, so the two stay disambiguated.
-if ! printf '%s' "$prompt" | grep -qiE '\bopencode\b|\.opencode/|@opencode-ai'; then
+# Gate: fire only on OpenCode markers. Match `opencode` as a standalone token (not "open code"),
+# plus config/package markers. "OpenAI Codex" matches none of these, so the two stay disambiguated.
+# NOTE: `\b` isn't portable in grep ERE, so we use an explicit non-word boundary pattern.
+if ! printf '%s' "$prompt" | grep -qiE '(^|[^[:alnum:]_])opencode([^[:alnum:]_]|$)|\.opencode/|@opencode-ai'; then
   exit 0
 fi
 

--- a/plugins/opencode-dev/skills/agent/SKILL.md
+++ b/plugins/opencode-dev/skills/agent/SKILL.md
@@ -48,7 +48,7 @@ in `opencode.json` — no code required.
 | **Filename = name** | `description:`/`name:` field sets the id | The **markdown filename** is the id: `review.md` → `review` agent; `test.md` → `/test` command |
 | **No CLAUDE.md fallback awareness** | Assuming only `AGENTS.md` is read | OpenCode falls back to `CLAUDE.md` / `~/.claude/CLAUDE.md` when no `AGENTS.md` |
 
-Read `references/*.md` before writing — these are the only non-obvious bits.
+Read `references/*.rst` before writing — these are the only non-obvious bits.
 
 ---
 

--- a/plugins/opencode-dev/skills/agent/SKILL.md
+++ b/plugins/opencode-dev/skills/agent/SKILL.md
@@ -1,0 +1,159 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode (SST's open-source coding agent, opencode.ai — NOT OpenAI
+  Codex) agents, custom commands, and project rules as markdown/JSON config. Use
+  when creating or editing files under `.opencode/agents/`, `.opencode/commands/`,
+  or `AGENTS.md`; setting an agent's `mode` (primary/subagent/all), `model`,
+  `permission`, `steps`, or `temperature`; templating commands with `$ARGUMENTS`,
+  `$1`, shell injection `` !`cmd` ``, or `@file` references; wiring the
+  `instructions` config key; or debugging why a `tools:` field, `maxSteps`, a
+  `/docs/modes/` link, or a `CLAUDE.md` fallback isn't behaving. Triggers: "opencode
+  subagent", "opencode custom command", "AGENTS.md", "opencode agent frontmatter".
+argument-hint: "What agent/command/rule do you want to build? (e.g. 'a read-only review subagent', 'a /test command with args', 'why is my CLAUDE.md ignored')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode agents, commands & rules
+
+OpenCode's config-as-markdown surface: **agents** (specialized assistants),
+**custom commands** (reusable prompt templates), and **rules** (`AGENTS.md`
+project instructions). All three are plain markdown-with-frontmatter or JSON keys
+in `opencode.json` — no code required.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing agent/command/rule config, read
+> `references/agents.rst`, `references/commands.rst`, or `references/rules.rst` AND
+> re-check <https://opencode.ai/docs/agents/> (and `/docs/commands/`, `/docs/rules/`)
+> for drift. The traps below are the deltas a fresh model gets wrong.
+>
+> Three claims here have **no dated vendored reference** and are author-knowledge —
+> re-check the live page before relying on them: the `/docs/modes/` 404 and "singular
+> dirs accepted for back-compat" (no `references/` source), and the config merge-order
+> chain under "Config & precedence" (a `/docs/config/` claim — no `references/config.rst`).
+
+---
+
+## The traps (what a fresh model gets wrong)
+
+| Trap | Wrong (don't) | Right (do) |
+|------|---------------|------------|
+| **Modes are gone** | Looking up `/docs/modes/` — it **404s** | `mode` is now an **agent field**: `primary` \| `subagent` \| `all` (default `all`) |
+| **`tools:` deprecated** | `tools: { write: false }` per agent | Use `permission:` (`allow`/`ask`/`deny`); `tools` still parses but is legacy |
+| **`maxSteps`** | `maxSteps: 5` | `steps: 5` — `maxSteps` is **deprecated** |
+| **Dir is plural** | `.opencode/agent/`, `.opencode/command/` | `.opencode/agents/`, `.opencode/commands/` (singular accepted for back-compat only) |
+| **Filename = name** | `description:`/`name:` field sets the id | The **markdown filename** is the id: `review.md` → `review` agent; `test.md` → `/test` command |
+| **No CLAUDE.md fallback awareness** | Assuming only `AGENTS.md` is read | OpenCode falls back to `CLAUDE.md` / `~/.claude/CLAUDE.md` when no `AGENTS.md` |
+
+Read `references/*.md` before writing — these are the only non-obvious bits.
+
+---
+
+## Agents
+
+Two types. **Primary** = main assistant you drive (Tab / `switch_agent` keybind to
+cycle); **subagent** = invoked by a primary or by `@mention`. Built-in primaries:
+`build` (all tools), `plan` (`edit`+`bash` default to `ask`). Built-in subagents:
+`general`, `explore`, `scout`. Declare in `opencode.json` under the `agent` key, or
+as one markdown file per agent in **plural** `.opencode/agents/` (project) or
+`~/.config/opencode/agents/` (global). **The filename is the agent name.**
+
+Frontmatter fields (see `references/agents.rst` for the full table):
+
+| Field | Notes |
+|-------|-------|
+| `description` | **Required.** What it does / when to use it (drives auto-invocation) |
+| `mode` | `primary` \| `subagent` \| `all` — defaults to `all` |
+| `permission` | **Preferred** access control — per-tool `allow`/`ask`/`deny`, or `{pattern: level}` |
+| `steps` | Max agentic iterations (**not** `maxSteps`) |
+| `prompt` | System prompt — inline string or `{file:./prompts/x.txt}` (relative to config) |
+| `disable` / `hidden` / `color` | Off / hide from `@`-menu (subagents only) / UI color |
+| `tools` | **Deprecated** — migrate to `permission` |
+
+`permission` keys gate tools (not 1:1 with tool names): `edit` covers
+**`write` + `edit` + `apply_patch`**; `todowrite` covers `todowrite` + `todoread`.
+Two disjoint sets (not a positional prefix — verify in `references/agents.rst`):
+**glob-capable** keys accept a shorthand action **or** a `{glob: action}` map —
+`read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `external_directory`, `lsp`,
+`skill`; **shorthand-only** keys take the action only — `todowrite`, `webfetch`,
+`websearch`, `question`, `doom_loop`. **Last matching rule wins** —
+put `"*"` first, exceptions after. `permission.task` (a glob map) controls which
+subagents this agent may invoke via the Task tool. Per-agent `permission` overrides
+top-level. Scaffold interactively with `opencode agent create`. See
+`assets/agent.md`.
+
+## Custom commands
+
+Markdown files in **plural** `.opencode/commands/` (or `~/.config/opencode/commands/`)
+— **filename = command name** (`test.md` → `/test`). The body is the **prompt
+template**; frontmatter configures it. JSON form lives under the `command` key and
+**requires `template`** (the body equivalent).
+
+Frontmatter / JSON fields: `description`, `agent` (which agent runs it — if that's a
+subagent, it triggers a subagent invocation **by default**), `subtask` (`true` forces
+subagent even for a `primary` agent; `false` disables the auto-subtask), `model`.
+
+Template syntax (in the body / `template`):
+
+- `$ARGUMENTS` — all args; `$1`, `$2`, `$3`, … — positional args.
+- `` !`command` `` — runs in the **project root**, splices stdout into the prompt.
+- `@path/to/file` — includes file content in the prompt.
+
+Built-ins `/init`, `/undo`, `/redo`, `/share`, `/help` are **overridable** by a
+same-named custom command. See `assets/command.md`.
+
+## Rules (AGENTS.md)
+
+Project instructions go in `AGENTS.md` at the repo root (commit it; `/init`
+generates/updates it). Global rules: `~/.config/opencode/AGENTS.md`.
+
+**Claude Code compatibility (the key delta):** when no `AGENTS.md` exists, OpenCode
+falls back to `CLAUDE.md` (project) and `~/.claude/CLAUDE.md` (global). Precedence on
+startup: (1) local files walking **up** from cwd (`AGENTS.md`, then `CLAUDE.md`),
+(2) global `~/.config/opencode/AGENTS.md`, (3) `~/.claude/CLAUDE.md`. **First match
+wins per category** — if both `AGENTS.md` and `CLAUDE.md` exist, only `AGENTS.md` is
+used. Disable the fallback with env vars:
+
+```bash
+export OPENCODE_DISABLE_CLAUDE_CODE=1        # all .claude support
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1 # only ~/.claude/CLAUDE.md
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # only .claude/skills
+```
+
+Add extra instruction files via the `instructions` config key (globs + remote URLs;
+URLs fetched with a 5s timeout) — these **combine** with `AGENTS.md`:
+
+```json
+{ "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", "packages/*/AGENTS.md"] }
+```
+
+> `AGENTS.md` does **not** auto-parse `@file` references — use `instructions` for
+> file inclusion, or write explicit "Read @x on demand" prose in the body.
+
+---
+
+## Config & precedence (shared)
+
+Config files **merge** (later overrides earlier): remote `.well-known/opencode` →
+global `~/.config/opencode/opencode.json` → `OPENCODE_CONFIG` → project
+`opencode.json` → `.opencode/` dirs → `OPENCODE_CONFIG_CONTENT` → managed files.
+Substitution: `{env:VAR}`, `{file:path}`. Full model: `/docs/config/`.
+
+## References
+
+| File | Source |
+|------|--------|
+| [references/agents.rst](references/agents.rst) | `/docs/agents/` — frontmatter, permission table, built-ins, `opencode agent create` |
+| [references/commands.rst](references/commands.rst) | `/docs/commands/` — templating, `$ARGUMENTS`/`!cmd`/`@file`, JSON `template` |
+| [references/rules.rst](references/rules.rst) | `/docs/rules/` — `AGENTS.md`, `CLAUDE.md` fallback, `instructions` key |
+
+## Assets
+
+| File | What it is |
+|------|------------|
+| [assets/agent.md](assets/agent.md) | A read-only review subagent (markdown, `permission`-based) |
+| [assets/command.md](assets/command.md) | A `/test` command using `$ARGUMENTS`, `` !`cmd` ``, and `@file` |

--- a/plugins/opencode-dev/skills/agent/assets/agent.md
+++ b/plugins/opencode-dev/skills/agent/assets/agent.md
@@ -1,0 +1,24 @@
+---
+# Save as .opencode/agents/review.md (project) or ~/.config/opencode/agents/review.md
+# The FILENAME is the agent name → this is the `review` subagent (@review).
+description: Reviews code for quality and best practices  # REQUIRED
+mode: subagent          # primary | subagent | all  (default: all)
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.1
+steps: 20               # max agentic iterations — NOT `maxSteps` (deprecated)
+permission:             # PREFERRED over the deprecated `tools:` field
+  edit: deny            # `edit` gates write + edit + apply_patch
+  bash:
+    "*": ask            # last matching rule wins → put "*" first
+    "git diff": allow
+    "git log*": allow
+  webfetch: deny
+---
+
+You are in code review mode. Focus on:
+
+- Code quality and best practices
+- Potential bugs and edge cases
+- Performance and security implications
+
+Provide constructive feedback without making direct changes.

--- a/plugins/opencode-dev/skills/agent/assets/command.md
+++ b/plugins/opencode-dev/skills/agent/assets/command.md
@@ -1,0 +1,19 @@
+---
+# Save as .opencode/commands/test.md (project) or ~/.config/opencode/commands/test.md
+# The FILENAME is the command name → run this as `/test`.
+# The body below is the prompt TEMPLATE (JSON form puts it under `command.test.template`).
+description: Run tests with coverage and triage failures
+agent: build         # which agent runs it; if a subagent, runs as a subtask by default
+# subtask: true      # force a subagent invocation even for a `primary` agent
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the test suite (focus area: $ARGUMENTS — first arg $1).
+
+Current results (shell output spliced in; runs in the project root):
+!`npm test`
+
+Project test config for reference:
+@vitest.config.ts
+
+Based on these results, list each failing test and suggest a concrete fix.

--- a/plugins/opencode-dev/skills/agent/references/agents.rst
+++ b/plugins/opencode-dev/skills/agent/references/agents.rst
@@ -1,0 +1,783 @@
+<!-- Source: https://opencode.ai/docs/agents/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Agents
+description: Configure and use specialized agents.
+---
+
+Agents are specialized AI assistants that can be configured for specific tasks and workflows. They allow you to create focused tools with custom prompts, models, and tool access.
+
+:::tip
+Use the plan agent to analyze code and review suggestions without making any code changes.
+:::
+
+You can switch between agents during a session or invoke them with the `@` mention.
+
+---
+
+## Types
+
+There are two types of agents in OpenCode; primary agents and subagents.
+
+---
+
+### Primary agents
+
+Primary agents are the main assistants you interact with directly. You can cycle through them using the **Tab** key, or your configured `switch_agent` keybind. These agents handle your main conversation. Tool access is configured via permissions — for example, Build has all tools enabled while Plan is restricted.
+
+:::tip
+You can use the **Tab** key to switch between primary agents during a session.
+:::
+
+OpenCode comes with two built-in primary agents, **Build** and **Plan**. We'll
+look at these below.
+
+---
+
+### Subagents
+
+Subagents are specialized assistants that primary agents can invoke for specific tasks. You can also manually invoke them by **@ mentioning** them in your messages.
+
+OpenCode comes with three built-in subagents, **General**, **Explore**, and **Scout**. We'll look at this below.
+
+---
+
+## Built-in
+
+OpenCode comes with two built-in primary agents and three built-in subagents.
+
+---
+
+### Use build
+
+_Mode_: `primary`
+
+Build is the **default** primary agent with all tools enabled. This is the standard agent for development work where you need full access to file operations and system commands.
+
+---
+
+### Use plan
+
+_Mode_: `primary`
+
+A restricted agent designed for planning and analysis. We use a permission system to give you more control and prevent unintended changes.
+By default, all of the following are set to `ask`:
+
+- `file edits`: All writes, patches, and edits
+- `bash`: All bash commands
+
+This agent is useful when you want the LLM to analyze code, suggest changes, or create plans without making any actual modifications to your codebase.
+
+---
+
+### Use general
+
+_Mode_: `subagent`
+
+A general-purpose agent for researching complex questions and executing multi-step tasks. Has full tool access (except todo), so it can make file changes when needed. Use this to run multiple units of work in parallel.
+
+---
+
+### Use explore
+
+_Mode_: `subagent`
+
+A fast, read-only agent for exploring codebases. Cannot modify files. Use this when you need to quickly find files by patterns, search code for keywords, or answer questions about the codebase.
+
+---
+
+### Use scout
+
+_Mode_: `subagent`
+
+A read-only agent for external docs and dependency research. Use this when you need to clone a dependency repository into OpenCode's managed cache, inspect library source, or cross-reference local code against upstream implementations without modifying your workspace.
+
+---
+
+### Use compaction
+
+_Mode_: `primary`
+
+Hidden system agent that compacts long context into a smaller summary. It runs automatically when needed and is not selectable in the UI.
+
+---
+
+### Use title
+
+_Mode_: `primary`
+
+Hidden system agent that generates short session titles. It runs automatically and is not selectable in the UI.
+
+---
+
+### Use summary
+
+_Mode_: `primary`
+
+Hidden system agent that creates session summaries. It runs automatically and is not selectable in the UI.
+
+---
+
+## Usage
+
+1. For primary agents, use the **Tab** key to cycle through them during a session. You can also use your configured `switch_agent` keybind.
+
+2. Subagents can be invoked:
+   - **Automatically** by primary agents for specialized tasks based on their descriptions.
+   - Manually by **@ mentioning** a subagent in your message. For example.
+
+     ```txt frame="none"
+     @general help me search for this function
+     ```
+
+3. **Navigation between sessions**: When subagents create child sessions, use `session_child_first` (default: **\<Leader>+Down**) to enter the first child session from the parent.
+
+4. Once you are in a child session, use:
+   - `session_child_cycle` (default: **Right**) to cycle to the next child session
+   - `session_child_cycle_reverse` (default: **Left**) to cycle to the previous child session
+   - `session_parent` (default: **Up**) to return to the parent session
+
+   This lets you switch between the main conversation and specialized subagent work.
+
+---
+
+## Configure
+
+You can customize the built-in agents or create your own through configuration. Agents can be configured in two ways:
+
+---
+
+### JSON
+
+Configure agents in your `opencode.json` config file:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "mode": "primary",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "{file:./prompts/build.txt}",
+      "permission": {
+        "edit": "allow",
+        "bash": "allow"
+      }
+    },
+    "plan": {
+      "mode": "primary",
+      "model": "anthropic/claude-haiku-4-20250514",
+      "permission": {
+        "edit": "deny",
+        "bash": "deny"
+      }
+    },
+    "code-reviewer": {
+      "description": "Reviews code for best practices and potential issues",
+      "mode": "subagent",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "permission": {
+        "edit": "deny"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Markdown
+
+You can also define agents using markdown files. Place them in:
+
+- Global: `~/.config/opencode/agents/`
+- Per-project: `.opencode/agents/`
+
+```markdown title="~/.config/opencode/agents/review.md"
+---
+description: Reviews code for quality and best practices
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+---
+
+You are in code review mode. Focus on:
+
+- Code quality and best practices
+- Potential bugs and edge cases
+- Performance implications
+- Security considerations
+
+Provide constructive feedback without making direct changes.
+```
+
+The markdown file name becomes the agent name. For example, `review.md` creates a `review` agent.
+
+---
+
+## Options
+
+Let's look at these configuration options in detail.
+
+---
+
+### Description
+
+Use the `description` option to provide a brief description of what the agent does and when to use it.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "description": "Reviews code for best practices and potential issues"
+    }
+  }
+}
+```
+
+This is a **required** config option.
+
+---
+
+### Temperature
+
+Control the randomness and creativity of the LLM's responses with the `temperature` config.
+
+Lower values make responses more focused and deterministic, while higher values increase creativity and variability.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "plan": {
+      "temperature": 0.1
+    },
+    "creative": {
+      "temperature": 0.8
+    }
+  }
+}
+```
+
+Temperature values typically range from 0.0 to 1.0:
+
+- **0.0-0.2**: Very focused and deterministic responses, ideal for code analysis and planning
+- **0.3-0.5**: Balanced responses with some creativity, good for general development tasks
+- **0.6-1.0**: More creative and varied responses, useful for brainstorming and exploration
+
+```json title="opencode.json"
+{
+  "agent": {
+    "analyze": {
+      "temperature": 0.1,
+      "prompt": "{file:./prompts/analysis.txt}"
+    },
+    "build": {
+      "temperature": 0.3
+    },
+    "brainstorm": {
+      "temperature": 0.7,
+      "prompt": "{file:./prompts/creative.txt}"
+    }
+  }
+}
+```
+
+If no temperature is specified, OpenCode uses model-specific defaults; typically 0 for most models, 0.55 for Qwen models.
+
+---
+
+### Max steps
+
+Control the maximum number of agentic iterations an agent can perform before being forced to respond with text only. This allows users who wish to control costs to set a limit on agentic actions.
+
+If this is not set, the agent will continue to iterate until the model chooses to stop or the user interrupts the session.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "quick-thinker": {
+      "description": "Fast reasoning with limited iterations",
+      "prompt": "You are a quick thinker. Solve problems with minimal steps.",
+      "steps": 5
+    }
+  }
+}
+```
+
+When the limit is reached, the agent receives a special system prompt instructing it to respond with a summarization of its work and recommended remaining tasks.
+
+:::caution
+The legacy `maxSteps` field is deprecated. Use `steps` instead.
+:::
+
+---
+
+### Disable
+
+Set to `true` to disable the agent.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "disable": true
+    }
+  }
+}
+```
+
+---
+
+### Prompt
+
+Specify a custom system prompt file for this agent with the `prompt` config. The prompt file should contain instructions specific to the agent's purpose.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "prompt": "{file:./prompts/code-review.txt}"
+    }
+  }
+}
+```
+
+This path is relative to where the config file is located. So this works for both the global OpenCode config and the project specific config.
+
+---
+
+### Model
+
+Use the `model` config to override the model for this agent. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
+
+:::tip
+If you don’t specify a model, primary agents use the [model globally configured](/docs/config#models) while subagents will use the model of the primary agent that invoked the subagent.
+:::
+
+```json title="opencode.json"
+{
+  "agent": {
+    "plan": {
+      "model": "anthropic/claude-haiku-4-20250514"
+    }
+  }
+}
+```
+
+The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
+
+---
+
+### Tools (deprecated)
+
+`tools` is **deprecated**. Prefer the agent's [`permission`](#permissions) field for new configs, updates and more fine-grained control.
+
+Allows you to control which tools are available in this agent. You can enable or disable specific tools by setting them to `true` or `false`. In an agent's `tools` config, `true` is equivalent to `{"*": "allow"}` permission and `false` is equivalent to `{"*": "deny"}` permission.
+
+```json title="opencode.json" {3-6,9-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tools": {
+    "write": true,
+    "bash": true
+  },
+  "agent": {
+    "plan": {
+      "tools": {
+        "write": false,
+        "bash": false
+      }
+    }
+  }
+}
+```
+
+:::note
+The agent-specific config overrides the global config.
+:::
+
+You can also use wildcards in legacy `tools` entries to control multiple tools at once. For example, to disable all tools from an MCP server:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "readonly": {
+      "tools": {
+        "mymcp_*": false,
+        "write": false,
+        "edit": false
+      }
+    }
+  }
+}
+```
+
+[Learn more about tools](/docs/tools).
+
+---
+
+### Permissions
+
+You can configure permissions to manage what actions an agent can take. Each permission key can be set to:
+
+- `"ask"` — Prompt for approval before running the tool
+- `"allow"` — Allow all operations without approval
+- `"deny"` — Disable the tool
+
+The available permission keys are:
+
+| Key                  | Tools it gates                                                   |
+| -------------------- | ---------------------------------------------------------------- |
+| `read`               | `read`                                                           |
+| `edit`               | `write`, `edit`, `apply_patch`                                   |
+| `glob`               | `glob`                                                           |
+| `grep`               | `grep`                                                           |
+| `list`               | `list`                                                           |
+| `bash`               | `bash`                                                           |
+| `task`               | `task`                                                           |
+| `external_directory` | Any tool that reads or writes files outside the project worktree |
+| `todowrite`          | `todowrite`, `todoread`                                          |
+| `webfetch`           | `webfetch`                                                       |
+| `websearch`          | `websearch`                                                      |
+| `lsp`                | `lsp`                                                            |
+| `skill`              | `skill`                                                          |
+| `question`           | `question`                                                       |
+| `doom_loop`          | Recovery prompts when an agent appears stuck                     |
+
+`read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `external_directory`, `lsp`, and `skill` accept either a shorthand action (`"allow" | "ask" | "deny"`) or an object of glob/pattern → action for fine-grained control. The remaining keys accept the shorthand action only.
+
+:::note
+Permission keys are matched as wildcard patterns against the underlying tool name, so the same syntax works for built-ins, custom tools, and MCP tools — for example `"mymcp_*": "deny"` denies every tool from an MCP server, and `"mymcp_search": "ask"` targets a single one.
+:::
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny"
+  }
+}
+```
+
+You can override these permissions per agent.
+
+```json title="opencode.json" {3-5,8-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny"
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "edit": "ask"
+      }
+    }
+  }
+}
+```
+
+You can also set permissions in Markdown agents.
+
+```markdown title="~/.config/opencode/agents/review.md"
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash:
+    "*": ask
+    "git diff": allow
+    "git log*": allow
+    "grep *": allow
+  webfetch: deny
+---
+
+Only analyze code and suggest changes.
+```
+
+You can set permissions for specific bash commands.
+
+```json title="opencode.json" {7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git push": "ask",
+          "grep *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+This can take a glob pattern.
+
+```json title="opencode.json" {7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git *": "ask"
+        }
+      }
+    }
+  }
+}
+```
+
+And you can also use the `*` wildcard to manage permissions for all commands.
+Since the last matching rule takes precedence, put the `*` wildcard first and specific rules after.
+
+```json title="opencode.json" {8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git status *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+[Learn more about permissions](/docs/permissions).
+
+---
+
+### Mode
+
+Control the agent's mode with the `mode` config. The `mode` option is used to determine how the agent can be used.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "mode": "subagent"
+    }
+  }
+}
+```
+
+The `mode` option can be set to `primary`, `subagent`, or `all`. If no `mode` is specified, it defaults to `all`.
+
+---
+
+### Hidden
+
+Hide a subagent from the `@` autocomplete menu with `hidden: true`. Useful for internal subagents that should only be invoked programmatically by other agents via the Task tool.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "internal-helper": {
+      "mode": "subagent",
+      "hidden": true
+    }
+  }
+}
+```
+
+This only affects user visibility in the autocomplete menu. Hidden agents can still be invoked by the model via the Task tool if permissions allow.
+
+:::note
+Only applies to `mode: subagent` agents.
+:::
+
+---
+
+### Task permissions
+
+Control which subagents an agent can invoke via the Task tool with `permission.task`. Uses glob patterns for flexible matching.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "orchestrator": {
+      "mode": "primary",
+      "permission": {
+        "task": {
+          "*": "deny",
+          "orchestrator-*": "allow",
+          "code-reviewer": "ask"
+        }
+      }
+    }
+  }
+}
+```
+
+When set to `deny`, the subagent is removed from the Task tool description entirely, so the model won't attempt to invoke it.
+
+:::tip
+Rules are evaluated in order, and the **last matching rule wins**. In the example above, `orchestrator-planner` matches both `*` (deny) and `orchestrator-*` (allow), but since `orchestrator-*` comes after `*`, the result is `allow`.
+:::
+
+:::tip
+Users can always invoke any subagent directly via the `@` autocomplete menu, even if the agent's task permissions would deny it.
+:::
+
+---
+
+### Color
+
+Customize the agent's visual appearance in the UI with the `color` option. This affects how the agent appears in the interface.
+
+Use a valid hex color (e.g., `#FF5733`) or theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "creative": {
+      "color": "#ff6b6b"
+    },
+    "code-reviewer": {
+      "color": "accent"
+    }
+  }
+}
+```
+
+---
+
+### Top P
+
+Control response diversity with the `top_p` option. Alternative to temperature for controlling randomness.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "brainstorm": {
+      "top_p": 0.9
+    }
+  }
+}
+```
+
+Values range from 0.0 to 1.0. Lower values are more focused, higher values more diverse.
+
+---
+
+### Additional
+
+Any other options you specify in your agent configuration will be **passed through directly** to the provider as model options. This allows you to use provider-specific features and parameters.
+
+For example, with OpenAI's reasoning models, you can control the reasoning effort:
+
+```json title="opencode.json" {6,7}
+{
+  "agent": {
+    "deep-thinker": {
+      "description": "Agent that uses high reasoning effort for complex problems",
+      "model": "openai/gpt-5",
+      "reasoningEffort": "high",
+      "textVerbosity": "low"
+    }
+  }
+}
+```
+
+These additional options are model and provider-specific. Check your provider's documentation for available parameters.
+
+:::tip
+Run `opencode models` to see a list of the available models.
+:::
+
+---
+
+## Create agents
+
+You can create new agents using the following command:
+
+```bash
+opencode agent create
+```
+
+This interactive command will:
+
+1. Ask where to save the agent; global or project-specific.
+2. Description of what the agent should do.
+3. Generate an appropriate system prompt and identifier.
+4. Let you select which permissions the agent should be allowed (anything you don't select is denied).
+5. Finally, create a markdown file with the agent configuration.
+
+---
+
+## Use cases
+
+Here are some common use cases for different agents.
+
+- **Build agent**: Full development work with all tools enabled
+- **Plan agent**: Analysis and planning without making changes
+- **Review agent**: Code review with read-only access plus documentation tools
+- **Debug agent**: Focused on investigation with bash and read tools enabled
+- **Docs agent**: Documentation writing with file operations but no system commands
+
+---
+
+## Examples
+
+Here are some example agents you might find useful.
+
+:::tip
+Do you have an agent you'd like to share? [Submit a PR](https://github.com/anomalyco/opencode).
+:::
+
+---
+
+### Documentation agent
+
+```markdown title="~/.config/opencode/agents/docs-writer.md"
+---
+description: Writes and maintains project documentation
+mode: subagent
+permission:
+  bash: deny
+---
+
+You are a technical writer. Create clear, comprehensive documentation.
+
+Focus on:
+
+- Clear explanations
+- Proper structure
+- Code examples
+- User-friendly language
+```
+
+---
+
+### Security auditor
+
+```markdown title="~/.config/opencode/agents/security-auditor.md"
+---
+description: Performs security audits and identifies vulnerabilities
+mode: subagent
+permission:
+  edit: deny
+---
+
+You are a security expert. Focus on identifying potential security issues.
+
+Look for:
+
+- Input validation vulnerabilities
+- Authentication and authorization flaws
+- Data exposure risks
+- Dependency vulnerabilities
+- Configuration security issues
+```

--- a/plugins/opencode-dev/skills/agent/references/commands.rst
+++ b/plugins/opencode-dev/skills/agent/references/commands.rst
@@ -1,0 +1,325 @@
+<!-- Source: https://opencode.ai/docs/commands/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Commands
+description: Create custom commands for repetitive tasks.
+---
+
+Custom commands let you specify a prompt you want to run when that command is executed in the TUI.
+
+```bash frame="none"
+/my-command
+```
+
+Custom commands are in addition to the built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`. [Learn more](/docs/tui#commands).
+
+---
+
+## Create command files
+
+Create markdown files in the `commands/` directory to define custom commands.
+
+Create `.opencode/commands/test.md`:
+
+```md title=".opencode/commands/test.md"
+---
+description: Run tests with coverage
+agent: build
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the full test suite with coverage report and show any failures.
+Focus on the failing tests and suggest fixes.
+```
+
+The frontmatter defines command properties. The content becomes the template.
+
+Use the command by typing `/` followed by the command name.
+
+```bash frame="none"
+"/test"
+```
+
+---
+
+## Configure
+
+You can add custom commands through the OpenCode config or by creating markdown files in the `commands/` directory.
+
+---
+
+### JSON
+
+Use the `command` option in your OpenCode [config](/docs/config):
+
+```json title="opencode.jsonc" {4-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "command": {
+    // This becomes the name of the command
+    "test": {
+      // This is the prompt that will be sent to the LLM
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
+      // This is shown as the description in the TUI
+      "description": "Run tests with coverage",
+      "agent": "build",
+      "model": "anthropic/claude-3-5-sonnet-20241022"
+    }
+  }
+}
+```
+
+Now you can run this command in the TUI:
+
+```bash frame="none"
+/test
+```
+
+---
+
+### Markdown
+
+You can also define commands using markdown files. Place them in:
+
+- Global: `~/.config/opencode/commands/`
+- Per-project: `.opencode/commands/`
+
+```markdown title="~/.config/opencode/commands/test.md"
+---
+description: Run tests with coverage
+agent: build
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the full test suite with coverage report and show any failures.
+Focus on the failing tests and suggest fixes.
+```
+
+The markdown file name becomes the command name. For example, `test.md` lets
+you run:
+
+```bash frame="none"
+/test
+```
+
+---
+
+## Prompt config
+
+The prompts for the custom commands support several special placeholders and syntax.
+
+---
+
+### Arguments
+
+Pass arguments to commands using the `$ARGUMENTS` placeholder.
+
+```md title=".opencode/commands/component.md"
+---
+description: Create a new component
+---
+
+Create a new React component named $ARGUMENTS with TypeScript support.
+Include proper typing and basic structure.
+```
+
+Run the command with arguments:
+
+```bash frame="none"
+/component Button
+```
+
+And `$ARGUMENTS` will be replaced with `Button`.
+
+You can also access individual arguments using positional parameters:
+
+- `$1` - First argument
+- `$2` - Second argument
+- `$3` - Third argument
+- And so on...
+
+For example:
+
+```md title=".opencode/commands/create-file.md"
+---
+description: Create a new file with content
+---
+
+Create a file named $1 in the directory $2
+with the following content: $3
+```
+
+Run the command:
+
+```bash frame="none"
+/create-file config.json src "{ \"key\": \"value\" }"
+```
+
+This replaces:
+
+- `$1` with `config.json`
+- `$2` with `src`
+- `$3` with `{ "key": "value" }`
+
+---
+
+### Shell output
+
+Use _!`command`_ to inject [bash command](/docs/tui#bash-commands) output into your prompt.
+
+For example, to create a custom command that analyzes test coverage:
+
+```md title=".opencode/commands/analyze-coverage.md"
+---
+description: Analyze test coverage
+---
+
+Here are the current test results:
+!`npm test`
+
+Based on these results, suggest improvements to increase coverage.
+```
+
+Or to review recent changes:
+
+```md title=".opencode/commands/review-changes.md"
+---
+description: Review recent changes
+---
+
+Recent git commits:
+!`git log --oneline -10`
+
+Review these changes and suggest any improvements.
+```
+
+Commands run in your project's root directory and their output becomes part of the prompt.
+
+---
+
+### File references
+
+Include files in your command using `@` followed by the filename.
+
+```md title=".opencode/commands/review-component.md"
+---
+description: Review component
+---
+
+Review the component in @src/components/Button.tsx.
+Check for performance issues and suggest improvements.
+```
+
+The file content gets included in the prompt automatically.
+
+---
+
+## Options
+
+Let's look at the configuration options in detail.
+
+---
+
+### Template
+
+The `template` option defines the prompt that will be sent to the LLM when the command is executed.
+
+```json title="opencode.json"
+{
+  "command": {
+    "test": {
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes."
+    }
+  }
+}
+```
+
+This is a **required** config option.
+
+---
+
+### Description
+
+Use the `description` option to provide a brief description of what the command does.
+
+```json title="opencode.json"
+{
+  "command": {
+    "test": {
+      "description": "Run tests with coverage"
+    }
+  }
+}
+```
+
+This is shown as the description in the TUI when you type in the command.
+
+---
+
+### Agent
+
+Use the `agent` config to optionally specify which [agent](/docs/agents) should execute this command.
+If this is a [subagent](/docs/agents/#subagents) the command will trigger a subagent invocation by default.
+To disable this behavior, set `subtask` to `false`.
+
+```json title="opencode.json"
+{
+  "command": {
+    "review": {
+      "agent": "plan"
+    }
+  }
+}
+```
+
+This is an **optional** config option. If not specified, defaults to your current agent.
+
+---
+
+### Subtask
+
+Use the `subtask` boolean to force the command to trigger a [subagent](/docs/agents/#subagents) invocation.
+This is useful if you want the command to not pollute your primary context and will **force** the agent to act as a subagent,
+even if `mode` is set to `primary` on the [agent](/docs/agents) configuration.
+
+```json title="opencode.json"
+{
+  "command": {
+    "analyze": {
+      "subtask": true
+    }
+  }
+}
+```
+
+This is an **optional** config option.
+
+---
+
+### Model
+
+Use the `model` config to override the default model for this command.
+
+```json title="opencode.json"
+{
+  "command": {
+    "analyze": {
+      "model": "anthropic/claude-3-5-sonnet-20241022"
+    }
+  }
+}
+```
+
+This is an **optional** config option.
+
+---
+
+## Built-in
+
+opencode includes several built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`; [learn more](/docs/tui#commands).
+
+:::note
+Custom commands can override built-in commands.
+:::
+
+If you define a custom command with the same name, it will override the built-in command.

--- a/plugins/opencode-dev/skills/agent/references/rules.rst
+++ b/plugins/opencode-dev/skills/agent/references/rules.rst
@@ -1,0 +1,190 @@
+<!-- Source: https://opencode.ai/docs/rules/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Rules
+description: Set custom instructions for opencode.
+---
+
+You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
+
+---
+
+## Initialize
+
+To create a new `AGENTS.md` file, you can run the `/init` command in opencode.
+
+:::tip
+You should commit your project's `AGENTS.md` file to Git.
+:::
+
+`/init` scans the important files in your repo, may ask a couple of targeted questions when the codebase cannot answer them, and then creates or updates `AGENTS.md` with concise project-specific guidance.
+
+It focuses on the things future agent sessions are most likely to need:
+
+- build, lint, and test commands
+- command order and focused verification steps when they matter
+- architecture and repo structure that are not obvious from filenames alone
+- project-specific conventions, setup quirks, and operational gotchas
+- references to existing instruction sources like Cursor or Copilot rules
+
+If you already have an `AGENTS.md`, `/init` will improve it in place instead of blindly replacing it.
+
+---
+
+## Example
+
+You can also just create this file manually. Here's an example of some things you can put into an `AGENTS.md` file.
+
+```markdown title="AGENTS.md"
+# SST v3 Monorepo Project
+
+This is an SST v3 monorepo with TypeScript. The project uses bun workspaces for package management.
+
+## Project Structure
+
+- `packages/` - Contains all workspace packages (functions, core, web, etc.)
+- `infra/` - Infrastructure definitions split by service (storage.ts, api.ts, web.ts)
+- `sst.config.ts` - Main SST configuration with dynamic imports
+
+## Code Standards
+
+- Use TypeScript with strict mode enabled
+- Shared code goes in `packages/core/` with proper exports configuration
+- Functions go in `packages/functions/`
+- Infrastructure should be split into logical files in `infra/`
+
+## Monorepo Conventions
+
+- Import shared modules using workspace names: `@my-app/core/example`
+```
+
+We are adding project-specific instructions here and this will be shared across your team.
+
+---
+
+## Types
+
+opencode also supports reading the `AGENTS.md` file from multiple locations. And this serves different purposes.
+
+### Project
+
+Place an `AGENTS.md` in your project root for project-specific rules. These only apply when you are working in this directory or its sub-directories.
+
+### Global
+
+You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This gets applied across all opencode sessions.
+
+Since this isn't committed to Git or shared with your team, we recommend using this to specify any personal rules that the LLM should follow.
+
+### Claude Code Compatibility
+
+For users migrating from Claude Code, OpenCode supports Claude Code's file conventions as fallbacks:
+
+- **Project rules**: `CLAUDE.md` in your project directory (used if no `AGENTS.md` exists)
+- **Global rules**: `~/.claude/CLAUDE.md` (used if no `~/.config/opencode/AGENTS.md` exists)
+- **Skills**: `~/.claude/skills/` — see [Agent Skills](/docs/skills/) for details
+
+To disable Claude Code compatibility, set one of these environment variables:
+
+```bash
+export OPENCODE_DISABLE_CLAUDE_CODE=1        # Disable all .claude support
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1 # Disable only ~/.claude/CLAUDE.md
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # Disable only .claude/skills
+```
+
+---
+
+## Precedence
+
+When opencode starts, it looks for rule files in this order:
+
+1. **Local files** by traversing up from the current directory (`AGENTS.md`, `CLAUDE.md`)
+2. **Global file** at `~/.config/opencode/AGENTS.md`
+3. **Claude Code file** at `~/.claude/CLAUDE.md` (unless disabled)
+
+The first matching file wins in each category. For example, if you have both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` is used. Similarly, `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`.
+
+---
+
+## Custom Instructions
+
+You can specify custom instruction files in your `opencode.json` or the global `~/.config/opencode/opencode.json`. This allows you and your team to reuse existing rules rather than having to duplicate them to AGENTS.md.
+
+Example:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
+}
+```
+
+You can also use remote URLs to load instructions from the web.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["https://raw.githubusercontent.com/my-org/shared-rules/main/style.md"]
+}
+```
+
+Remote instructions are fetched with a 5 second timeout.
+
+All instruction files are combined with your `AGENTS.md` files.
+
+---
+
+## Referencing External Files
+
+While opencode doesn't automatically parse file references in `AGENTS.md`, you can achieve similar functionality in two ways:
+
+### Using opencode.json
+
+The recommended approach is to use the `instructions` field in `opencode.json`:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["docs/development-standards.md", "test/testing-guidelines.md", "packages/*/AGENTS.md"]
+}
+```
+
+### Manual Instructions in AGENTS.md
+
+You can teach opencode to read external files by providing explicit instructions in your `AGENTS.md`. Here's a practical example:
+
+```markdown title="AGENTS.md"
+# TypeScript Project Rules
+
+## External File Loading
+
+CRITICAL: When you encounter a file reference (e.g., @rules/general.md), use your Read tool to load it on a need-to-know basis. They're relevant to the SPECIFIC task at hand.
+
+Instructions:
+
+- Do NOT preemptively load all references - use lazy loading based on actual need
+- When loaded, treat content as mandatory instructions that override defaults
+- Follow references recursively when needed
+
+## Development Guidelines
+
+For TypeScript code style and best practices: @docs/typescript-guidelines.md
+For React component architecture and hooks patterns: @docs/react-patterns.md
+For REST API design and error handling: @docs/api-standards.md
+For testing strategies and coverage requirements: @test/testing-guidelines.md
+
+## General Guidelines
+
+Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.
+```
+
+This approach allows you to:
+
+- Create modular, reusable rule files
+- Share rules across projects via symlinks or git submodules
+- Keep AGENTS.md concise while referencing detailed guidelines
+- Ensure opencode loads files only when needed for the specific task
+
+:::tip
+For monorepos or projects with shared standards, using `opencode.json` with glob patterns (like `packages/*/AGENTS.md`) is more maintainable than manual instructions.
+:::

--- a/plugins/opencode-dev/skills/delegate/SKILL.md
+++ b/plugins/opencode-dev/skills/delegate/SKILL.md
@@ -1,0 +1,172 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Build a Claude Code plugin that delegates coding work to OpenCode (SST's open-source
+  agent, opencode.ai) — the OpenCode analog of openai/codex-plugin-cc. Maps the
+  codex-plugin-cc template (thin bash forwarders → a Node `.mjs` companion holding a
+  persistent connection to the OpenCode daemon → a detached background-job store with
+  status/result/cancel) onto OpenCode's three drive paths. Use when building a
+  CC→OpenCode delegation/handoff plugin, porting codex-plugin-cc to OpenCode, or
+  choosing between `opencode acp`, `opencode serve` + `@opencode-ai/sdk`
+  (`createOpencodeClient`), and `opencode run --format json --attach
+  --dangerously-skip-permissions` as the transport for delegated tasks.
+argument-hint: "e.g. 'build a CC plugin that hands a task off to OpenCode and polls for the result'"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# Delegate to OpenCode from Claude Code
+
+Build a Claude Code plugin that hands work to **OpenCode** (SST; `opencode.ai`,
+GitHub `sst/opencode` — **not** OpenAI Codex). This skill teaches *only* OpenCode's
+drive paths and how the codex-plugin-cc architecture maps onto them.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing delegate code, read `references/cli.rst` and
+> `references/acp.rst` AND re-check <https://opencode.ai/docs/acp/> (and
+> `/docs/cli/`, `/docs/server/`) for drift. The ACP wire protocol is **not** in
+> these references — its JSON-RPC method schema lives at
+> <https://agentclientprotocol.com>; verify there, don't recall it.
+
+**Scope guard — do NOT re-teach here:**
+- Claude Code plugin authoring (`commands/`, subagents, `hooks/`,
+  `${CLAUDE_PLUGIN_ROOT}`) → the `claude-code` bundle + `plugin-dev`.
+- OpenCode SDK client surface, server endpoints, `GET /doc` OpenAPI → `opencode-dev:sdk`.
+
+This skill is the **delta**: which OpenCode transport to drive, and the
+codex-plugin-cc template mapped onto it.
+
+**Version pins** (verify current before authoring): JS packages `@opencode-ai/sdk`,
+`@opencode-ai/plugin`; Go module `github.com/sst/opencode-sdk-go` **v0.19.2**, Go
+**1.22+** — verify this exact module path (other namesake Go modules exist).
+
+---
+
+## Pick a drive path
+
+OpenCode exposes three ways an external process can drive it. Choose by how the
+delegating plugin needs to talk to it:
+
+| Path | Command | Transport | Persistence / sessions | Cancel | When |
+|---|---|---|---|---|---|
+| **ACP** | `opencode acp` | JSON-RPC over **stdin/stdout, nd-JSON** (newline-delimited) | Persistent subprocess, editor-style threads | protocol-level (see ACP schema) | Richest; closest analog to codex `app-server`. Editors (Zed/JetBrains) already drive it this way. |
+| **serve + SDK** | `opencode serve` + `@opencode-ai/sdk` `createOpencodeClient({baseUrl})` | HTTP + **SSE** (`client.event.subscribe`) | Long-lived daemon, multi-session, default `127.0.0.1:4096` | `client.session.abort(...)` | **Best fit for a codex-plugin-cc-style job store.** Most documented, easiest to keep alive. |
+| **run (one-shot)** | `opencode run [msg..] --format json` | child process; **raw JSON event stream on stdout** | Stateless per invocation (`--continue`/`--session`/`--fork` to chain) | kill the (detached) pid | Simplest fire-and-forget subprocess. |
+
+**Default recommendation:** start with **serve + SDK**. It is the verifiable,
+documented analog of a persistent daemon and gives you a clean `abort`. Reach for
+`acp` only if you need ACP's editor-grade thread protocol; reach for `run` for the
+simplest possible one-shot.
+
+### codex `app-server` ↔ `opencode acp` — concept-level only
+
+codex-plugin-cc's companion held a persistent JSON-RPC connection to `codex
+app-server` (methods like `turn/start`, `turn/resume`, `turn/interrupt`). **Those
+are codex methods — they do NOT exist in OpenCode/ACP.** The analogy is structural:
+both are persistent JSON-RPC over stdio. OpenCode's `acp` speaks the **Agent Client
+Protocol** (Zed's open standard) with its *own* method namespace — get the actual
+method names from <https://agentclientprotocol.com>, not from the codex surface.
+
+---
+
+## Drive-path traps (the things a fresh model gets wrong)
+
+- **`--format json` is the streaming opt-in.** `opencode run` defaults to `--format
+  default` (formatted, human text). For a companion you parse, you **must** pass
+  `--format json` to get "raw JSON events." The event object shape is **not
+  documented here** — capture it empirically (run once, log stdout) before parsing;
+  don't hardcode an invented shape.
+- **`--attach http://localhost:4096` reuses a running `serve`** — verbatim purpose:
+  "to avoid MCP server cold boot times on every run." Without `--attach`, each
+  `opencode run` spins up its own server (random port via `--port`) and re-boots MCP
+  servers. For a delegation plugin doing many runs, **`serve` once + `run --attach`**
+  (or the SDK) is the difference between snappy and sluggish.
+- **`--dangerously-skip-permissions` auto-approves only permissions that are NOT
+  explicitly denied** — `deny` rules in config/agent still block. It is not a
+  blanket bypass. A delegated headless run needs this (no TTY to answer prompts), so
+  pair it with a tight `permission` policy on the OpenCode side.
+- **Basic auth:** set `OPENCODE_SERVER_PASSWORD` on `serve`/`web`; the companion
+  passes `--password/-p` (or `OPENCODE_SERVER_PASSWORD`) and `--username/-u`
+  (default `opencode`). The SDK client needs the matching credential too.
+- **ACP loses `/undo` and `/redo`** (and only those slash commands) — verbatim
+  caveat. Everything else (tools, MCP, AGENTS.md rules, agents, permissions) works
+  identically over ACP.
+- **`createOpencodeClient` (connect-only) vs `createOpencode` (starts server +
+  client).** There is **no `createOpencodeServer`** in the SDK — ignore third-party
+  material that uses it. Full SDK detail lives in `opencode-dev:sdk`.
+
+---
+
+## The codex-plugin-cc template, mapped onto OpenCode
+
+The thing users clone is a Claude Code plugin whose entire CC-facing surface is
+**transport-agnostic**; porting Codex→OpenCode means **swapping only the transport
+layer** inside the companion.
+
+```
+Claude Code plugin (UNCHANGED across Codex/OpenCode)
+  commands/{review,transfer,status,result,cancel,setup}.md   ← thin bash forwarders
+  agents/<delegator>.md                                       ← delegation subagent
+        │  every command/agent shells out to ONE call:
+        ▼
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs" <verb> ...
+        │
+        ▼
+  companion.mjs  ← THE ONLY LAYER YOU PORT
+     • owns the connection to the OpenCode daemon (swap transport here)
+     • spawns a DETACHED worker per task; never blocks Claude Code
+     • persists a job store: {id,status,phase,pid,logFile,sessionID,request}
+     • verbs: task | status | result | cancel
+        │
+        ▼
+  OpenCode daemon  ← serve+SDK  |  acp  |  run --attach
+```
+
+**What stays identical** when porting from codex-plugin-cc: the slash commands, the
+delegation subagent, the `${CLAUDE_PLUGIN_ROOT}/scripts/*.mjs` forwarder convention,
+the detached-job store with `status`/`result`/`cancel`, and the `/<plugin>:setup`
+command that checks/installs the foreign CLI (here: `opencode`; needs Node 18+).
+
+**What you swap** — the companion's transport (pick from the table above):
+
+| codex-plugin-cc | OpenCode equivalent |
+|---|---|
+| persistent JSON-RPC to `codex app-server` | `opencode serve` + `createOpencodeClient` **(recommended)**, or `opencode acp` (ACP JSON-RPC/stdio) |
+| `turn/start` start a turn | SDK `client.session.create` + `client.session.prompt` *(verify signatures in `opencode-dev:sdk` + `GET /doc`)* |
+| `turn/interrupt` | SDK `client.session.abort(...)`; for the `run` path, kill the detached pid |
+| streamed turn events | SDK `client.event.subscribe()` (SSE), or `run --format json` stdout stream |
+
+### Detached background jobs — the load-bearing pattern
+
+A delegated task must outlive the (synchronous, fast) Claude Code tool call. Spawn
+the worker truly detached, record its pid, and poll via separate `status`/`result`
+verbs:
+
+```js
+const child = spawn(process.execPath, [worker, jobId], {
+  detached: true,
+  stdio: "ignore",   // or redirect to logFile
+});
+child.unref();       // REQUIRED — without unref the parent won't exit / job isn't detached
+```
+
+Then `status` reads the job-store file; `result` tails `logFile`; `cancel` calls
+`client.session.abort(...)` (serve+SDK) or `process.kill(job.pid)` (run path).
+
+See `assets/companion.skeleton.mjs` for a minimal serve+SDK companion and
+`assets/delegate-command.md` for a starter forwarder command.
+
+---
+
+## Before you ship
+
+1. Read `references/cli.rst` (every `run`/`serve`/`acp` flag) + `references/acp.rst`
+   and confirm flags against your installed `opencode --version`.
+2. Decide one drive path; keep the CC-facing surface transport-agnostic so the other
+   two remain swap-in options.
+3. Capture the real `run --format json` event shape (or the SDK event stream)
+   empirically before parsing it.
+4. Cross-reference `opencode-dev:sdk` for client signatures and server auth — do not
+   re-derive them here.

--- a/plugins/opencode-dev/skills/delegate/assets/companion.skeleton.mjs
+++ b/plugins/opencode-dev/skills/delegate/assets/companion.skeleton.mjs
@@ -1,0 +1,67 @@
+// companion.skeleton.mjs — minimal CC→OpenCode delegation companion.
+//
+// Anchored on the verifiable drive path: `opencode serve` + `@opencode-ai/sdk`
+// (`createOpencodeClient`). This is the OpenCode analog of codex-plugin-cc's
+// persistent-connection companion. The CC-facing surface (verbs below) is the same
+// regardless of transport — to use `opencode acp` or `opencode run` instead, swap
+// only the connect()/start()/cancel() bodies.
+//
+// VERIFY before relying on signatures: SDK method arg shapes are generated from the
+// server's OpenAPI spec (`GET http://localhost:4096/doc`) — see the `opencode-dev:sdk`
+// skill. Pins: @opencode-ai/sdk; node 18+.
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { createOpencodeClient } from "@opencode-ai/sdk";
+
+const STORE = `${process.env.HOME}/.cache/cc-opencode/jobs.json`;
+const BASE_URL = process.env.OPENCODE_BASE_URL ?? "http://localhost:4096";
+
+const client = () =>
+  createOpencodeClient({ baseUrl: BASE_URL }); // connect-only; assumes `opencode serve` is up
+
+// --- job store: {id,status,phase,pid,logFile,sessionID,request} ----------------
+const load = () => (existsSync(STORE) ? JSON.parse(readFileSync(STORE, "utf8")) : {});
+const save = (jobs) => writeFileSync(STORE, JSON.stringify(jobs, null, 2));
+const put = (job) => { const j = load(); j[job.id] = job; save(j); };
+
+// --- verbs ---------------------------------------------------------------------
+async function task(request) {
+  const id = `job_${Date.now()}`;
+  const logFile = `${process.env.HOME}/.cache/cc-opencode/${id}.log`;
+  // Spawn the worker TRULY detached so it outlives this fast CC tool call.
+  const child = spawn(process.execPath, [import.meta.filename, "__worker", id, logFile, request], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref(); // REQUIRED — without unref the job is not detached.
+  put({ id, status: "running", phase: "dispatched", pid: child.pid, logFile, request });
+  console.log(JSON.stringify({ id }));
+}
+
+async function worker(id, logFile, request) {
+  const c = client();
+  // Verify these signatures against `opencode-dev:sdk` + GET /doc before shipping.
+  const session = await c.session.create({});                       // returns session id
+  put({ ...load()[id], sessionID: session.id, phase: "prompting" });
+  await c.session.prompt({ path: { id: session.id }, body: { parts: [{ type: "text", text: request }] } });
+  put({ ...load()[id], status: "done", phase: "complete" });
+  writeFileSync(logFile, JSON.stringify({ sessionID: session.id }, null, 2));
+}
+
+function status(id) { console.log(JSON.stringify(load()[id] ?? { error: "unknown job" })); }
+function result(id) { const j = load()[id]; console.log(existsSync(j?.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)"); }
+
+async function cancel(id) {
+  const j = load()[id];
+  if (j?.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
+  else if (j?.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
+  put({ ...j, status: "cancelled" });
+}
+
+// --- dispatch ------------------------------------------------------------------
+const [verb, ...args] = process.argv.slice(2);
+const verbs = { task: () => task(args.join(" ")), status: () => status(args[0]),
+  result: () => result(args[0]), cancel: () => cancel(args[0]),
+  __worker: () => worker(args[0], args[1], args.slice(2).join(" ")) };
+await (verbs[verb] ?? (() => { console.error(`usage: companion.mjs task|status|result|cancel`); process.exit(1); }))();

--- a/plugins/opencode-dev/skills/delegate/assets/companion.skeleton.mjs
+++ b/plugins/opencode-dev/skills/delegate/assets/companion.skeleton.mjs
@@ -11,10 +11,13 @@
 // skill. Pins: @opencode-ai/sdk; node 18+.
 
 import { spawn } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 
-const STORE = `${process.env.HOME}/.cache/cc-opencode/jobs.json`;
+const SELF = fileURLToPath(import.meta.url); // node 18+ has no import.meta.filename
+const CACHE_DIR = `${process.env.HOME}/.cache/cc-opencode`;
+const STORE = `${CACHE_DIR}/jobs.json`;
 const BASE_URL = process.env.OPENCODE_BASE_URL ?? "http://localhost:4096";
 
 const client = () =>
@@ -22,15 +25,15 @@ const client = () =>
 
 // --- job store: {id,status,phase,pid,logFile,sessionID,request} ----------------
 const load = () => (existsSync(STORE) ? JSON.parse(readFileSync(STORE, "utf8")) : {});
-const save = (jobs) => writeFileSync(STORE, JSON.stringify(jobs, null, 2));
+const save = (jobs) => { mkdirSync(CACHE_DIR, { recursive: true }); writeFileSync(STORE, JSON.stringify(jobs, null, 2)); };
 const put = (job) => { const j = load(); j[job.id] = job; save(j); };
 
 // --- verbs ---------------------------------------------------------------------
 async function task(request) {
   const id = `job_${Date.now()}`;
-  const logFile = `${process.env.HOME}/.cache/cc-opencode/${id}.log`;
+  const logFile = `${CACHE_DIR}/${id}.log`;
   // Spawn the worker TRULY detached so it outlives this fast CC tool call.
-  const child = spawn(process.execPath, [import.meta.filename, "__worker", id, logFile, request], {
+  const child = spawn(process.execPath, [SELF, "__worker", id, logFile, request], {
     detached: true,
     stdio: "ignore",
   });
@@ -42,20 +45,26 @@ async function task(request) {
 async function worker(id, logFile, request) {
   const c = client();
   // Verify these signatures against `opencode-dev:sdk` + GET /doc before shipping.
-  const session = await c.session.create({});                       // returns session id
-  put({ ...load()[id], sessionID: session.id, phase: "prompting" });
-  await c.session.prompt({ path: { id: session.id }, body: { parts: [{ type: "text", text: request }] } });
+  const created = await c.session.create({ body: {} });             // {data}-wrapped response
+  const sessionID = created.data.id;
+  put({ ...load()[id], sessionID, phase: "prompting" });
+  await c.session.prompt({ path: { id: sessionID }, body: { parts: [{ type: "text", text: request }] } });
   put({ ...load()[id], status: "done", phase: "complete" });
-  writeFileSync(logFile, JSON.stringify({ sessionID: session.id }, null, 2));
+  writeFileSync(logFile, JSON.stringify({ sessionID }, null, 2));
 }
 
 function status(id) { console.log(JSON.stringify(load()[id] ?? { error: "unknown job" })); }
-function result(id) { const j = load()[id]; console.log(existsSync(j?.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)"); }
+function result(id) {
+  const j = load()[id];
+  if (!j) { console.log(JSON.stringify({ error: "unknown job" })); return; }
+  console.log(existsSync(j.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)");
+}
 
 async function cancel(id) {
   const j = load()[id];
-  if (j?.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
-  else if (j?.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
+  if (!j) { console.log(JSON.stringify({ error: "unknown job" })); return; }
+  if (j.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
+  else if (j.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
   put({ ...j, status: "cancelled" });
 }
 

--- a/plugins/opencode-dev/skills/delegate/assets/delegate-command.md
+++ b/plugins/opencode-dev/skills/delegate/assets/delegate-command.md
@@ -1,0 +1,29 @@
+---
+description: Delegate a coding task to OpenCode and return a job id to poll
+argument-hint: "<task description>"
+---
+<!--
+  Starter Claude Code slash command — a THIN BASH FORWARDER into the companion.
+  No logic lives here; the companion owns the OpenCode connection + job store.
+  Companion paths: `${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs`.
+  Prereqs (handle in a /<plugin>:setup command, not here): `opencode` CLI on PATH,
+  a running `opencode serve` (default 127.0.0.1:4096), Node 18+.
+  Sibling forwarders reuse the same one-line pattern: status / result / cancel.
+-->
+
+Delegate this task to OpenCode and report the job id:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs" task "$ARGUMENTS"
+```
+
+Then tell the user the returned `id` and that they can poll with
+`/<plugin>:status <id>`, fetch output with `/<plugin>:result <id>`, or stop it with
+`/<plugin>:cancel <id>`. Do not block waiting for completion — the companion ran the
+work in a detached worker.
+
+<!--
+  Transport note: this forwarder is identical whether the companion drives OpenCode
+  via `serve`+SDK, `opencode acp`, or `opencode run --format json --attach ...`.
+  Swap the companion's transport, not this command. See SKILL.md.
+-->

--- a/plugins/opencode-dev/skills/delegate/references/acp.rst
+++ b/plugins/opencode-dev/skills/delegate/references/acp.rst
@@ -1,0 +1,178 @@
+<!-- Source: https://opencode.ai/docs/acp/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode delegate code. -->
+
+# ACP Support
+
+Use OpenCode in any ACP-compatible editor.
+
+OpenCode supports the [Agent Client Protocol](https://agentclientprotocol.com) or (ACP), allowing you to use it directly in compatible editors and IDEs.
+
+> For a list of editors and tools that support ACP, check out the [ACP progress report](https://zed.dev/blog/acp-progress-report#available-now).
+
+ACP is an open protocol that standardizes communication between code editors and AI coding agents.
+
+---
+
+## Configure
+
+To use OpenCode via ACP, configure your editor to run the `opencode acp` command.
+
+The command starts OpenCode as an ACP-compatible subprocess that communicates with your editor over JSON-RPC via stdio.
+
+Below are examples for popular editors that support ACP.
+
+---
+
+### Zed
+
+Add to your [Zed](https://zed.dev) configuration (`~/.config/zed/settings.json`):
+
+```json title="~/.config/zed/settings.json"
+{
+  "agent_servers": {
+    "OpenCode": {
+      "command": "opencode",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+To open it, use the `agent: new thread` action in the **Command Palette**.
+
+You can also bind a keyboard shortcut by editing your `keymap.json`:
+
+```json title="keymap.json"
+[
+  {
+    "bindings": {
+      "cmd-alt-o": [
+        "agent::NewExternalAgentThread",
+        {
+          "agent": {
+            "custom": {
+              "name": "OpenCode",
+              "command": {
+                "command": "opencode",
+                "args": ["acp"]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```
+
+---
+
+### JetBrains IDEs
+
+Add to your [JetBrains IDE](https://www.jetbrains.com/) acp.json according to the [documentation](https://www.jetbrains.com/help/ai-assistant/acp.html):
+
+```json title="acp.json"
+{
+  "agent_servers": {
+    "OpenCode": {
+      "command": "/absolute/path/bin/opencode",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+To open it, use the new 'OpenCode' agent in the AI Chat agent selector.
+
+---
+
+### Avante.nvim
+
+Add to your [Avante.nvim](https://github.com/yetone/avante.nvim) configuration:
+
+```lua
+{
+  acp_providers = {
+    ["opencode"] = {
+      command = "opencode",
+      args = { "acp" }
+    }
+  }
+}
+```
+
+If you need to pass environment variables:
+
+```lua {6-8}
+{
+  acp_providers = {
+    ["opencode"] = {
+      command = "opencode",
+      args = { "acp" },
+      env = {
+        OPENCODE_API_KEY = os.getenv("OPENCODE_API_KEY")
+      }
+    }
+  }
+}
+```
+
+---
+
+### CodeCompanion.nvim
+
+To use OpenCode as an ACP agent in [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim), add the following to your Neovim config:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      adapter = {
+        name = "opencode",
+        model = "claude-sonnet-4",
+      },
+    },
+  },
+})
+```
+
+This config sets up CodeCompanion to use OpenCode as the ACP agent for chat.
+
+If you need to pass environment variables (like `OPENCODE_API_KEY`), refer to [Configuring Adapters: Environment Variables](https://codecompanion.olimorris.dev/getting-started#setting-an-api-key) in the CodeCompanion.nvim documentation for full details.
+
+## Support
+
+OpenCode works the same via ACP as it does in the terminal. All features are supported:
+
+> Some built-in slash commands like `/undo` and `/redo` are currently unsupported.
+
+- Built-in tools (file operations, terminal commands, etc.)
+- Custom tools and slash commands
+- MCP servers configured in your OpenCode config
+- Project-specific rules from `AGENTS.md`
+- Custom formatters and linters
+- Agents and permissions system
+
+---
+
+## CLI page note (from /docs/cli/ — the `acp` command)
+
+### acp
+
+Start an ACP (Agent Client Protocol) server.
+
+```bash
+opencode acp
+```
+
+This command starts an ACP server that communicates via stdin/stdout using **nd-JSON** (newline-delimited JSON).
+
+#### Flags
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--cwd`         | Working directory                          |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |

--- a/plugins/opencode-dev/skills/delegate/references/cli.rst
+++ b/plugins/opencode-dev/skills/delegate/references/cli.rst
@@ -1,0 +1,539 @@
+<!-- Source: https://opencode.ai/docs/cli/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode delegate code. -->
+
+# CLI
+
+OpenCode CLI options and commands.
+
+The OpenCode CLI by default starts the [TUI](/docs/tui) when run without any arguments.
+
+```bash
+opencode
+```
+
+But it also accepts commands as documented on this page. This allows you to interact with OpenCode programmatically.
+
+```bash
+opencode run "Explain how closures work in JavaScript"
+```
+
+---
+
+### tui
+
+Start the OpenCode terminal user interface.
+
+```bash
+opencode [project]
+```
+
+#### Flags
+
+| Flag            | Short | Description                                                             |
+| --------------- | ----- | ----------------------------------------------------------------------- |
+| `--continue`    | `-c`  | Continue the last session                                               |
+| `--session`     | `-s`  | Session ID to continue                                                  |
+| `--fork`        |       | Fork the session when continuing (use with `--continue` or `--session`) |
+| `--prompt`      |       | Prompt to use                                                           |
+| `--model`       | `-m`  | Model to use in the form of provider/model                              |
+| `--agent`       |       | Agent to use                                                            |
+| `--port`        |       | Port to listen on                                                       |
+| `--hostname`    |       | Hostname to listen on                                                   |
+| `--mdns`        |       | Enable mDNS discovery                                                   |
+| `--mdns-domain` |       | Custom mDNS domain name                                                 |
+| `--cors`        |       | Additional browser origin(s) to allow CORS                              |
+
+---
+
+## Commands
+
+The OpenCode CLI also has the following commands.
+
+---
+
+### agent
+
+Manage agents for OpenCode.
+
+```bash
+opencode agent [command]
+```
+
+#### create
+
+Create a new agent with custom configuration.
+
+```bash
+opencode agent create
+```
+
+This command will guide you through creating a new agent with a custom system prompt and permission configuration. Anything you don't allow is denied in the generated agent's frontmatter.
+
+#### Flags
+
+| Flag            | Short | Description                                                                                                                                                                                                                |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--path`        |       | Directory to write the agent file to (defaults to global or `.opencode/agent` based on the prompt)                                                                                                                         |
+| `--description` |       | What the agent should do                                                                                                                                                                                                   |
+| `--mode`        |       | Agent mode: `all`, `primary`, or `subagent`                                                                                                                                                                                |
+| `--permissions` |       | Comma-separated list of permissions to allow (default: all). Available: `bash`, `read`, `edit`, `glob`, `grep`, `webfetch`, `task`, `todowrite`, `websearch`, `lsp`, `skill`. Anything omitted is denied. Alias: `--tools` |
+| `--model`       | `-m`  | Model to use, in `provider/model` format                                                                                                                                                                                   |
+
+Passing all of `--path`, `--description`, `--mode`, and `--permissions` runs the command non-interactively.
+
+#### list
+
+List all available agents.
+
+```bash
+opencode agent list
+```
+
+---
+
+### attach
+
+Attach a terminal to an already running OpenCode backend server started via `serve` or `web` commands.
+
+```bash
+opencode attach [url]
+```
+
+This allows using the TUI with a remote OpenCode backend. For example:
+
+```bash
+# Start the backend server for web/mobile access
+opencode web --port 4096 --hostname 0.0.0.0
+
+# In another terminal, attach the TUI to the running backend
+opencode attach http://10.20.30.40:4096
+```
+
+#### Flags
+
+| Flag         | Short | Description                                                                |
+| ------------ | ----- | -------------------------------------------------------------------------- |
+| `--dir`      |       | Working directory to start TUI in                                          |
+| `--continue` | `-c`  | Continue the last session                                                  |
+| `--session`  | `-s`  | Session ID to continue                                                     |
+| `--fork`     |       | Fork the session when continuing (use with `--continue` or `--session`)    |
+| `--password` | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
+| `--username` | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+
+---
+
+### auth
+
+Command to manage credentials and login for providers.
+
+```bash
+opencode auth [command]
+```
+
+#### login
+
+`opencode auth login` configures API keys. Stored in `~/.local/share/opencode/auth.json`.
+
+```bash
+opencode auth login
+```
+
+| Flag         | Short | Description                                          |
+| ------------ | ----- | ---------------------------------------------------- |
+| `--provider` | `-p`  | Provider ID or name to log in to                     |
+| `--method`   | `-m`  | Login method label to use, skipping method selection |
+
+#### list
+
+```bash
+opencode auth list
+opencode auth ls
+```
+
+#### logout
+
+```bash
+opencode auth logout
+```
+
+---
+
+### github
+
+Manage the GitHub agent for repository automation.
+
+```bash
+opencode github [command]
+```
+
+#### install
+
+```bash
+opencode github install
+```
+
+#### run
+
+Run the GitHub agent. This is typically used in GitHub Actions.
+
+```bash
+opencode github run
+```
+
+| Flag      | Description                            |
+| --------- | -------------------------------------- |
+| `--event` | GitHub mock event to run the agent for |
+| `--token` | GitHub personal access token           |
+
+---
+
+### mcp
+
+Manage Model Context Protocol servers.
+
+```bash
+opencode mcp [command]
+```
+
+- `opencode mcp add` — Add a local or remote MCP server.
+- `opencode mcp list` / `opencode mcp ls` — List configured MCP servers and connection status.
+- `opencode mcp auth [name]` — Authenticate with an OAuth-enabled MCP server. `opencode mcp auth list` / `ls` lists OAuth-capable servers.
+- `opencode mcp logout [name]` — Remove OAuth credentials.
+- `opencode mcp debug <name>` — Debug OAuth connection issues.
+
+---
+
+### models
+
+List all available models from configured providers.
+
+```bash
+opencode models [provider]
+opencode models anthropic
+opencode models --refresh
+```
+
+| Flag        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `--refresh` | Refresh the models cache from models.dev                     |
+| `--verbose` | Use more verbose model output (includes metadata like costs) |
+
+---
+
+### run
+
+Run opencode in non-interactive mode by passing a prompt directly.
+
+```bash
+opencode run [message..]
+```
+
+```bash
+opencode run Explain the use of context in Go
+```
+
+You can also attach to a running `opencode serve` instance to avoid MCP server cold boot times on every run:
+
+```bash
+# Start a headless server in one terminal
+opencode serve
+
+# In another terminal, run commands that attach to it
+opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
+```
+
+#### Flags
+
+| Flag                              | Short | Description                                                                |
+| --------------------------------- | ----- | -------------------------------------------------------------------------- |
+| `--command`                       |       | The command to run, use message for args                                   |
+| `--continue`                      | `-c`  | Continue the last session                                                  |
+| `--session`                       | `-s`  | Session ID to continue                                                     |
+| `--fork`                          |       | Fork the session when continuing (use with `--continue` or `--session`)    |
+| `--share`                         |       | Share the session                                                          |
+| `--model`                         | `-m`  | Model to use in the form of provider/model                                 |
+| `--agent`                         |       | Agent to use                                                               |
+| `--file`                          | `-f`  | File(s) to attach to message                                               |
+| `--format`                        |       | Format: default (formatted) or json (raw JSON events)                      |
+| `--title`                         |       | Title for the session (uses truncated prompt if no value provided)         |
+| `--attach`                        |       | Attach to a running opencode server (e.g., http://localhost:4096)          |
+| `--password`                      | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
+| `--username`                      | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+| `--dir`                           |       | Directory to run in, or path on the remote server when attaching           |
+| `--port`                          |       | Port for the local server (defaults to random port)                        |
+| `--variant`                       |       | Model variant (provider-specific reasoning effort)                         |
+| `--thinking`                      |       | Show thinking blocks                                                       |
+| `--dangerously-skip-permissions`  |       | Auto-approve permissions that are not explicitly denied (dangerous!)       |
+
+---
+
+### serve
+
+Start a headless OpenCode server for API access. Check out the [server docs](/docs/server) for the full HTTP interface.
+
+```bash
+opencode serve
+```
+
+This starts an HTTP server that provides API access to opencode functionality without the TUI interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### session
+
+Manage OpenCode sessions.
+
+```bash
+opencode session [command]
+```
+
+#### list
+
+```bash
+opencode session list
+```
+
+| Flag          | Short | Description                          |
+| ------------- | ----- | ------------------------------------ |
+| `--max-count` | `-n`  | Limit to N most recent sessions      |
+| `--format`    |       | Output format: table or json (table) |
+
+#### delete
+
+```bash
+opencode session delete <sessionID>
+```
+
+---
+
+### stats
+
+```bash
+opencode stats
+```
+
+| Flag        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `--days`    | Show stats for the last N days (all time)                                   |
+| `--tools`   | Number of tools to show (all)                                               |
+| `--models`  | Show model usage breakdown (hidden by default). Pass a number to show top N |
+| `--project` | Filter by project (all projects, empty string: current project)             |
+
+---
+
+### export
+
+Export session data as JSON.
+
+```bash
+opencode export [sessionID]
+```
+
+| Flag         | Description                           |
+| ------------ | ------------------------------------- |
+| `--sanitize` | Redact sensitive transcript/file data |
+
+---
+
+### import
+
+Import session data from a JSON file or OpenCode share URL.
+
+```bash
+opencode import <file>
+opencode import session.json
+opencode import https://opncd.ai/s/abc123
+```
+
+---
+
+### web
+
+Start a headless OpenCode server with a web interface.
+
+```bash
+opencode web
+```
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### acp
+
+Start an ACP (Agent Client Protocol) server.
+
+```bash
+opencode acp
+```
+
+This command starts an ACP server that communicates via stdin/stdout using nd-JSON.
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--cwd`         | Working directory                          |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### plugin
+
+Install a plugin and update your config.
+
+```bash
+opencode plugin <module>
+opencode plug <module>
+```
+
+| Flag       | Short | Description                     |
+| ---------- | ----- | ------------------------------- |
+| `--global` | `-g`  | Install in global config        |
+| `--force`  | `-f`  | Replace existing plugin version |
+
+---
+
+### pr
+
+Fetch and checkout a GitHub PR branch, then run OpenCode.
+
+```bash
+opencode pr <number>
+```
+
+---
+
+### db
+
+Database tools.
+
+```bash
+opencode db [query]
+opencode db path
+```
+
+| Flag       | Description                    |
+| ---------- | ------------------------------ |
+| `--format` | Output format: `json` or `tsv` |
+
+---
+
+### debug
+
+Debugging and troubleshooting tools.
+
+```bash
+opencode debug [command]
+```
+
+---
+
+### uninstall
+
+```bash
+opencode uninstall
+```
+
+| Flag            | Short | Description                                 |
+| --------------- | ----- | ------------------------------------------- |
+| `--keep-config` | `-c`  | Keep configuration files                    |
+| `--keep-data`   | `-d`  | Keep session data and snapshots             |
+| `--dry-run`     |       | Show what would be removed without removing |
+| `--force`       | `-f`  | Skip confirmation prompts                   |
+
+---
+
+### upgrade
+
+```bash
+opencode upgrade [target]
+opencode upgrade
+opencode upgrade v0.1.48
+```
+
+| Flag       | Short | Description                                                       |
+| ---------- | ----- | ----------------------------------------------------------------- |
+| `--method` | `-m`  | The installation method that was used; curl, npm, pnpm, bun, brew |
+
+---
+
+## Global Flags
+
+| Flag           | Short | Description                          |
+| -------------- | ----- | ------------------------------------ |
+| `--help`       | `-h`  | Display help                         |
+| `--version`    | `-v`  | Print version number                 |
+| `--print-logs` |       | Print logs to stderr                 |
+| `--log-level`  |       | Log level (DEBUG, INFO, WARN, ERROR) |
+| `--pure`       |       | Run without external plugins         |
+
+---
+
+## Environment variables
+
+| Variable                              | Type    | Description                                       |
+| ------------------------------------- | ------- | ------------------------------------------------- |
+| `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
+| `OPENCODE_CONFIG`                     | string  | Path to config file                               |
+| `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
+| `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
+| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
+| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
+| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
+| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
+| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
+| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
+| `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
+| `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
+| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
+| `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
+| `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
+
+### Experimental
+
+| Variable                                        | Type    | Description                             |
+| ----------------------------------------------- | ------- | --------------------------------------- |
+| `OPENCODE_EXPERIMENTAL`                         | boolean | Enable the experimental umbrella flag   |
+| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Enable icon discovery                   |
+| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disable copy on select in TUI           |
+| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Default timeout for bash commands in ms |
+| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Max output tokens for LLM responses     |
+| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Enable file watcher for entire dir      |
+| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Enable oxfmt formatter                  |
+| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Enable experimental LSP tool            |
+| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disable file watcher                    |
+| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
+| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |
+| `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS`    | boolean | Enable background subagent tasks        |
+| `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM`            | boolean | Enable experimental event system        |
+| `OPENCODE_EXPERIMENTAL_NATIVE_LLM`              | boolean | Enable native LLM request path          |
+| `OPENCODE_EXPERIMENTAL_PARALLEL`                | boolean | Enable parallel web search execution    |
+| `OPENCODE_EXPERIMENTAL_SCOUT`                   | boolean | Enable Scout subagent                   |
+| `OPENCODE_EXPERIMENTAL_WORKSPACES`              | boolean | Enable workspace support                |

--- a/plugins/opencode-dev/skills/plugin/SKILL.md
+++ b/plugins/opencode-dev/skills/plugin/SKILL.md
@@ -1,0 +1,144 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode plugins and hooks — JS/TS modules that hook into OpenCode's
+  lifecycle to block tools, mutate args, inject env, react to events, or register
+  custom tools. Use when building or debugging anything under `.opencode/plugins/`,
+  importing `@opencode-ai/plugin`, writing a `tool.execute.before` /
+  `tool.execute.after` / `permission.ask` / `shell.env` / `command.execute.before`
+  handler, subscribing to OpenCode events via the `event` handler (`session.idle`,
+  `command.executed`), registering a custom tool from a plugin, or looking for an
+  OpenCode "stop hook" or a settings.json hook table. Distinct from OpenAI Codex.
+argument-hint: "What OpenCode plugin/hook do you want? (e.g. 'block reads of .env', 'notify when a session finishes', 'add a custom tool from a plugin')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Plugins & Hooks
+
+OpenCode (SST's open-source coding agent, `opencode.ai`, `sst/opencode` — **not**
+OpenAI Codex) extends via **plugins**: a JS/TS module exporting
+`async (input, options?) => Promise<Hooks>`. There is **no settings-file hook
+table like Claude Code** — "hooks" exist *only* as keys of the object your plugin
+returns. Get the vocabulary layering right and most plugins are a few lines.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing plugin code, read `references/plugins.rst` AND
+> re-check <https://opencode.ai/docs/plugins/> for drift. The handler-key set is
+> defined in `interface Hooks` (`packages/plugin/src/index.ts`).
+
+**Version pins.** Packages `@opencode-ai/plugin` (types + `tool` helper) and
+`@opencode-ai/sdk` (the `client`). The `interface Hooks` key set and field names
+encoded below were validated against `references/plugins.rst` as fetched
+**2026-06-29**; re-check that baseline for drift before pinning a version. SDK/Go
+specifics (Go SDK `v0.19.2`, Go 1.22+) belong to the **sdk** facet, not here.
+
+---
+
+## The one trap that breaks most plugins: handlers vs. events
+
+The docs print a single **"Events"** list that silently mixes two different
+layers. They share nouns but differ in **tense and access mechanism**:
+
+| Layer | How you use it | Tense | Examples |
+|---|---|---|---|
+| **Handler keys you RETURN** | top-level keys of the returned object; called with `(input, output)` | **imperative** | `tool.execute.before`, `tool.execute.after`, `permission.ask`, `command.execute.before`, `shell.env`, `chat.message` |
+| **Bus events you READ** | only inside the `event` handler, via `event.type` | **past-tense / `.updated` / `.idle`** | `command.executed`, `session.idle`, `session.updated`, `permission.asked`, `file.edited`, `lsp.updated` |
+
+Same word, two layers: `command.execute.before` is a **handler key** you return;
+`command.executed` is an **`event.type`** you match. `permission.ask` is a handler;
+`permission.asked` is an event. Never write `event: { "session.idle": ... }` — the
+`event` handler is one function that switches on `event.type`.
+
+```js
+return {
+  "command.execute.before": async (input, output) => { /* imperative handler */ },
+  event: async ({ event }) => {                          // bus reader
+    if (event.type === "session.idle") { /* … */ }
+  },
+}
+```
+
+## Full handler-key set (`interface Hooks`)
+
+Returnable keys, all optional: `dispose`, `event`, `config`, `tool` (a **map**,
+not a function), `auth`, `provider`, `chat.message`, `chat.params`, `chat.headers`,
+`permission.ask`, `command.execute.before`, `tool.execute.before`,
+`tool.execute.after`, `shell.env`, `tool.definition`, and experimental
+`experimental.{chat.messages.transform, chat.system.transform, provider.small_model,
+session.compacting, compaction.autocontinue, text.complete}`.
+
+- **There is no `stop` hook** — a community gist invents one; it does not exist.
+  For "session finished," read `event` + `event.type === "session.idle"`.
+- There is **`command.execute.before`** but no `command.execute.after` handler —
+  the after-the-fact signal is the `command.executed` *event*.
+
+## The `(input, output)` contract
+
+Imperative handlers receive two args: **`input` is read-only; mutate `output` in
+place; `throw` to block** the action.
+
+| Handler | `input` (read) | `output` (mutate) | Block by |
+|---|---|---|---|
+| `tool.execute.before` | `{ tool, sessionID, callID }` | `{ args }` | `throw` |
+| `tool.execute.after` | `{ tool, … }` | `{ title, output, metadata }` | — |
+| `permission.ask` | the `Permission` | `{ status: "ask" \| "deny" \| "allow" }` | set `status` |
+| `shell.env` | `{ cwd, … }` | `{ env }` | — |
+| `command.execute.before` | command info | command args | `throw` |
+| `tool.definition` | tool id | `{ description, parameters }` | — |
+
+Gotcha: the field is `output.args`, keyed by tool. For `read` it's
+`output.args.filePath`; for the **`apply_patch`** tool it's `output.args.patchText`
+(there is no `filePath`). Don't assume a uniform arg shape.
+
+## Where plugins live, and how they load
+
+- **Plural** `.opencode/plugins/` (project) or `~/.config/opencode/plugins/`
+  (global) — auto-loaded at startup. (A widely-copied community gist writes the
+  singular `.opencode/plugin/`; that is **wrong** and silently loads nothing.)
+- **npm packages** via the config `"plugin": [...]` array — Bun-installed to
+  `~/.cache/opencode/node_modules/`. Both bare and `@scoped` names work.
+- **Local runtime deps**: add `.opencode/package.json`; OpenCode runs `bun install`
+  at startup, then your plugin/tool can `import` them.
+
+## PluginInput — the context you destructure
+
+`PluginInput` is `{ client, project, directory, worktree, serverUrl, $ }` (plus
+`experimental_workspace`). Two non-obvious points: `$` is **Bun's shell**, and to
+log you must use the SDK client — `client.app.log({ body: { service, level,
+message, extra } })`, level `debug|info|warn|error` — **not** `console.log`, which
+is swallowed.
+
+## Registering a custom tool from a plugin
+
+The `tool` key is a **map** (`{ name: tool(...) }`), not a function — `import
+{ tool } from "@opencode-ai/plugin"`, build arg schemas off `tool.schema.*`. A
+plugin tool whose name matches a built-in **takes precedence**.
+
+> This is the *programmatic* route. Filesystem-discovered custom tools in
+> `.opencode/tools/*.ts` and the full `tool()` API are the **tools** facet
+> (`/opencode-dev:tools`) — cross-reference, don't duplicate.
+
+---
+
+## Recipes (full code in `references/plugins.rst`)
+
+| Goal | Key | Sketch |
+|---|---|---|
+| Block reading `.env` | `tool.execute.before` | `if (input.tool === "read" && output.args.filePath.includes(".env")) throw …` |
+| Sanitize bash args | `tool.execute.before` | mutate `output.args.command` (e.g. `shescape`) |
+| Notify on session done | `event` | `if (event.type === "session.idle") await $\`…\`` |
+| Inject shell env | `shell.env` | `output.env.MY_API_KEY = "…"` |
+| Persist context across compaction | `experimental.session.compacting` | `output.context.push("…")` or set `output.prompt` |
+| Add a custom tool | `tool` map | `tool({ description, args, execute })` |
+
+Starter scaffold pairing one imperative handler with the `event` reader:
+[`assets/starter-plugin.ts`](assets/starter-plugin.ts).
+
+## Reference files
+
+| File | Contents |
+|---|---|
+| [references/plugins.rst](references/plugins.rst) | Verbatim `/docs/plugins/` (load order, all examples, logging, compaction) + the `interface Hooks` key set and `PluginInput` type surface |

--- a/plugins/opencode-dev/skills/plugin/assets/starter-plugin.ts
+++ b/plugins/opencode-dev/skills/plugin/assets/starter-plugin.ts
@@ -1,0 +1,32 @@
+// .opencode/plugins/starter.ts  (note the PLURAL `plugins/` directory)
+//
+// Minimal OpenCode plugin showing the two-layer model side by side:
+//   - an IMPERATIVE handler key  -> (input, output), mutate output / throw to block
+//   - the `event` BUS reader      -> switch on past-tense `event.type`
+//
+// Verify the Hooks key set against `interface Hooks` in @opencode-ai/plugin
+// (packages/plugin/src/index.ts) and https://opencode.ai/docs/plugins/ — the API
+// moves fast. There is NO `stop` hook; "session finished" is event.type "session.idle".
+
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const Starter: Plugin = async ({ client, $, directory, worktree }) => {
+  return {
+    // IMPERATIVE handler: input is read-only, mutate `output` in place, throw to block.
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "read" && output.args.filePath?.includes(".env")) {
+        throw new Error("Blocked: do not read .env files")
+      }
+    },
+
+    // BUS reader: one function, switch on the past-tense event.type.
+    event: async ({ event }) => {
+      if (event.type === "session.idle") {
+        // Structured logging — prefer client.app.log over console.log.
+        await client.app.log({
+          body: { service: "starter", level: "info", message: "session idle" },
+        })
+      }
+    },
+  }
+}

--- a/plugins/opencode-dev/skills/plugin/references/plugins.rst
+++ b/plugins/opencode-dev/skills/plugin/references/plugins.rst
@@ -1,0 +1,397 @@
+<!-- Source: https://opencode.ai/docs/plugins/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode plugin code. -->
+
+# Plugins
+
+> Write your own plugins to extend OpenCode.
+
+Plugins allow you to extend OpenCode by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify OpenCode's default behavior.
+
+For examples, check out the [plugins](https://opencode.ai/docs/ecosystem#plugins) created by the community.
+
+---
+
+## Use a plugin
+
+There are two ways to load plugins.
+
+### From local files
+
+Place JavaScript or TypeScript files in the plugin directory.
+
+- `.opencode/plugins/` - Project-level plugins
+- `~/.config/opencode/plugins/` - Global plugins
+
+Files in these directories are automatically loaded at startup.
+
+### From npm
+
+Specify npm packages in your config file.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
+}
+```
+
+Both regular and scoped npm packages are supported.
+
+Browse available plugins in the [ecosystem](https://opencode.ai/docs/ecosystem#plugins).
+
+### How plugins are installed
+
+**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/node_modules/`.
+
+**Local plugins** are loaded directly from the plugin directory. To use external packages, you must create a `package.json` within your config directory (see [Dependencies](#dependencies)), or publish the plugin to npm and add it to your config.
+
+### Load order
+
+Plugins are loaded from all sources and all hooks run in sequence. The load order is:
+
+1. Global config (`~/.config/opencode/opencode.json`)
+2. Project config (`opencode.json`)
+3. Global plugin directory (`~/.config/opencode/plugins/`)
+4. Project plugin directory (`.opencode/plugins/`)
+
+Duplicate npm packages with the same name and version are loaded once. However, a local plugin and an npm plugin with similar names are both loaded separately.
+
+---
+
+## Create a plugin
+
+A plugin is a **JavaScript/TypeScript module** that exports one or more plugin functions. Each function receives a context object and returns a hooks object.
+
+### Dependencies
+
+Local plugins and custom tools can use external npm packages. Add a `package.json` to your config directory with the dependencies you need.
+
+```json title=".opencode/package.json"
+{
+  "dependencies": {
+    "shescape": "^2.1.0"
+  }
+}
+```
+
+OpenCode runs `bun install` at startup to install these. Your plugins and tools can then import them.
+
+```ts title=".opencode/plugins/my-plugin.ts"
+import { escape } from "shescape"
+
+export const MyPlugin = async (ctx) => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "bash") {
+        output.args.command = escape(output.args.command)
+      }
+    },
+  }
+}
+```
+
+### Basic structure
+
+```js title=".opencode/plugins/example.js"
+export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
+  console.log("Plugin initialized!")
+
+  return {
+    // Hook implementations go here
+  }
+}
+```
+
+The plugin function receives:
+
+- `project`: The current project information.
+- `directory`: The current working directory.
+- `worktree`: The git worktree path.
+- `client`: An opencode SDK client for interacting with the AI.
+- `$`: Bun's [shell API](https://bun.com/docs/runtime/shell) for executing commands.
+
+### TypeScript support
+
+For TypeScript plugins, you can import types from the plugin package:
+
+```ts title="my-plugin.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree }) => {
+  return {
+    // Type-safe hook implementations
+  }
+}
+```
+
+### Events
+
+Plugins can subscribe to events as seen below in the Examples section. Here is a list of the different events available.
+
+#### Command Events
+
+- `command.executed`
+
+#### File Events
+
+- `file.edited`
+- `file.watcher.updated`
+
+#### Installation Events
+
+- `installation.updated`
+
+#### LSP Events
+
+- `lsp.client.diagnostics`
+- `lsp.updated`
+
+#### Message Events
+
+- `message.part.removed`
+- `message.part.updated`
+- `message.removed`
+- `message.updated`
+
+#### Permission Events
+
+- `permission.asked`
+- `permission.replied`
+
+#### Server Events
+
+- `server.connected`
+
+#### Session Events
+
+- `session.created`
+- `session.compacted`
+- `session.deleted`
+- `session.diff`
+- `session.error`
+- `session.idle`
+- `session.status`
+- `session.updated`
+
+#### Todo Events
+
+- `todo.updated`
+
+#### Shell Events
+
+- `shell.env`
+
+#### Tool Events
+
+- `tool.execute.after`
+- `tool.execute.before`
+
+#### TUI Events
+
+- `tui.prompt.append`
+- `tui.command.execute`
+- `tui.toast.show`
+
+---
+
+## Examples
+
+Here are some examples of plugins you can use to extend opencode.
+
+### Send notifications
+
+Send notifications when certain events occur:
+
+```js title=".opencode/plugins/notification.js"
+export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
+  return {
+    event: async ({ event }) => {
+      // Send notification on session completion
+      if (event.type === "session.idle") {
+        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+      }
+    },
+  }
+}
+```
+
+We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications.
+
+> **Note:** If you're using the OpenCode desktop app, it can send system notifications automatically when a response is ready or when a session errors.
+
+### .env protection
+
+Prevent opencode from reading `.env` files:
+
+```javascript title=".opencode/plugins/env-protection.js"
+export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "read" && output.args.filePath.includes(".env")) {
+        throw new Error("Do not read .env files")
+      }
+    },
+  }
+}
+```
+
+### Inject environment variables
+
+Inject environment variables into all shell execution (AI tools and user terminals):
+
+```javascript title=".opencode/plugins/inject-env.js"
+export const InjectEnvPlugin = async () => {
+  return {
+    "shell.env": async (input, output) => {
+      output.env.MY_API_KEY = "secret"
+      output.env.PROJECT_ROOT = input.cwd
+    },
+  }
+}
+```
+
+### Custom tools
+
+Plugins can also add custom tools to opencode:
+
+```ts title=".opencode/plugins/custom-tools.ts"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+
+export const CustomToolsPlugin: Plugin = async (ctx) => {
+  return {
+    tool: {
+      mytool: tool({
+        description: "This is a custom tool",
+        args: {
+          foo: tool.schema.string(),
+        },
+        async execute(args, context) {
+          const { directory, worktree } = context
+          return `Hello ${args.foo} from ${directory} (worktree: ${worktree})`
+        },
+      }),
+    },
+  }
+}
+```
+
+The `tool` helper creates a custom tool that opencode can call. It takes a Zod schema function and returns a tool definition with:
+
+- `description`: What the tool does
+- `args`: Zod schema for the tool's arguments
+- `execute`: Function that runs when the tool is called
+
+Your custom tools will be available to opencode alongside built-in tools.
+
+> **Note:** If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence.
+
+### Logging
+
+Use `client.app.log()` instead of `console.log` for structured logging:
+
+```ts title=".opencode/plugins/my-plugin.ts"
+export const MyPlugin = async ({ client }) => {
+  await client.app.log({
+    body: {
+      service: "my-plugin",
+      level: "info",
+      message: "Plugin initialized",
+      extra: { foo: "bar" },
+    },
+  })
+}
+```
+
+Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://opencode.ai/docs/sdk) for details.
+
+### Compaction hooks
+
+Customize the context included when a session is compacted:
+
+```ts title=".opencode/plugins/compaction.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Inject additional context into the compaction prompt
+      output.context.push(`
+## Custom Context
+
+Include any state that should persist across compaction:
+- Current task status
+- Important decisions made
+- Files being actively worked on
+`)
+    },
+  }
+}
+```
+
+The `experimental.session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.
+
+You can also replace the compaction prompt entirely by setting `output.prompt`:
+
+```ts title=".opencode/plugins/custom-compaction.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CustomCompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Replace the entire compaction prompt
+      output.prompt = `
+You are generating a continuation prompt for a multi-agent swarm session.
+
+Summarize:
+1. The current task and its status
+2. Which files are being modified and by whom
+3. Any blockers or dependencies between agents
+4. The next steps to complete the work
+
+Format as a structured prompt that a new agent can use to resume work.
+`
+    },
+  }
+}
+```
+
+When `output.prompt` is set, it completely replaces the default compaction prompt. The `output.context` array is ignored in this case.
+
+---
+
+## Plugin type surface (from `@opencode-ai/plugin`, type source `packages/plugin/src/index.ts`)
+
+A plugin's signature and the full handler-key set (not all are shown on the live docs page; verify against the package types):
+
+```ts
+export type Plugin = (input: PluginInput, options?: PluginOptions) => Promise<Hooks>
+
+export type PluginInput = {
+  client: ReturnType<typeof createOpencodeClient> // @opencode-ai/sdk
+  project: Project
+  directory: string
+  worktree: string
+  experimental_workspace: { register(type, adapter): void }
+  serverUrl: URL
+  $: BunShell
+}
+```
+
+**Handler hook keys (the callable keys you return — `interface Hooks`):**
+`dispose`, `event`, `config`, `tool` (a MAP, registers custom tools — not a function),
+`auth`, `provider`, `chat.message`, `chat.params`, `chat.headers`,
+`permission.ask` (output `{ status: "ask" | "deny" | "allow" }`),
+`command.execute.before`,
+`tool.execute.before` (input `{ tool, sessionID, callID }`, output `{ args }`),
+`tool.execute.after` (output `{ title, output, metadata }`),
+`shell.env` (output `{ env }`),
+`tool.definition` (output `{ description, parameters }`),
+and experimental: `experimental.chat.messages.transform`,
+`experimental.chat.system.transform`, `experimental.provider.small_model`,
+`experimental.session.compacting`, `experimental.compaction.autocontinue`,
+`experimental.text.complete`.
+
+There is **no `stop` hook** in the official `Hooks` type.
+
+Exported types: `Plugin, PluginInput, PluginOptions, PluginModule, Hooks, Config, AuthHook, ProviderHook, WorkspaceAdapter`, plus `tool` / `ToolDefinition`.
+
+For the patch tool, check `input.tool === "apply_patch"` and read `output.args.patchText` (not `filePath`).

--- a/plugins/opencode-dev/skills/policies/SKILL.md
+++ b/plugins/opencode-dev/skills/policies/SKILL.md
@@ -1,0 +1,173 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode enterprise governance — the `experimental.policies` provider
+  allow/deny layer and the `permission` per-tool gate — for `opencode.json` /
+  `.opencode/`. Use when configuring which LLM providers OpenCode may use,
+  migrating off `disabled_providers`/`enabled_providers`, locking down a fleet,
+  or setting tool permissions (`allow`/`ask`/`deny`) for `bash`, `edit`, `read`,
+  `external_directory`, `doom_loop`, etc. Trigger on mentions of OpenCode
+  policies, `experimental.policies`, `provider.use`, `permission` config, OpenCode
+  `.env` access, doom-loop / external-directory guards, per-agent permission
+  overrides, or "restrict OpenCode to Anthropic only".
+argument-hint: "What governance do you want? (e.g. 'allow only Anthropic provider', 'deny edit but allow docs', 'why can OpenCode still read .env?')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Policies & Permissions
+
+Two **separate** governance layers in OpenCode config. Don't conflate them:
+
+| Layer | Key | Governs | Values |
+|---|---|---|---|
+| **Policies** | `experimental.policies` (array) | *Whether OpenCode may use a resource* — today only **LLM providers** | `effect: allow\|deny` |
+| **Permissions** | `permission` (top-level) | *What tools may do in a session* — per tool, per pattern | `allow` \| `ask` \| `deny` |
+
+> OpenCode's API moves fast and predates the model's training cutoff — before
+> writing policies code, read `references/policies.rst` + `references/permissions.rst`
+> AND re-check https://opencode.ai/docs/policies/ and
+> https://opencode.ai/docs/permissions/ for drift. The official config schema is
+> `https://opencode.ai/config.json`. Policies are still under `experimental.`.
+
+Verbatim docs live in `references/`. This file is the **delta a fresh model gets
+wrong** — read it before authoring, then verify against the references.
+
+---
+
+## Layer 1 — Policies (`experimental.policies`)
+
+The traps that bite, in order of how often a fresh model gets them wrong:
+
+1. **It's nested under `experimental.`, not a top-level `policies` key.**
+   `{ "experimental": { "policies": [ … ] } }`. A bare top-level `"policies"` is
+   silently ignored.
+2. **`provider.use` is the ONLY `action` that exists today.** Policies govern
+   **LLM providers, not tools/commands/permissions.** You cannot deny a tool or a
+   slash command with a policy — that's the permission layer (Layer 2). If you
+   catch yourself writing `"action": "tool.use"` or `"bash"`, you're in the wrong
+   layer.
+3. **Precedence is INVERTED vs normal config merge.** Everywhere else in OpenCode,
+   project config overrides global. For policies, **global beats project** — a repo
+   `opencode.json` *cannot* re-enable a provider the global config denied. This is
+   the enforcement guarantee an enterprise relies on.
+4. **Default-when-no-match is `allow`.** Policies are a denylist by default. To run
+   an allowlist ("only Anthropic"), you must put a broad `deny *` FIRST, then
+   `allow` the specific providers.
+5. **Last-matching statement wins** (within a list). Order broad → specific. With
+   default-allow + last-match-wins, the allowlist idiom is: `deny *` then
+   `allow anthropic`.
+6. **Policies REPLACE the deprecated `disabled_providers` / `enabled_providers`.**
+   Don't emit those legacy keys — translate them:
+   - `disabled_providers: [openai, google]` → one `deny provider.use` per id.
+   - `enabled_providers: [anthropic, openai]` → `deny *` then `allow` each id.
+
+Statement shape (all three fields required):
+
+```json
+{ "effect": "deny", "action": "provider.use", "resource": "openai" }
+```
+
+`resource` is a provider id or wildcard (`*` = zero-or-more chars, `?` = one char),
+e.g. `"company-*"`. See `assets/policies.json` for the allowlist template.
+
+### Allowlist (only Anthropic) — the canonical pattern
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      { "effect": "deny",  "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" }
+    ]
+  }
+}
+```
+
+If you flipped the order (`allow anthropic` then `deny *`), last-match-wins means
+`deny *` wins for *every* provider including Anthropic — nothing works. Broad first.
+
+---
+
+## Layer 2 — Permissions (`permission`)
+
+Per-tool / per-pattern gate over tool **actions** in a session. Three resolved
+states: `allow` (run silently), `ask` (prompt), `deny` (block).
+
+### The non-uniform-defaults trap
+
+There is no single default. A fresh model assumes "everything defaults to allow" —
+wrong on three counts:
+
+| Key | Default | Why it surprises |
+|---|---|---|
+| most tools | `allow` | the baseline |
+| `doom_loop` | **`ask`** | fires when the **same tool repeats 3× with identical input** |
+| `external_directory` | **`ask`** | fires when a tool touches a path **outside the project cwd** |
+| `read` of `.env` | **`deny`** | `*.env` + `*.env.*` deny, `*.env.example` allow |
+
+So "why can't OpenCode read `.env`?" / "why did it pause on the 3rd identical call?"
+are *defaults*, not bugs. To let OpenCode read a secret file you must explicitly
+`allow` it under `read`; to silence the loop guard set `doom_loop: "allow"`.
+
+### Other delta to pin
+
+- **One `edit` permission covers `edit`, `write`, and the patch tool** (named
+  `apply_patch` in OpenCode's built-in tool list; the `/docs/permissions/` page
+  refers to it loosely as "patch"). There is no separate `write` or `patch`
+  permission key.
+- **Last-matching pattern wins** (same as policies). Put `"*"` first, exceptions
+  after. `{ "bash": { "*": "ask", "git *": "allow", "rm *": "deny" } }`.
+- **Pattern needs the trailing wildcard for args.** `"grep *"` matches
+  `grep foo file.txt`; bare `"grep"` matches only the literal word and blocks the
+  call. Commands with arguments require the explicit `*`.
+- `~` / `$HOME` expand at the **start** of a pattern.
+- Full key list (matches against): `read, edit, glob, grep, bash, task, skill,
+  lsp, question, webfetch, websearch, external_directory, doom_loop`. `lsp` is
+  non-granular (no object form). See `references/permissions.rst` for what each
+  matches on.
+- Set everything at once with a string: `"permission": "allow"`.
+
+### Per-agent override
+
+Agent-level permission rules **beat** the top-level `permission` block. This is a
+separate axis from policies — don't assume the policy global>project rule carries
+over to permissions; it doesn't. Override via `agent.<name>.permission` in JSON, or
+`permission:` in a markdown agent's frontmatter:
+
+```yaml
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash: ask
+  webfetch: deny
+---
+Only analyze code and suggest changes.
+```
+
+See `assets/permission.json` for a JSON template with `bash`, `edit`, and a
+per-agent block.
+
+### "Ask" outcomes
+
+When OpenCode prompts: `once` (this request only), `always` (future matching
+requests, **current session only** — not persisted), `reject`.
+
+---
+
+## Quick checklist before you ship a governance config
+
+- Provider lock-down → `experimental.policies`; tool lock-down → `permission`.
+  Never `provider.use` for a tool.
+- Allowlist = `deny *` FIRST, then `allow <id>` (default is allow; last match wins).
+- Enterprise floor goes in **global** config (project can't override policies).
+- Migrating? Delete `disabled_providers`/`enabled_providers`; emit policies instead.
+- Remember the non-uniform permission defaults: `.env` already denied, `doom_loop`
+  + `external_directory` already `ask`.
+- One `edit` key = edit + write + apply_patch.
+- Validate against `https://opencode.ai/config.json` and re-check the live docs.

--- a/plugins/opencode-dev/skills/policies/assets/permission.json
+++ b/plugins/opencode-dev/skills/policies/assets/permission.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "rm *": "deny"
+    },
+    "edit": {
+      "*": "deny",
+      "packages/web/src/content/docs/*.mdx": "allow"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow"
+    },
+    "doom_loop": "allow",
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    }
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git *": "allow",
+          "git push *": "deny"
+        }
+      }
+    }
+  }
+}

--- a/plugins/opencode-dev/skills/policies/assets/policies.json
+++ b/plugins/opencode-dev/skills/policies/assets/policies.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" }
+    ]
+  }
+}

--- a/plugins/opencode-dev/skills/policies/references/permissions.rst
+++ b/plugins/opencode-dev/skills/policies/references/permissions.rst
@@ -1,0 +1,200 @@
+<!-- Source: https://opencode.ai/docs/permissions/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode permissions code. -->
+
+# Permissions (OpenCode)
+
+## Overview
+
+OpenCode uses permission configuration to control whether actions run automatically, require approval, or are blocked. The system resolves each permission rule to one of three states:
+
+- `"allow"` — execute without approval
+- `"ask"` — prompt user for approval
+- `"deny"` — block the action
+
+## Configuration Structure
+
+### Global and Tool-Specific Permissions
+
+Permissions can be set globally using `"*"` and overridden for specific tools:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "ask",
+    "bash": "allow",
+    "edit": "deny"
+  }
+}
+```
+
+Alternatively, set all permissions uniformly:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": "allow"
+}
+```
+
+## Granular Rules (Object Syntax)
+
+Most permissions support object-based rules that apply different actions based on tool input:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "npm *": "allow",
+      "rm *": "deny",
+      "grep *": "allow"
+    },
+    "edit": {
+      "*": "deny",
+      "packages/web/src/content/docs/*.mdx": "allow"
+    }
+  }
+}
+```
+
+**Evaluation Rule:** Last matching pattern wins. Place catch-all `"*"` first, then more specific rules.
+
+### Wildcard Matching
+
+- `*` — zero or more characters
+- `?` — exactly one character
+- All other characters match literally
+
+### Home Directory Expansion
+
+Patterns support `~` or `$HOME` at the start:
+
+- `~/projects/*` → `/Users/username/projects/*`
+- `$HOME/projects/*` → `/Users/username/projects/*`
+- `~` → `/Users/username`
+
+### External Directories
+
+The `external_directory` permission allows tool calls affecting paths outside the project working directory. This applies to tools accepting path inputs (read, edit, glob, grep, bash commands):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    }
+  }
+}
+```
+
+Allowed directories inherit workspace defaults. Add explicit denial rules when restricting specific tools:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    },
+    "edit": {
+      "~/projects/personal/**": "deny"
+    }
+  }
+}
+```
+
+## Available Permissions
+
+- `read` — reading files (matches file path)
+- `edit` — file modifications (covers edit, write, patch)
+- `glob` — file globbing (matches glob pattern)
+- `grep` — content search (matches regex pattern)
+- `bash` — shell command execution (matches parsed commands)
+- `task` — launching subagents (matches subagent type)
+- `skill` — loading skills (matches skill name)
+- `lsp` — running LSP queries (non-granular)
+- `question` — asking users during execution
+- `webfetch` — URL fetching (matches URL)
+- `websearch` — web search (matches query)
+- `external_directory` — triggered when tools access paths outside project
+- `doom_loop` — triggered when same tool repeats 3 times with identical input
+
+## Default Permissions
+
+```json
+{
+  "permission": {
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow"
+    }
+  }
+}
+```
+
+- Most permissions default to `"allow"`
+- `doom_loop` and `external_directory` default to `"ask"`
+- `.env` files are denied by default
+
+## "Ask" Behavior
+
+When OpenCode prompts for approval, three outcomes are available:
+
+- `once` — approve only this request
+- `always` — approve future matching requests (current session only)
+- `reject` — deny the request
+
+Tools provide suggested patterns for `always` approval (e.g., bash suggests command prefixes like `git status*`).
+
+## Agent-Level Overrides
+
+Agent permissions override global configuration. Agent rules take precedence:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "git commit *": "deny",
+      "git push *": "deny",
+      "grep *": "allow"
+    }
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git *": "allow",
+          "git commit *": "ask",
+          "git push *": "deny",
+          "grep *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+Markdown-based agent permissions:
+
+```yaml
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash: ask
+  webfetch: deny
+---
+Only analyze code and suggest changes.
+```
+
+**Note on pattern matching:** Commands with arguments require explicit patterns. `"grep *"` permits `grep pattern file.txt`, while `"grep"` alone blocks it.

--- a/plugins/opencode-dev/skills/policies/references/policies.rst
+++ b/plugins/opencode-dev/skills/policies/references/policies.rst
@@ -1,0 +1,118 @@
+<!-- Source: https://opencode.ai/docs/policies/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode policies code. -->
+
+# Policies (OpenCode)
+
+## Overview
+
+Policies control which configured resources OpenCode may use. They are configured via the `experimental.policies` array in `opencode.json` and function separately from permissions — permissions govern tool capabilities during sessions, while policies regulate resource access like LLM providers.
+
+## Configuration Structure
+
+Each policy statement requires three fields:
+
+- **`effect`** — `"allow"` or `"deny"`
+- **`action`** — The operation being controlled
+- **`resource`** — Resource ID or wildcard pattern
+
+### Example: Deny OpenAI Provider
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "openai"
+      }
+    ]
+  }
+}
+```
+
+A denied provider becomes unavailable for model selection or use, regardless of configuration status.
+
+## Supported Policy Actions
+
+| Action | Resource | Description |
+|--------|----------|-------------|
+| `provider.use` | Provider ID (e.g., `openai`) | Allow/deny LLM provider usage |
+
+## Wildcard Matching
+
+The `resource` field supports wildcards: `*` matches zero or more characters; `?` matches one character.
+
+```json
+{
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "company-*"
+      }
+    ]
+  }
+}
+```
+
+## Rule Precedence
+
+**Last matching rule wins.** Place broad rules first, then specific exceptions after them.
+
+### Allow Only Anthropic
+
+```json
+{
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "*"
+      },
+      {
+        "effect": "allow",
+        "action": "provider.use",
+        "resource": "anthropic"
+      }
+    ]
+  }
+}
+```
+
+Default behavior: provider use is allowed if no policy matches.
+
+**Priority hierarchy:** Global policies override project policies, preventing repository-level re-enablement of globally denied providers.
+
+## Provider Lists Migration
+
+Replace legacy `disabled_providers` and `enabled_providers` settings with policies.
+
+### Replace `disabled_providers`
+
+```json
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "openai" },
+      { "effect": "deny", "action": "provider.use", "resource": "google" }
+    ]
+  }
+}
+```
+
+### Replace `enabled_providers`
+
+```json
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" },
+      { "effect": "allow", "action": "provider.use", "resource": "openai" }
+    ]
+  }
+}
+```

--- a/plugins/opencode-dev/skills/sdk/SKILL.md
+++ b/plugins/opencode-dev/skills/sdk/SKILL.md
@@ -1,0 +1,166 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Drive OpenCode (the SST coding agent, opencode.ai) programmatically — the
+  @opencode-ai/sdk JS/TS client, the github.com/sst/opencode-sdk-go Go client,
+  and the `opencode serve` HTTP/OpenAPI server it talks to. Use when building an
+  integration on top of OpenCode, calling createOpencode / createOpencodeClient,
+  running `opencode serve`, hitting the OpenAPI spec at /doc, listing or prompting
+  sessions over HTTP, wiring OPENCODE_SERVER_PASSWORD auth, requesting structured
+  (json_schema) output, or using opencode.NewClient / Session.List / the Field
+  param wrappers in Go. NOT OpenAI Codex; NOT the opencode.ai/docs/go Zen
+  subscription.
+argument-hint: "What do you want to build on the OpenCode SDK/server? (e.g. 'prompt a session over HTTP and get JSON back', 'spin up a server from Node', 'list sessions in Go')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode SDK & server
+
+Control OpenCode the way the TUI does: the TUI is itself a client of the `opencode serve`
+HTTP server, so the SDK can do anything the TUI does. SDK types are **generated from the
+server's OpenAPI 3.1 spec** — the spec at `/doc` is the real contract; the SDK is a typed
+shell over it.
+
+> **OpenCode's API moves fast and predates the model's training cutoff** — before writing
+> sdk code, read `references/sdk.rst` (+ `server.rst`, `go.rst`) AND re-check
+> <https://opencode.ai/docs/sdk/> for drift. Pin versions; don't trust memory of method names.
+
+## Pick your entry point
+
+| You want to… | Use | From |
+|---|---|---|
+| Spawn a server **and** get a client in one Node call | **`createOpencode()`** | `@opencode-ai/sdk` |
+| Connect to an **already-running** server | **`createOpencodeClient({ baseUrl })`** | `@opencode-ai/sdk` |
+| Drive from Go | **`opencode.NewClient()`** | `github.com/sst/opencode-sdk-go` |
+| Talk raw HTTP / any language | `opencode serve` + the endpoints in `references/server.rst` | OpenAPI at `/doc` |
+
+> **There is NO `createOpencodeServer`.** It appears only in third-party material and is
+> not on the official SDK page. The canonical JS surface is exactly two factories:
+> `createOpencode` (server + client) and `createOpencodeClient` (client only). Do not
+> propagate `createOpencodeServer`.
+
+## Version pins (record + verify current)
+
+| Thing | Pin | Note |
+|---|---|---|
+| Go SDK module | `github.com/sst/opencode-sdk-go@v0.19.2` | **official path** — other namesake Go modules exist; verify this one |
+| Go toolchain | **Go 1.22+** | required by the SDK |
+| JS package | `@opencode-ai/sdk` | `npm install @opencode-ai/sdk` |
+| Plugin/tool types | `@opencode-ai/plugin` | for in-plugin clients (see `/opencode-dev:plugin`) |
+
+`createOpencode`'s `client` is the same type as `PluginInput.client` — code written here
+is reusable inside a plugin.
+
+## `opencode serve` — the server
+
+```
+opencode serve [--port 4096] [--hostname 127.0.0.1] [--cors <origin>] [--mdns] [--mdns-domain <d>]
+```
+
+- Defaults: **port `4096`, host `127.0.0.1`** (loopback-only — not exposed to the network).
+- **Auth is opt-in via env, not flags:** set `OPENCODE_SERVER_PASSWORD` to require HTTP basic
+  auth; username defaults to `opencode` (override with `OPENCODE_SERVER_USERNAME`). No password
+  set ⇒ no auth.
+- `--cors` is **repeatable** (pass once per origin); browsers need it, server-to-server doesn't.
+- **OpenAPI 3.1 spec lives at `GET /doc`** — fetch it to regenerate types or to find any
+  endpoint not yet wrapped by the SDK. This is the source of truth, not this file.
+
+Endpoint traps (full list in `references/server.rst`):
+- Health is **`GET /global/health`** (returns `{ healthy, version }`), not `/health`.
+- Send-and-wait is `POST /session/:id/message`; fire-and-forget is **`POST /session/:id/prompt_async`**.
+- Search is `GET /find?pattern=`, files `GET /find/file?query=`, symbols `GET /find/symbol?query=`,
+  read `GET /file/content?path=`.
+- SSE event stream: `GET /event` (per-session) / `GET /global/event`.
+
+## JS/TS client
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+const { client, server } = await createOpencode()   // server.url, server.close()
+```
+
+`createOpencode` options: `hostname` (`127.0.0.1`), `port` (`4096`), `timeout` (`5000`),
+`signal`, `config` (an inline `Config` that **overrides `opencode.json`**). Always
+`await server.close()` when done — the factory owns the spawned process.
+
+`createOpencodeClient` options: `baseUrl` (`http://localhost:4096`), `fetch`, `parseAs`,
+**`responseStyle`** (`"data"` | `"fields"`), **`throwOnError`** (bool). Default style returns
+`{ data, ... }` — note results are accessed as **`result.data.…`** (e.g.
+`result.data.info.structured_output`), so a missing `.data` is the usual "why is my field
+undefined" bug.
+
+API surfaces are **namespaced objects**, not flat: `client.global.health()`,
+`client.app.log()/agents()`, `client.project.list()/current()`, `client.session.*`
+(`list/get/create/update/delete/prompt/command/shell/messages/abort/share/init/revert/…`),
+`client.find.text/files/symbols`, `client.file.read/status`, `client.tui.*`,
+`client.auth.set`, `client.event.subscribe()`. Full method list in `references/sdk.rst`.
+
+### Structured output (the json_schema path)
+
+```javascript
+const result = await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    parts: [{ type: "text", text: "…" }],
+    format: { type: "json_schema", schema: { /* JSON Schema */ }, retryCount: 2 },
+  },
+})
+result.data.info.structured_output            // the parsed object
+result.data.info.error?.name === "StructuredOutputError"  // check this before reading output
+```
+
+- `format.type` is `"text"` (default) or **`"json_schema"`**; the schema goes in
+  `format.schema`, retries in `format.retryCount` (default `2`).
+- Under the hood the model is forced through a `StructuredOutput` tool. On failure
+  `info.error.name === "StructuredOutputError"` (with `.message`, `.retries`) — **the call
+  still resolves**, so guard on the error field rather than a `try/catch`.
+
+See `assets/hello-sdk.ts` for a runnable spawn → prompt → structured-output → close flow.
+
+## Go client
+
+```go
+import "github.com/sst/opencode-sdk-go"
+client := opencode.NewClient()
+sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+```
+
+- **Every request param is wrapped in a `Field`** to separate zero/null/omitted. Build with
+  `opencode.F(v)`, `opencode.Null[T]()`, `opencode.Raw[T](any)` (and `String/Int/Float`
+  helpers). A bare `""`/`0` is **not sent** unless wrapped — forgetting `F()` silently omits it.
+- Response fields are plain value types; inspect presence via the per-field
+  `res.JSON.<Field>.IsNull()/IsMissing()/IsInvalid()` and undocumented keys via
+  `res.JSON.ExtraFields[...]`.
+- Errors: `errors.As(err, &apiErr)` into **`*opencode.Error`** (`StatusCode`,
+  `DumpRequest/DumpResponse`). Retries default to **2** (connection errors, 408/409/429/≥500);
+  **no default timeout** — set one via `context` + `option.WithRequestTimeout()`.
+- Reach undocumented endpoints with `client.Get/Post(...)` and `option.WithJSONSet/WithQuerySet`.
+
+`NewClient()` targets `127.0.0.1:4096` by default; configure base URL/headers/auth via the
+`option` package. See `assets/hello-sdk.go`. Full API in the SDK's own `api.md`.
+
+## Traps to avoid
+
+- ⚠️ **`opencode.ai/docs/go/` is the wrong page for the Go SDK** — it documents the paid
+  "OpenCode Zen Go" model subscription, not the library. The Go *SDK* is
+  `github.com/sst/opencode-sdk-go` (see `references/go.rst`).
+- ⚠️ **This is SST OpenCode, not OpenAI Codex.** Don't import Codex/`app-server` APIs.
+- ⚠️ No `createOpencodeServer`; no Python package is officially verified (JS/TS + Go only).
+- ⚠️ JS results are under **`result.data`** (default `responseStyle`); structured-output
+  failures surface as `info.error`, not a thrown exception (unless `throwOnError`).
+
+## Reference & example files
+
+| File | Contents |
+|---|---|
+| [references/sdk.rst](references/sdk.rst) | JS/TS SDK — factories, options, all `client.*` methods, structured output |
+| [references/server.rst](references/server.rst) | `opencode serve` flags, env auth, full endpoint list, OpenAPI `/doc` |
+| [references/go.rst](references/go.rst) | Go SDK — install/pin, `NewClient`, `Field` wrappers, errors, retries, options |
+| [assets/hello-sdk.ts](assets/hello-sdk.ts) | Node: spawn server → create session → structured prompt → close |
+| [assets/hello-sdk.go](assets/hello-sdk.go) | Go: `NewClient` → `Session.List` with `*opencode.Error` handling |
+
+Related facets: programmatic tool/hook code → `/opencode-dev:plugin`; delegating from a
+Claude Code plugin (ACP / `serve` / `opencode run`) → `/opencode-dev:delegate`.

--- a/plugins/opencode-dev/skills/sdk/assets/hello-sdk.go
+++ b/plugins/opencode-dev/skills/sdk/assets/hello-sdk.go
@@ -1,5 +1,5 @@
 // Drive OpenCode from Go via the official SDK.
-// Verify the surface in references/go.md and re-check github.com/sst/opencode-sdk-go for drift.
+// Verify the surface in references/go.rst and re-check github.com/sst/opencode-sdk-go for drift.
 //
 // Official module (NOT the anomalyco/manno23 forks):
 //   go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'   // requires Go 1.22+

--- a/plugins/opencode-dev/skills/sdk/assets/hello-sdk.go
+++ b/plugins/opencode-dev/skills/sdk/assets/hello-sdk.go
@@ -1,0 +1,34 @@
+// Drive OpenCode from Go via the official SDK.
+// Verify the surface in references/go.md and re-check github.com/sst/opencode-sdk-go for drift.
+//
+// Official module (NOT the anomalyco/manno23 forks):
+//   go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'   // requires Go 1.22+
+//
+// NewClient() targets a running `opencode serve` (default http://127.0.0.1:4096).
+// Point it elsewhere or add auth with option.With* (e.g. option.WithBaseURL,
+// option.WithHeader for OPENCODE_SERVER_PASSWORD basic auth).
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sst/opencode-sdk-go"
+)
+
+func main() {
+	client := opencode.NewClient()
+
+	sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+	if err != nil {
+		// All request params are wrapped in opencode.F(...) / Null[T]() / Raw[T]().
+		var apiErr *opencode.Error
+		if errors.As(err, &apiErr) {
+			fmt.Println(string(apiErr.DumpRequest(true)))
+		}
+		panic(err.Error())
+	}
+
+	fmt.Printf("%+v\n", sessions)
+}

--- a/plugins/opencode-dev/skills/sdk/assets/hello-sdk.ts
+++ b/plugins/opencode-dev/skills/sdk/assets/hello-sdk.ts
@@ -1,0 +1,45 @@
+// Drive OpenCode from JS/TS via @opencode-ai/sdk.
+// Verify the surface in references/sdk.md and re-check https://opencode.ai/docs/sdk/ for drift.
+//   npm install @opencode-ai/sdk
+//
+// createOpencode() spawns `opencode serve` AND returns a connected client.
+// To attach to an already-running server instead, use:
+//   import { createOpencodeClient } from "@opencode-ai/sdk"
+//   const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+// There is NO createOpencodeServer in the official SDK — do not use it.
+
+import { createOpencode } from "@opencode-ai/sdk"
+
+const { client, server } = await createOpencode({ hostname: "127.0.0.1", port: 4096 })
+
+try {
+  const health = await client.global.health() // { healthy: true, version }
+  console.log("server", server.url, health)
+
+  const session = await client.session.create({ body: {} })
+  const id = session.data.id
+
+  // Structured output: model is forced through a json_schema StructuredOutput tool.
+  const result = await client.session.prompt({
+    path: { id },
+    body: {
+      parts: [{ type: "text", text: "Summarize this repo in one sentence." }],
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        },
+      },
+    },
+  })
+
+  if (result.data.info.error?.name === "StructuredOutputError") {
+    console.error("structured output failed:", result.data.info.error.message)
+  } else {
+    console.log(result.data.info.structured_output)
+  }
+} finally {
+  await server.close()
+}

--- a/plugins/opencode-dev/skills/sdk/assets/hello-sdk.ts
+++ b/plugins/opencode-dev/skills/sdk/assets/hello-sdk.ts
@@ -1,5 +1,5 @@
 // Drive OpenCode from JS/TS via @opencode-ai/sdk.
-// Verify the surface in references/sdk.md and re-check https://opencode.ai/docs/sdk/ for drift.
+// Verify the surface in references/sdk.rst and re-check https://opencode.ai/docs/sdk/ for drift.
 //   npm install @opencode-ai/sdk
 //
 // createOpencode() spawns `opencode serve` AND returns a connected client.

--- a/plugins/opencode-dev/skills/sdk/references/go.rst
+++ b/plugins/opencode-dev/skills/sdk/references/go.rst
@@ -1,0 +1,177 @@
+<!-- Source: https://github.com/sst/opencode-sdk-go (README, main) — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+> TRAP: `https://opencode.ai/docs/go/` is NOT the Go SDK — it documents the "OpenCode Zen Go" subscription (curated coding models, billing). The Go *SDK* truth is this repo: `github.com/sst/opencode-sdk-go`. Full API in its `api.md`.
+
+# Opencode Go API Library
+
+The Opencode Go library provides convenient access to the [Opencode REST API](https://opencode.ai/docs) from applications written in Go. Generated with Stainless.
+
+## Installation
+
+```go
+import (
+	"github.com/sst/opencode-sdk-go" // imported as opencode
+)
+```
+
+Pin the version:
+
+```sh
+go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'
+```
+
+## Requirements
+
+This library requires Go 1.22+.
+
+## Usage
+
+The full API of this library can be found in `api.md`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sst/opencode-sdk-go"
+)
+
+func main() {
+	client := opencode.NewClient()
+	sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%+v\n", sessions)
+}
+```
+
+### Request fields
+
+All request parameters are wrapped in a generic `Field` type, used to distinguish zero values from null or omitted fields. Construct fields with `String()`, `Int()`, `Float()`, or the generic `F[T]()`. To send a null, use `Null[T]()`; to send a nonconforming value, use `Raw[T](any)`. Any field not specified is not sent.
+
+```go
+params := FooParams{
+	Name: opencode.F("hello"),
+
+	// Explicitly send `"description": null`
+	Description: opencode.Null[string](),
+
+	Point: opencode.F(opencode.Point{
+		X: opencode.Int(0),
+		Y: opencode.Int(1),
+
+		// In cases where the API specifies a given type,
+		// but you want to send something else, use `Raw`:
+		Z: opencode.Raw[int64](0.01), // sends a float
+	}),
+}
+```
+
+### Response objects
+
+All fields in response structs are value types (not pointers or wrappers). If a field is `null`, not present, or invalid, it is its zero value. Each response struct includes a special `JSON` field:
+
+```go
+if res.Name == "" {
+	res.JSON.Name.IsNull()    // true if `"name"` is not present or explicitly null
+	res.JSON.Name.IsMissing() // true if the `"name"` key was not present at all
+	if res.JSON.Name.IsInvalid() {
+		raw := res.JSON.Name.Raw()
+		// ...
+	}
+}
+```
+
+`.JSON` structs include an `Extras`/`ExtraFields` map for properties not in the struct:
+
+```go
+body := res.JSON.ExtraFields["my_unexpected_field"].Raw()
+```
+
+### RequestOptions (functional options pattern)
+
+Functions in the `option` package return a `RequestOption`. Supply to client or per-request:
+
+```go
+client := opencode.NewClient(
+	option.WithHeader("X-Some-Header", "custom_header_info"),
+)
+
+client.Session.List(context.TODO(), ...,
+	option.WithHeader("X-Some-Header", "some_other_custom_header_info"),
+	option.WithJSONSet("some.json.path", map[string]string{"my": "object"}),
+)
+```
+
+### Pagination
+
+`.ListAutoPaging()` iterates items across all pages; `.List()` fetches a single page with helpers like `.GetNextPage()`.
+
+### Errors
+
+Non-success status codes return `*opencode.Error` (with `StatusCode`, `*http.Request`, `*http.Response`). Use `errors.As`:
+
+```go
+_, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+if err != nil {
+	var apierr *opencode.Error
+	if errors.As(err, &apierr) {
+		println(string(apierr.DumpRequest(true)))  // serialized HTTP request
+		println(string(apierr.DumpResponse(true))) // serialized HTTP response
+	}
+	panic(err.Error()) // GET "/session": 400 Bad Request { ... }
+}
+```
+
+### Timeouts
+
+Requests do not time out by default; use context. Per-retry timeout via `option.WithRequestTimeout()`:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+defer cancel()
+client.Session.List(ctx, opencode.SessionListParams{},
+	option.WithRequestTimeout(20*time.Second),
+)
+```
+
+### File uploads
+
+Parameters for file uploads are typed `param.Field[io.Reader]`. Default multipart file name `anonymous_file`, content-type `application/octet-stream`. Helper: `opencode.FileParam(reader io.Reader, filename string, contentType string)`.
+
+### Retries
+
+Retries 2 times by default (connection errors, 408, 409, 429, >=500). Configure with `option.WithMaxRetries()`:
+
+```go
+client := opencode.NewClient(option.WithMaxRetries(0)) // default is 2
+client.Session.List(context.TODO(), opencode.SessionListParams{}, option.WithMaxRetries(5))
+```
+
+### Accessing raw response data
+
+```go
+var response *http.Response
+sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{},
+	option.WithResponseInto(&response))
+fmt.Printf("Status Code: %d\n", response.StatusCode)
+```
+
+### Custom/undocumented requests
+
+Use `client.Get`, `client.Post`, etc. for undocumented endpoints; `option.WithQuerySet()` / `option.WithJSONSet()` for undocumented params; `result.JSON.RawJSON()` / `result.JSON.Foo.Raw()` for undocumented response properties.
+
+### Middleware
+
+```go
+func Logger(req *http.Request, next option.MiddlewareNext) (res *http.Response, err error) {
+	res, err = next(req)
+	return res, err
+}
+client := opencode.NewClient(option.WithMiddleware(Logger))
+```
+
+Replace the default `http.Client` with `option.WithHTTPClient(client)`.

--- a/plugins/opencode-dev/skills/sdk/references/sdk.rst
+++ b/plugins/opencode-dev/skills/sdk/references/sdk.rst
@@ -1,0 +1,178 @@
+<!-- Source: https://opencode.ai/docs/sdk/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+# OpenCode SDK
+
+A type-safe JS client for interacting with the OpenCode server, to build integrations and control it programmatically. The TUI is itself a client, so the SDK can do anything the TUI does. SDK types are generated from the server's OpenAPI 3.1 spec.
+
+## Installation
+
+```
+npm install @opencode-ai/sdk
+```
+
+## Client Creation
+
+### Full instance — `createOpencode()` (starts server + client)
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+const { client } = await createOpencode()
+```
+
+Options:
+- `hostname` (string, default: `127.0.0.1`)
+- `port` (number, default: `4096`)
+- `signal` (AbortSignal)
+- `timeout` (number, default: `5000`)
+- `config` (Config object)
+
+Returns an object exposing the `client` plus the spawned server (`server.url`, `server.close()`).
+
+### Client-only connection — `createOpencodeClient({ baseUrl })`
+
+```javascript
+import { createOpencodeClient } from "@opencode-ai/sdk"
+const client = createOpencodeClient({
+  baseUrl: "http://localhost:4096",
+})
+```
+
+Options:
+- `baseUrl` (string, default: `http://localhost:4096`)
+- `fetch` (custom function)
+- `parseAs` (string)
+- `responseStyle` (string: `data` or `fields`)
+- `throwOnError` (boolean)
+
+> NOTE: `createOpencodeServer` does NOT appear on the official SDK page. The canonical surface is `createOpencode` + `createOpencodeClient`.
+
+## Configuration
+
+Configuration can be passed inline, overriding `opencode.json`:
+
+```javascript
+const opencode = await createOpencode({
+  hostname: "127.0.0.1",
+  port: 4096,
+  config: {
+    model: "anthropic/claude-3-5-sonnet-20241022",
+  },
+})
+```
+
+## Types
+
+```javascript
+import type { Session, Message, Part } from "@opencode-ai/sdk"
+```
+
+## Structured Output
+
+Format types:
+- `text` – Standard text response (default)
+- `json_schema` – Validated JSON matching provided schema
+
+`json_schema` format fields:
+- `type` (required): `'json_schema'`
+- `schema` (required): JSON Schema object
+- `retryCount` (optional): Validation retry attempts (default: 2)
+
+```javascript
+const result = await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    parts: [{ type: "text", text: "Research Anthropic and provide company info" }],
+    format: {
+      type: "json_schema",
+      schema: {
+        type: "object",
+        properties: {
+          company: { type: "string", description: "Company name" },
+          founded: { type: "number", description: "Year founded" },
+          products: {
+            type: "array",
+            items: { type: "string" },
+            description: "Main products",
+          },
+        },
+        required: ["company", "founded"],
+      },
+    },
+  },
+})
+console.log(result.data.info.structured_output)
+```
+
+Error handling:
+
+```javascript
+if (result.data.info.error?.name === "StructuredOutputError") {
+  console.error("Failed to produce structured output:", result.data.info.error.message)
+  console.error("Attempts:", result.data.info.error.retries)
+}
+```
+
+## API Methods
+
+### Global
+- `global.health()` – Returns `{ healthy: true, version: string }`
+
+### App
+- `app.log()` – Write log entry (returns `boolean`)
+- `app.agents()` – List available agents (returns `Agent[]`)
+
+### Project
+- `project.list()` – List all projects (returns `Project[]`)
+- `project.current()` – Get current project (returns `Project`)
+
+### Path
+- `path.get()` – Get current path info (returns `Path`)
+
+### Config
+- `config.get()` – Get config info (returns `Config`)
+- `config.providers()` – List providers and defaults
+
+### Sessions
+- `session.list()`
+- `session.get({ path })`
+- `session.children({ path })`
+- `session.create({ body })`
+- `session.delete({ path })`
+- `session.update({ path, body })`
+- `session.init({ path, body })` – Analyze app, create `AGENTS.md`
+- `session.abort({ path })`
+- `session.share({ path })`
+- `session.unshare({ path })`
+- `session.summarize({ path, body })`
+- `session.messages({ path })`
+- `session.message({ path })`
+- `session.prompt({ path, body })` – Supports `noReply: true` and `outputFormat`
+- `session.command({ path, body })`
+- `session.shell({ path, body })`
+- `session.revert({ path, body })`
+- `session.unrevert({ path })`
+- `postSessionByIdPermissionsByPermissionId({ path, body })`
+
+### Files
+- `find.text({ query })` – Search text in files
+- `find.files({ query })` – Find files/directories by name (query supports `type` ("file"/"directory"), `directory`, `limit` 1–200)
+- `find.symbols({ query })` – Find workspace symbols
+- `file.read({ query })` – Read file content
+- `file.status({ query? })` – Get tracked file status
+
+### TUI
+- `tui.appendPrompt({ body })`
+- `tui.openHelp()`
+- `tui.openSessions()`
+- `tui.openThemes()`
+- `tui.openModels()`
+- `tui.submitPrompt()`
+- `tui.clearPrompt()`
+- `tui.executeCommand({ body })`
+- `tui.showToast({ body })`
+
+### Auth
+- `auth.set({ ... })` – Set authentication credentials
+
+### Events
+- `event.subscribe()` – Server-sent events stream

--- a/plugins/opencode-dev/skills/sdk/references/server.rst
+++ b/plugins/opencode-dev/skills/sdk/references/server.rst
@@ -1,0 +1,133 @@
+<!-- Source: https://opencode.ai/docs/server/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+# OpenCode Server
+
+OpenCode Server is a headless HTTP service that exposes an OpenAPI endpoint for programmatic interaction. The `opencode serve` command starts this server.
+
+## Usage
+
+```
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--port` | Port to listen on | `4096` |
+| `--hostname` | Hostname to listen on | `127.0.0.1` |
+| `--mdns` | Enable mDNS discovery | `false` |
+| `--mdns-domain` | Custom domain name for mDNS service | `opencode.local` |
+| `--cors` | Additional browser origins to allow | `[]` |
+
+Pass `--cors` multiple times for multiple origins:
+
+```
+opencode serve --cors http://localhost:5173 --cors https://app.example.com
+```
+
+## Authentication
+
+Set environment variables to protect the server:
+- `OPENCODE_SERVER_PASSWORD` — required password
+- `OPENCODE_SERVER_USERNAME` — defaults to `opencode`
+
+```
+OPENCODE_SERVER_PASSWORD=your-password opencode serve
+```
+
+## API Specification
+
+Access the OpenAPI 3.1 spec at: `http://<hostname>:<port>/doc`
+
+## Core API Endpoints
+
+### Global
+- `GET /global/health` — Server health/version
+- `GET /global/event` — Global events (SSE stream)
+
+### Project
+- `GET /project` — List all projects
+- `GET /project/current` — Current project
+
+### Path & VCS
+- `GET /path` — Current path
+- `GET /vcs` — VCS info
+
+### Config
+- `GET /config` — Get config
+- `PATCH /config` — Update config
+- `GET /config/providers` — List providers
+
+### Provider
+- `GET /provider` — List providers
+- `GET /provider/auth` — Auth methods
+- `POST /provider/{id}/oauth/authorize` — OAuth authorization
+- `POST /provider/{id}/oauth/callback` — OAuth callback
+
+### Sessions
+- `GET /session` — List sessions
+- `POST /session` — Create session
+- `GET /session/:id` — Get session
+- `DELETE /session/:id` — Delete session
+- `PATCH /session/:id` — Update session
+- `POST /session/:id/abort` — Abort session
+- `POST /session/:id/fork` — Fork session
+- `POST /session/:id/init` — Initialize/analyze app
+- `GET /session/:id/diff` — Get session diff
+- `POST /session/:id/share` — Share session
+- `DELETE /session/:id/share` — Unshare session
+- `POST /session/:id/revert` — Revert message
+- `POST /session/:id/unrevert` — Restore reverted messages
+
+### Messages
+- `GET /session/:id/message` — List messages
+- `POST /session/:id/message` — Send message (wait for response)
+- `GET /session/:id/message/:messageID` — Get message
+- `POST /session/:id/prompt_async` — Send async message
+- `POST /session/:id/command` — Execute slash command
+- `POST /session/:id/shell` — Run shell command
+
+### Commands
+- `GET /command` — List all commands
+
+### Files
+- `GET /find?pattern=<pat>` — Search text in files
+- `GET /find/file?query=<q>` — Find files/directories
+- `GET /find/symbol?query=<q>` — Find workspace symbols
+- `GET /file?path=<path>` — List files
+- `GET /file/content?path=<p>` — Read file
+- `GET /file/status` — Get tracked file status
+
+### Tools (Experimental)
+- `GET /experimental/tool/ids` — List tool IDs
+- `GET /experimental/tool?provider=<p>&model=<m>` — List tools with schemas
+
+### LSP, Formatters & MCP
+- `GET /lsp` — LSP server status
+- `GET /formatter` — Formatter status
+- `GET /mcp` — MCP server status
+- `POST /mcp` — Add MCP server dynamically
+
+### Agents
+- `GET /agent` — List available agents
+
+### Logging
+- `POST /log` — Write log entry
+
+### TUI
+- `POST /tui/append-prompt` — Append prompt text
+- `POST /tui/submit-prompt` — Submit prompt
+- `POST /tui/clear-prompt` — Clear prompt
+- `POST /tui/execute-command` — Execute command
+- `POST /tui/show-toast` — Show notification
+- `POST /tui/open-help` — Open help
+- `POST /tui/open-sessions` — Open session selector
+- `POST /tui/open-themes` — Open theme selector
+- `POST /tui/open-models` — Open model selector
+
+### Auth
+- `PUT /auth/:id` — Set authentication credentials
+
+### Events
+- `GET /event` — Server-sent events stream

--- a/plugins/opencode-dev/skills/skill/SKILL.md
+++ b/plugins/opencode-dev/skills/skill/SKILL.md
@@ -1,0 +1,206 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode Agent Skills (SKILL.md) and wire external References for the
+  SST OpenCode coding agent (opencode.ai, github.com/sst/opencode — NOT OpenAI
+  Codex). Covers the on-demand `skill` tool, the `permission.skill` glob gate vs
+  the `tools.skill: false` kill-switch, the name-matches-directory + regex rule,
+  the six discovery paths, and the `references` config key (named external roots
+  via `@alias`). Use when the user mentions an OpenCode SKILL.md, `.opencode/skills/`,
+  `.claude/skills/` drop-in compatibility, `skill({ name })`, the `skill` permission,
+  `<available_skills>`, the `references` key, `@alias`, or making a Claude Code skill
+  work in OpenCode.
+argument-hint: "What OpenCode skill or reference are you authoring? (e.g. 'add a git-release SKILL.md', 'expose ../docs as @docs', 'why isn't my skill loading')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Agent Skills + References
+
+Author OpenCode **Agent Skills** (`SKILL.md` instruction bundles loaded on demand) and
+**References** (external dirs/repos attached via `@alias`). OpenCode is SST's open-source
+coding agent — **not OpenAI Codex** — and its skill format is Claude-Code-compatible by
+design, which is exactly where the wrong assumptions creep in.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's training
+> cutoff — before writing skill code, read `references/skills.rst` (and `references/references.rst`
+> for the `references` key) AND re-check <https://opencode.ai/docs/skills/> for drift.
+
+---
+
+## The big shortcut: Claude Code skills are drop-in
+
+OpenCode reads `.claude/skills/<name>/SKILL.md` and `~/.claude/skills/<name>/SKILL.md`
+**verbatim** — no conversion, no port. If a Claude Code skill already exists, **do not
+rewrite it**; just confirm its `name` matches its directory and its frontmatter passes the
+rules below. The six discovery locations (project + global × three roots):
+
+| Root | Project | Global |
+|------|---------|--------|
+| OpenCode-native | `.opencode/skills/<name>/SKILL.md` | `~/.config/opencode/skills/<name>/SKILL.md` |
+| Claude-compatible | `.claude/skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` |
+| agent-compatible | `.agents/skills/<name>/SKILL.md` | `~/.agents/skills/<name>/SKILL.md` |
+
+Project discovery **walks up from cwd to the git worktree root**, loading every match along
+the way. Skill `name`s **must be unique across all six locations** — a duplicate name is a
+common silent-failure cause.
+
+---
+
+## Frontmatter — only five fields exist
+
+OpenCode recognizes **exactly** these; everything else is **silently ignored**:
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `name` | yes | 1–64 chars, regex `^[a-z0-9]+(-[a-z0-9]+)*$`, **must equal the containing directory name** |
+| `description` | yes | 1–1024 chars; specific enough for the agent to choose it |
+| `license` | no | license identifier (e.g. `MIT`) |
+| `compatibility` | no | e.g. `opencode` |
+| `metadata` | no | **string→string map only** — no nested objects, no numbers/booleans |
+
+Traps a fresh model hits:
+
+- **`name` must match the folder name exactly.** `skills/git-release/SKILL.md` ⇒ `name: git-release`.
+  No start/end hyphen, no `--`.
+- **Claude Code frontmatter keys are inert here.** `argument-hint`, `user-invocable`,
+  `allowed-tools`, `allowed_directories`, etc. are **not recognized** — they don't error, they
+  just do nothing. Don't rely on them for OpenCode behavior.
+- **`metadata` is flat string→string.** `metadata: { audience: maintainers }` ✅;
+  `metadata: { steps: 3 }` or nested maps ❌.
+- The file **must be named `SKILL.md` in all caps**.
+
+Minimal valid skill (see `assets/SKILL.template.md`):
+
+```markdown
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+---
+## What I do
+- Draft release notes from merged PRs
+```
+
+---
+
+## How a skill is invoked
+
+The agent sees only `name` + `description` in the `skill` tool description, rendered as:
+
+```xml
+<available_skills>
+  <skill><name>git-release</name><description>Create consistent releases and changelogs</description></skill>
+</available_skills>
+```
+
+and loads the full body **on demand** by calling the native tool:
+
+```
+skill({ name: "git-release" })
+```
+
+So the `description` is the **only** trigger signal — write it like a good Claude Code
+description (concrete "use when…" terms), not a title.
+
+---
+
+## Gating skills — two distinct mechanisms (don't conflate)
+
+| Goal | Key | Shape | Effect |
+|------|-----|-------|--------|
+| Allow/deny/ask **per skill name** | `permission.skill` | glob map → `allow`\|`deny`\|`ask` | `deny` **hides** the skill from the agent; `ask` prompts the user before load |
+| **Disable the skill tool entirely** | `tools.skill` | `false` | drops the whole `<available_skills>` section from context |
+
+`permission.skill` is a **permission glob map**, not a boolean:
+
+```json
+{ "permission": { "skill": {
+    "*": "allow", "pr-review": "allow", "internal-*": "deny", "experimental-*": "ask" } } }
+```
+
+Per-agent overrides (agents beat global):
+
+```yaml
+# custom agent frontmatter
+---
+permission:
+  skill: { "documents-*": "allow" }
+---
+```
+
+```json
+// built-in agent in opencode.json
+{ "agent": { "plan": { "permission": { "skill": { "internal-*": "allow" } } } } }
+```
+
+To kill skills for an agent entirely use `tools: { skill: false }` (frontmatter) or
+`agent.<name>.tools.skill: false` (config) — **not** a permission entry.
+
+---
+
+## References — named external roots via `@alias`
+
+A separate feature (`references` config key) that exposes dirs/repos **outside the project**.
+Config in `opencode.json`/`opencode.jsonc`, keyed by alias. Full detail in
+`references/references.rst`.
+
+```jsonc
+{ "references": {
+    "docs":   { "path": "../docs", "description": "Product behavior + doc conventions" },
+    "effect": { "repository": "Effect-TS/effect", "branch": "main" } } }
+```
+
+| Type | Field | Shorthand |
+|------|-------|-----------|
+| Local dir | `path` (relative-to-config, absolute, or `~/`) | `"docs": "../docs"` |
+| Git repo | `repository` (Git URL / `host/path` / GitHub `owner/repo`) + optional `branch` | `"effect": "Effect-TS/effect"` |
+
+Optional for both: `description`, `hidden`.
+
+Non-inferable traps:
+
+- **Alias charset is restricted.** An alias **cannot be empty or contain `/`, whitespace,
+  backticks, or commas.** (So `@my-docs` ✅, `@my/docs` ✗.)
+- **Git references refresh asynchronously** — a newly configured `repository` may take a
+  moment to finish cloning/updating; it won't be there instantly.
+- **Only references *with a `description`* are advertised to the agent** (injected into system
+  context). Without a description a reference is reachable solely via `@`-autocomplete / manual
+  `@alias` — the agent won't know it exists.
+- `@alias` attaches the **root**; `@alias/` searches **files inside** it.
+- `hidden: true` only removes the alias from TUI `@`-autocomplete; a hidden ref **with** a
+  description is still in agent context.
+- References are auto-allowed through OpenCode's **external-directory permission boundary**, but
+  **normal tool permissions still apply** — a read-only agent doesn't gain edit access just
+  because a dir is a reference.
+
+---
+
+## Troubleshooting "my skill won't load"
+
+1. Filename is `SKILL.md` (all caps).
+2. Frontmatter has both `name` and `description`, and `name` == directory name and matches the regex.
+3. The name is unique across all six discovery locations.
+4. It isn't `deny`'d by `permission.skill` (deny ⇒ hidden), and `tools.skill` isn't `false` for the active agent.
+
+---
+
+## Reference files
+
+| File | Contents |
+|------|----------|
+| [references/skills.rst](references/skills.rst) | Verbatim Agent Skills doc — discovery paths, frontmatter rules, regex, `skill` tool, `permission.skill`, per-agent overrides, troubleshooting |
+| [references/references.rst](references/references.rst) | Verbatim References doc — `references` key, `path`/`repository` fields, shorthands, `@alias` usage, alias charset, async git refresh, field table |
+| [assets/SKILL.template.md](assets/SKILL.template.md) | Minimal OpenCode-valid `SKILL.md` skeleton |
+
+## Version pins
+
+OpenCode SDK packages: `@opencode-ai/sdk`, `@opencode-ai/plugin` (JS/TS); official Go module
+`github.com/sst/opencode-sdk-go` (Go SDK **v0.19.2**, **Go 1.22+**) — verify this exact module
+path. Skills themselves are plain markdown and need no SDK; these pins matter only if
+a skill shells out to OpenCode tooling. Re-verify current versions before pinning.

--- a/plugins/opencode-dev/skills/skill/assets/SKILL.template.md
+++ b/plugins/opencode-dev/skills/skill/assets/SKILL.template.md
@@ -1,0 +1,34 @@
+<!--
+Minimal OpenCode Agent Skill skeleton.
+Place at one of (folder name MUST equal the `name` below):
+  .opencode/skills/<name>/SKILL.md          (project, OpenCode-native)
+  ~/.config/opencode/skills/<name>/SKILL.md (global, OpenCode-native)
+  .claude/skills/<name>/SKILL.md            (project, Claude Code skills are read VERBATIM)
+  ~/.claude/skills/<name>/SKILL.md          (global, Claude Code drop-in)
+  .agents/skills/<name>/ or ~/.agents/skills/<name>/
+File MUST be named SKILL.md (all caps). Only the five frontmatter fields below
+are recognized; any other key (argument-hint, user-invocable, allowed-tools, …)
+is silently ignored by OpenCode.
+-->
+---
+name: my-skill                 # 1–64 chars, ^[a-z0-9]+(-[a-z0-9]+)*$, MUST equal the directory name
+description: One specific sentence the agent uses to decide when to load this skill. 1–1024 chars; name concrete triggers.
+license: MIT                   # optional
+compatibility: opencode        # optional
+metadata:                      # optional — string→string ONLY (no nesting, no numbers)
+  audience: maintainers
+---
+
+## What I do
+
+- Step or capability one
+- Step or capability two
+
+## When to use me
+
+Describe the trigger conditions. Ask clarifying questions if inputs are ambiguous.
+
+<!-- The agent sees only `name` + `description` until it calls skill({ name: "my-skill" });
+     this body loads on demand. Gate access with permission.skill globs in opencode.json:
+       { "permission": { "skill": { "*": "allow", "internal-*": "deny" } } }
+     Disable the tool entirely for an agent with tools: { skill: false }. -->

--- a/plugins/opencode-dev/skills/skill/references/references.rst
+++ b/plugins/opencode-dev/skills/skill/references/references.rst
@@ -1,0 +1,158 @@
+<!-- Source: https://opencode.ai/docs/references/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode skill code. -->
+
+# References
+
+> title: References — description: Add local directories and Git repositories as project references.
+
+References give OpenCode access to directories outside the current project. Use them to make documentation, shared libraries, examples, or another repository available while you work.
+
+References are configured by alias in `opencode.json` or `opencode.jsonc`.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "references": {
+    "docs": {
+      "path": "../product-docs",
+      "description": "Use for product behavior and documentation conventions",
+    },
+    "sdk": {
+      "repository": "anomalyco/opencode-sdk-js",
+      "branch": "main",
+      "description": "Use for JavaScript SDK implementation details",
+    },
+  },
+}
+```
+
+---
+
+## Local directories
+
+Use `path` to reference a local directory.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "docs": {
+      "path": "../docs",
+    },
+  },
+}
+```
+
+Paths can be:
+
+- Relative to the config file that defines the reference
+- Absolute, such as `/home/user/docs`
+- Relative to your home directory, such as `~/docs`
+
+You can also use a string shorthand:
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "docs": "../docs",
+  },
+}
+```
+
+---
+
+## Git repositories
+
+Use `repository` to reference a Git repository. OpenCode materializes the repository in its local repository cache and makes the checked-out source available as a reference directory.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "effect": {
+      "repository": "Effect-TS/effect",
+      "branch": "main",
+    },
+  },
+}
+```
+
+`repository` accepts Git URLs, host/path references, and GitHub `owner/repo` shorthand. The optional `branch` field selects a branch or ref. Without `branch`, OpenCode uses the repository's default branch.
+
+You can use string shorthand when you do not need a branch, description, or other options:
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "effect": "Effect-TS/effect",
+  },
+}
+```
+
+:::note
+Git references are refreshed asynchronously. A newly configured repository may take a moment to finish cloning or updating.
+:::
+
+---
+
+## Describe usage
+
+Add `description` to explain when an agent should use a reference.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "design-system": {
+      "path": "../design-system",
+      "description": "Use when implementing UI components or design tokens",
+    },
+  },
+}
+```
+
+OpenCode includes references with descriptions in agent context. Descriptions should be short and specific enough to distinguish references with similar content. References without descriptions remain available through autocomplete and direct use, but are not advertised to agents.
+
+---
+
+## Hide autocomplete entries
+
+Set `hidden` to `true` to omit a reference from `@` autocomplete in the TUI.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "internal": {
+      "path": "../internal",
+      "description": "Use for internal implementation details",
+      "hidden": true,
+    },
+  },
+}
+```
+
+`hidden` only affects autocomplete. A hidden reference with a description remains included in agent context.
+
+---
+
+## Use references
+
+Configured references appear in TUI `@` autocomplete. Type `@alias` to attach the reference root, or `@alias/` to search for files inside it.
+
+```text
+Compare this implementation with @sdk/src/client.ts
+```
+
+Agents also receive the resolved paths and descriptions of configured references that have descriptions in their system context, so they can inspect a reference when it is relevant without you attaching it manually.
+
+OpenCode automatically allows reference directories through its external-directory permission boundary. Normal tool permissions still apply; for example, an agent that cannot edit files does not gain edit access because a directory is configured as a reference.
+
+---
+
+## Configure fields
+
+| Field         | Local | Git | Description                                      |
+| ------------- | ----- | --- | ------------------------------------------------ |
+| `path`        | Yes   | No  | Local reference directory                        |
+| `repository`  | No    | Yes | Git URL, host/path, or GitHub `owner/repo` value |
+| `branch`      | No    | Yes | Optional Git branch or ref                       |
+| `description` | Yes   | Yes | Guidance describing when to use the reference    |
+| `hidden`      | Yes   | Yes | Hide the reference from TUI `@` autocomplete     |
+
+Reference aliases cannot be empty or contain `/`, whitespace, backticks, or commas.

--- a/plugins/opencode-dev/skills/skill/references/skills.rst
+++ b/plugins/opencode-dev/skills/skill/references/skills.rst
@@ -1,0 +1,223 @@
+<!-- Source: https://opencode.ai/docs/skills/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode skill code. -->
+
+# Agent Skills
+
+> title: "Agent Skills" — description: "Define reusable behavior via SKILL.md definitions"
+
+Agent skills let OpenCode discover reusable instructions from your repo or home directory.
+Skills are loaded on-demand via the native `skill` tool—agents see available skills and can load the full content when needed.
+
+---
+
+## Place files
+
+Create one folder per skill name and put a `SKILL.md` inside it.
+OpenCode searches these locations:
+
+- Project config: `.opencode/skills/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
+- Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
+- Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
+- Project agent-compatible: `.agents/skills/<name>/SKILL.md`
+- Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+
+---
+
+## Understand discovery
+
+For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
+It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` along the way.
+
+Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
+
+---
+
+## Write frontmatter
+
+Each `SKILL.md` must start with YAML frontmatter.
+Only these fields are recognized:
+
+- `name` (required)
+- `description` (required)
+- `license` (optional)
+- `compatibility` (optional)
+- `metadata` (optional, string-to-string map)
+
+Unknown frontmatter fields are ignored.
+
+---
+
+## Validate names
+
+`name` must:
+
+- Be 1–64 characters
+- Be lowercase alphanumeric with single hyphen separators
+- Not start or end with `-`
+- Not contain consecutive `--`
+- Match the directory name that contains `SKILL.md`
+
+Equivalent regex:
+
+```text
+^[a-z0-9]+(-[a-z0-9]+)*$
+```
+
+---
+
+## Follow length rules
+
+`description` must be 1-1024 characters.
+Keep it specific enough for the agent to choose correctly.
+
+---
+
+## Use an example
+
+Create `.opencode/skills/git-release/SKILL.md` like this:
+
+```markdown
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## What I do
+
+- Draft release notes from merged PRs
+- Propose a version bump
+- Provide a copy-pasteable `gh release create` command
+
+## When to use me
+
+Use this when you are preparing a tagged release.
+Ask clarifying questions if the target versioning scheme is unclear.
+```
+
+---
+
+## Recognize tool description
+
+OpenCode lists available skills in the `skill` tool description.
+Each entry includes the skill name and description:
+
+```xml
+<available_skills>
+  <skill>
+    <name>git-release</name>
+    <description>Create consistent releases and changelogs</description>
+  </skill>
+</available_skills>
+```
+
+The agent loads a skill by calling the tool:
+
+```
+skill({ name: "git-release" })
+```
+
+---
+
+## Configure permissions
+
+Control which skills agents can access using pattern-based permissions in `opencode.json`:
+
+```json
+{
+  "permission": {
+    "skill": {
+      "*": "allow",
+      "pr-review": "allow",
+      "internal-*": "deny",
+      "experimental-*": "ask"
+    }
+  }
+}
+```
+
+| Permission | Behavior                                  |
+| ---------- | ----------------------------------------- |
+| `allow`    | Skill loads immediately                   |
+| `deny`     | Skill hidden from agent, access rejected  |
+| `ask`      | User prompted for approval before loading |
+
+Patterns support wildcards: `internal-*` matches `internal-docs`, `internal-tools`, etc.
+
+---
+
+## Override per agent
+
+Give specific agents different permissions than the global defaults.
+
+**For custom agents** (in agent frontmatter):
+
+```yaml
+---
+permission:
+  skill:
+    "documents-*": "allow"
+---
+```
+
+**For built-in agents** (in `opencode.json`):
+
+```json
+{
+  "agent": {
+    "plan": {
+      "permission": {
+        "skill": {
+          "internal-*": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Disable the skill tool
+
+Completely disable skills for agents that shouldn't use them:
+
+**For custom agents**:
+
+```yaml
+---
+tools:
+  skill: false
+---
+```
+
+**For built-in agents**:
+
+```json
+{
+  "agent": {
+    "plan": {
+      "tools": {
+        "skill": false
+      }
+    }
+  }
+}
+```
+
+When disabled, the `<available_skills>` section is omitted entirely.
+
+---
+
+## Troubleshoot loading
+
+If a skill does not show up:
+
+1. Verify `SKILL.md` is spelled in all caps
+2. Check that frontmatter includes `name` and `description`
+3. Ensure skill names are unique across all locations
+4. Check permissions—skills with `deny` are hidden from agents

--- a/plugins/opencode-dev/skills/tools/SKILL.md
+++ b/plugins/opencode-dev/skills/tools/SKILL.md
@@ -1,0 +1,170 @@
+---
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Extend OpenCode's capabilities with the three add-on mechanisms: standalone
+  custom tools (`.opencode/tools/*.ts`), MCP servers (the `mcp` config key), and
+  LSP servers (the `lsp` config key). Encodes the traps a fresh model gets wrong —
+  plural dir + filename-is-toolname + built-in override, the `environment` (MCP)
+  vs `env` (LSP) spelling split, MCP tool namespacing + the `tools` glob gate,
+  the `lsp` boolean-or-object shape, the built-in tool list, and `apply_patch`
+  (not `patch`) sharing the one `edit` permission. Use when the user is writing
+  an OpenCode custom tool, importing `tool` from `@opencode-ai/plugin`,
+  overriding a built-in like `bash`, wiring an MCP server, configuring `lsp`,
+  setting `permission`/`tools` gates, or asks about `.opencode/tools/`,
+  `apply_patch`, `patchText`, `environment`, or namespaced MCP tools.
+argument-hint: "e.g. 'add a custom .opencode tool that overrides bash' or 'wire a remote MCP server'"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode: extending tools (custom tools, MCP, LSP)
+
+OpenCode's API moves fast and predates the model's training cutoff — before
+writing tools code, read `references/custom-tools.rst`, `references/mcp-servers.rst`,
+`references/lsp.rst`, `references/tools.rst` AND re-check
+https://opencode.ai/docs/custom-tools/ (and the `/mcp-servers/`, `/lsp/`, `/tools/`
+pages) for drift.
+
+**Three distinct extension mechanisms — pick one:**
+
+| Want | Mechanism | Where | Surface |
+|---|---|---|---|
+| Your own callable function | **Custom tool** | file `.opencode/tools/<name>.ts` | `tool()` from `@opencode-ai/plugin` |
+| An external MCP toolset | **MCP server** | `mcp` key in `opencode.json` | config only |
+| Diagnostics for the agent | **LSP server** | `lsp` key in `opencode.json` | config only |
+
+**Pin:** the load-bearing package is `@opencode-ai/plugin@1.17.11` (frontmatter
+`compatibility:`; source of `tool` / `tool.schema`). Re-check the installed
+version (`npm view @opencode-ai/plugin version`) against the API recital below
+before relying on it. (Go SDK `v0.19.2` / Go 1.22+ belong to `/opencode-dev:sdk`,
+not this facet.)
+
+**Facet boundary:** this skill covers **filesystem-discovered** standalone tools.
+Registering a tool **programmatically from inside a plugin** (the `tool` map hook)
+is `/opencode-dev:plugin` — both import `tool` from `@opencode-ai/plugin`, but
+don't duplicate the plugin route here. Permission `allow|ask|deny` *semantics* are
+owned by `/opencode-dev:policies`; this skill only shows the `tools` enable/disable
+gate and points there.
+
+## 1. Custom tools — the filename/override traps
+
+```ts
+// .opencode/tools/database.ts  → tool name is "database" (filename == tool name)
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Query the project database",
+  args: { query: tool.schema.string().describe("SQL query to execute") },
+  async execute(args, context) { return `ran: ${args.query}` },
+})
+```
+
+- **Dir is plural `.opencode/tools/`** (project) or `~/.config/opencode/tools/`
+  (global). Singular is wrong.
+- **Filename = tool name.** `database.ts` → `database`.
+- **A file named after a built-in OVERRIDES it.** Drop `bash.ts` in
+  `.opencode/tools/` and your tool replaces the built-in `bash` (keyed by name).
+  This is the supported way to sandbox/restrict a built-in.
+- **Multiple named exports → `<filename>_<export>`.** `math.ts` exporting `add`
+  and `multiply` yields `math_add` and `math_multiply` (NOT `add`/`multiply`).
+- Args use `tool.schema` (Zod re-export). Plain-object form is allowed if you
+  `import { z } from "zod"` yourself.
+- `execute(args, context)` — `context` = `{ agent, sessionID, messageID,
+  directory, worktree }`. Shell out to any language via `Bun.$` (see
+  `references/custom-tools.rst` Python example).
+
+## 2. MCP servers — `mcp` key, two transports
+
+```jsonc
+{ "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-srv":  { "type": "local",  "command": ["npx","-y","my-mcp"],
+                    "enabled": true, "environment": { "MY_VAR": "v" } },
+    "remote-srv": { "type": "remote", "url": "https://x.com", "enabled": true,
+                    "headers": { "Authorization": "Bearer KEY" } } } }
+```
+
+- **Local env key is `environment`** (full word). This is the #1 trap — see §4.
+- `type` (`"local"`/`"remote"`) is required. Non-obvious optionals: `timeout`
+  (ms, default **5000**), plus `cwd` and `oauth`.
+- **OAuth:** omit it and OpenCode auto-detects 401 → Dynamic Client Registration
+  (RFC 7591). `"oauth": {}` triggers DCR explicitly; `"oauth": false` disables it.
+  CLI: `opencode mcp auth|list|logout|debug <srv>`.
+- **MCP tools are namespaced by the server name as prefix** — server `sentry`
+  exposes `sentry_*`. You reference and gate them by that prefix.
+- Caveat: MCP servers add to context; enabling a heavy one (e.g. GitHub MCP) can
+  blow the context window.
+
+### Gating MCP tools — `tools` (enable/disable), not `permission`
+
+Two separate mechanisms, do not conflate:
+
+- **`tools`** = top-level glob map that **enables/disables** tools:
+  `"tools": { "sentry_*": false }`. Re-enable per agent:
+  `"agent": { "my-agent": { "tools": { "sentry_*": true } } }`.
+- **`permission`** = `allow|ask|deny` over actions (owned by
+  `/opencode-dev:policies`). Different axis.
+
+## 3. LSP servers — `lsp` key is boolean-or-object
+
+Disabled by default. The `lsp` key accepts a **boolean OR an object**:
+
+| Value | Effect |
+|---|---|
+| `true` | Enable all 30+ built-in servers |
+| `false` | Disable all LSP |
+| `{}` | Keep built-ins + add/override custom entries |
+| `{ "<srv>": { "disabled": true } }` | Disable one server, keep the rest |
+
+```json
+{ "$schema": "https://opencode.ai/config.json",
+  "lsp": { "typescript": { "disabled": true },
+           "custom-lsp": { "command": ["custom-lsp-server","--stdio"],
+                           "extensions": [".custom"] } } }
+```
+
+Per-server fields beyond the example: `env` (object — NOT `environment`; see §4)
+and `initialization` (object). Suppress auto-download with
+`OPENCODE_DISABLE_LSP_DOWNLOAD=true`.
+
+## 4. The two cross-cutting traps
+
+**`environment` vs `env` — same concept, two spellings:**
+
+| Layer | Env key |
+|---|---|
+| MCP local server (`mcp.<srv>`) | **`environment`** (full word) |
+| LSP server (`lsp.<srv>`) | **`env`** (short) |
+| Custom tool `tool()` | neither — use `Bun.$` / `process.env` in `execute` |
+
+**`lsp` is overloaded three ways — keep them separate:**
+
+| `lsp` as… | What it is |
+|---|---|
+| top-level **config key** | wires LSP *servers* (boolean-or-object, §3) |
+| built-in **tool** named `lsp` | experimental; needs `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` |
+| **permission** key `lsp` | gates that tool's actions (policies facet) |
+
+## 5. Built-in tools + the `apply_patch` / `edit` trap
+
+Built-in tool names (this is the permission/gating vocabulary): `bash`, `edit`,
+`write`, `read`, `grep`, `glob`, `lsp` (experimental), `apply_patch`, `skill`,
+`todowrite`, `webfetch`, `websearch`, `question`.
+
+- **`edit`, `write`, and `apply_patch` share ONE `edit` permission** — denying
+  `edit` blocks all three. There is no separate `write`/`apply_patch` permission.
+- The patch tool is **`apply_patch`**, NOT `patch`. Its argument is
+  **`output.args.patchText`** (NOT `filePath`) — relevant when a plugin's
+  `tool.execute.before` inspects patch operations. Marker lines
+  (`*** Add File:` / `*** Update File:` / `*** Delete File:`) carry relative
+  paths inside `patchText`.
+- `grep`/`glob` are powered by ripgrep and respect `.gitignore`; add a `.ignore`
+  with `!node_modules/` to allow ignored paths.
+- `todowrite` is disabled for subagents by default; `websearch` needs Exa
+  (`OPENCODE_ENABLE_EXA=1` or the OpenCode provider).
+
+## Assets
+- `assets/custom-tool.ts` — minimal standalone tool template.
+- `assets/mcp.json` — local + remote MCP server config (note `environment`).
+- `assets/lsp.json` — custom + disabled LSP server config (note `env`).

--- a/plugins/opencode-dev/skills/tools/assets/custom-tool.ts
+++ b/plugins/opencode-dev/skills/tools/assets/custom-tool.ts
@@ -1,0 +1,19 @@
+// .opencode/tools/database.ts
+// Filename == tool name → this registers a tool called "database".
+// (A file named after a built-in, e.g. bash.ts, OVERRIDES that built-in.)
+// For multiple tools per file, use named exports → tool name is `<file>_<export>`.
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Query the project database",
+  args: {
+    // tool.schema is a Zod re-export; or `import { z } from "zod"` and use z.
+    query: tool.schema.string().describe("SQL query to execute"),
+  },
+  // context = { agent, sessionID, messageID, directory, worktree }
+  async execute(args, context) {
+    // Shell out to any language via Bun.$ if needed:
+    // const out = await Bun.$`psql -c ${args.query}`.text()
+    return `Executed query against ${context.directory}: ${args.query}`
+  },
+})

--- a/plugins/opencode-dev/skills/tools/assets/lsp.json
+++ b/plugins/opencode-dev/skills/tools/assets/lsp.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "typescript": { "disabled": true },
+    "rust": {
+      "command": ["rust-analyzer"],
+      "env": { "RUST_LOG": "debug" }
+    },
+    "custom-lsp": {
+      "command": ["custom-lsp-server", "--stdio"],
+      "extensions": [".custom"]
+    }
+  }
+}

--- a/plugins/opencode-dev/skills/tools/assets/mcp.json
+++ b/plugins/opencode-dev/skills/tools/assets/mcp.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-srv": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-everything"],
+      "enabled": true,
+      "environment": { "MY_ENV_VAR": "value" }
+    },
+    "remote-srv": {
+      "type": "remote",
+      "url": "https://my-mcp-server.com/mcp",
+      "enabled": true,
+      "headers": { "Authorization": "Bearer {env:MY_API_KEY}" }
+    }
+  },
+  "tools": {
+    "local-srv*": false
+  },
+  "agent": {
+    "my-agent": {
+      "tools": { "local-srv*": true }
+    }
+  }
+}

--- a/plugins/opencode-dev/skills/tools/references/custom-tools.rst
+++ b/plugins/opencode-dev/skills/tools/references/custom-tools.rst
@@ -1,0 +1,154 @@
+<!-- Source: https://opencode.ai/docs/custom-tools/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# Custom Tools - OpenCode Technical Documentation
+
+## Overview
+Custom tools are functions that LLMs can invoke during conversations in OpenCode. They operate alongside built-in tools like `read`, `write`, and `bash`.
+
+## Creating a Tool
+
+### Location
+Tools can be defined in two locations:
+- **Locally**: `.opencode/tools/` directory in your project
+- **Globally**: `~/.config/opencode/tools/`
+
+### Structure
+Tools are defined as TypeScript or JavaScript files using the `tool()` helper:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Query the project database",
+  args: {
+    query: tool.schema.string().describe("SQL query to execute"),
+  },
+  async execute(args) {
+    // Your database logic here
+    return `Executed query: ${args.query}`
+  },
+})
+```
+
+The filename becomes the tool name (e.g., `database.ts` creates a `database` tool).
+
+### Multiple Tools Per File
+Export multiple tools with naming convention `<filename>_<exportname>`:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export const add = tool({
+  description: "Add two numbers",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args) {
+    return (args.a + args.b).toString()
+  },
+})
+
+export const multiply = tool({
+  description: "Multiply two numbers",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args) {
+    return (args.a * args.b).toString()
+  },
+})
+```
+
+This creates `math_add` and `math_multiply` tools.
+
+### Name Collisions
+Custom tools override built-in tools with identical names. Example replacing `bash`:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Restricted bash wrapper",
+  args: {
+    command: tool.schema.string(),
+  },
+  async execute(args) {
+    return `blocked: ${args.command}`
+  },
+})
+```
+
+### Arguments
+Define arguments using `tool.schema` (Zod-based):
+
+```typescript
+args: {
+  query: tool.schema.string().describe("SQL query to execute")
+}
+```
+
+Or import Zod directly:
+
+```typescript
+import { z } from "zod"
+export default {
+  description: "Tool description",
+  args: {
+    param: z.string().describe("Parameter description"),
+  },
+  async execute(args, context) {
+    return "result"
+  },
+}
+```
+
+### Context
+Tools receive session context:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Get project information",
+  args: {},
+  async execute(args, context) {
+    const { agent, sessionID, messageID, directory, worktree } = context
+    return `Agent: ${agent}, Session: ${sessionID}, Message: ${messageID}, Directory: ${directory}, Worktree: ${worktree}`
+  },
+})
+```
+
+Key properties:
+- `context.directory` - session working directory
+- `context.worktree` - git worktree root
+
+## Examples
+
+### Write a Tool in Python
+
+Python script (`.opencode/tools/add.py`):
+```python
+import sys
+a = int(sys.argv[1])
+b = int(sys.argv[2])
+print(a + b)
+```
+
+Tool definition (`.opencode/tools/python-add.ts`):
+```typescript
+import { tool } from "@opencode-ai/plugin"
+import path from "path"
+
+export default tool({
+  description: "Add two numbers using Python",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args, context) {
+    const script = path.join(context.worktree, ".opencode/tools/add.py")
+    const result = await Bun.$`python3 ${script} ${args.a} ${args.b}`.text()
+    return result.trim()
+  },
+})
+```
+
+Uses Bun's `$` shell utility for script execution.

--- a/plugins/opencode-dev/skills/tools/references/lsp.rst
+++ b/plugins/opencode-dev/skills/tools/references/lsp.rst
@@ -1,0 +1,108 @@
+<!-- Source: https://opencode.ai/docs/lsp/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# LSP Servers Configuration Guide
+
+## Overview
+OpenCode integrates with Language Server Protocol servers to provide diagnostics feedback for agents. The feature is disabled by default.
+
+## Built-in LSP Servers
+
+OpenCode includes 30+ pre-configured LSP servers for languages including:
+
+- **JavaScript/TypeScript**: typescript, eslint, deno
+- **Python**: pyright
+- **Rust**: rust-analyzer
+- **Go**: gopls
+- **Java**: jdtls
+- **C/C++**: clangd
+- **PHP**: intelephense
+- **Ruby**: ruby-lsp
+- **And many others** (Astro, Bash, C#, Clojure, Dart, Elixir, F#, Gleam, Haskell, Kotlin, Lua, Nix, OCaml, Prisma, Razor, Svelte, Vue, YAML, Zig)
+
+Each server has specific file extensions and requirements listed in the documentation table.
+(Note: the fetch summarized the per-language extension/requirement table; re-check the
+live page for the full table when wiring a built-in server.)
+
+## Configuration
+
+### Enable All Built-in Servers
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": true
+}
+```
+
+### Custom Configuration
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {}
+}
+```
+
+### Server Entry Properties
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `disabled` | boolean | Disable specific server |
+| `command` | string[] | Command to start server |
+| `extensions` | string[] | File extensions handled |
+| `env` | object | Environment variables |
+| `initialization` | object | LSP initialization options |
+
+### Environment Variables Example
+```json
+{
+  "lsp": {
+    "rust": {
+      "command": ["rust-analyzer"],
+      "env": {
+        "RUST_LOG": "debug"
+      }
+    }
+  }
+}
+```
+
+### Custom LSP Server
+```json
+{
+  "lsp": {
+    "custom-lsp": {
+      "command": ["custom-lsp-server", "--stdio"],
+      "extensions": [".custom"]
+    }
+  }
+}
+```
+
+### Disable Servers
+```json
+{
+  "lsp": false
+}
+```
+
+Or disable specific server:
+```json
+{
+  "lsp": {
+    "typescript": {
+      "disabled": true
+    }
+  }
+}
+```
+
+## PHP Intelephense License
+
+Place license key in text file at:
+- **macOS/Linux**: `$HOME/intelephense/license.txt`
+- **Windows**: `%USERPROFILE%/intelephense/license.txt`
+
+File should contain only the license key.
+
+## Auto-download
+
+Suppress LSP server auto-download with `OPENCODE_DISABLE_LSP_DOWNLOAD=true`.

--- a/plugins/opencode-dev/skills/tools/references/mcp-servers.rst
+++ b/plugins/opencode-dev/skills/tools/references/mcp-servers.rst
@@ -1,0 +1,252 @@
+<!-- Source: https://opencode.ai/docs/mcp-servers/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# MCP Servers Technical Documentation
+
+## Overview
+OpenCode supports integrating external tools via the Model Context Protocol (MCP), offering both local and remote server configurations. "MCP tools are automatically available to the LLM alongside built-in tools" once added.
+
+## Enable Configuration
+
+Basic MCP configuration structure in `opencode.jsonc`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "name-of-mcp-server": {
+      "enabled": true
+    }
+  }
+}
+```
+
+### Remote Defaults Override
+Organizations can provide default MCP servers via `.well-known/opencode` endpoints. Local config values override remote defaults through config precedence.
+
+## Local MCP Servers
+
+Configuration type: `"local"`
+
+```jsonc
+{
+  "mcp": {
+    "my-local-mcp-server": {
+      "type": "local",
+      "command": ["npx", "-y", "my-mcp-command"],
+      "enabled": true,
+      "environment": {
+        "MY_ENV_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+### Local Server Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `type` | String | Y | Must be `"local"` |
+| `command` | Array | Y | Command and arguments to run |
+| `cwd` | String | N | Working directory for process |
+| `environment` | Object | N | Environment variables |
+| `enabled` | Boolean | N | Enable/disable on startup |
+| `timeout` | Number | N | Tool fetch timeout in ms (default: 5000) |
+
+## Remote MCP Servers
+
+Configuration type: `"remote"`
+
+```json
+{
+  "mcp": {
+    "my-remote-mcp": {
+      "type": "remote",
+      "url": "https://my-mcp-server.com",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer MY_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Remote Server Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `type` | String | Y | Must be `"remote"` |
+| `url` | String | Y | Remote server URL |
+| `enabled` | Boolean | N | Enable/disable on startup |
+| `headers` | Object | N | Request headers |
+| `oauth` | Object | N | OAuth configuration |
+| `timeout` | Number | N | Tool fetch timeout in ms (default: 5000) |
+
+## OAuth Authentication
+
+### Automatic OAuth
+No special configuration needed for most OAuth-enabled servers. OpenCode detects 401 responses and initiates Dynamic Client Registration (RFC 7591).
+
+### Pre-registered Credentials
+
+```json
+{
+  "mcp": {
+    "my-oauth-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "clientId": "{env:MY_MCP_CLIENT_ID}",
+        "clientSecret": "{env:MY_MCP_CLIENT_SECRET}",
+        "scope": "tools:read tools:execute"
+      }
+    }
+  }
+}
+```
+
+### OAuth CLI Commands
+
+```bash
+# Authenticate with server
+opencode mcp auth my-oauth-server
+
+# List all servers and auth status
+opencode mcp list
+
+# Remove stored credentials
+opencode mcp logout my-oauth-server
+
+# Debug OAuth flow
+opencode mcp debug my-oauth-server
+```
+
+### Disable OAuth
+
+```json
+{
+  "mcp": {
+    "my-api-key-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:MY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### OAuth Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `oauth` | Object \| false | OAuth config or `false` to disable |
+| `clientId` | String | OAuth client ID |
+| `clientSecret` | String | OAuth client secret |
+| `scope` | String | OAuth scopes to request |
+
+## Tool Management
+
+### Global Disable
+
+```json
+{
+  "mcp": {
+    "my-mcp-foo": { "type": "local", "command": [...] },
+    "my-mcp-bar": { "type": "local", "command": [...] }
+  },
+  "tools": {
+    "my-mcp-foo": false
+  }
+}
+```
+
+### Glob Pattern Disable
+
+```json
+{
+  "tools": {
+    "my-mcp*": false
+  }
+}
+```
+
+### Per-Agent Configuration
+
+```json
+{
+  "mcp": {
+    "my-mcp": {
+      "type": "local",
+      "command": ["bun", "x", "my-mcp-command"],
+      "enabled": true
+    }
+  },
+  "tools": {
+    "my-mcp*": false
+  },
+  "agent": {
+    "my-agent": {
+      "tools": {
+        "my-mcp*": true
+      }
+    }
+  }
+}
+```
+
+### Glob Pattern Syntax
+- `*` matches zero or more characters
+- `?` matches exactly one character
+- All other characters match literally
+
+## Common MCP Server Examples
+
+### Sentry
+```json
+{
+  "mcp": {
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+Authenticate: `opencode mcp auth sentry`
+
+### Context7
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Grep by Vercel
+```json
+{
+  "mcp": {
+    "gh_grep": {
+      "type": "remote",
+      "url": "https://mcp.grep.app"
+    }
+  }
+}
+```
+
+## Important Caveat
+
+"MCP servers add to your context, so you want to be careful with which ones you enable." Certain servers like GitHub MCP can rapidly exceed context limits through token accumulation.

--- a/plugins/opencode-dev/skills/tools/references/tools.rst
+++ b/plugins/opencode-dev/skills/tools/references/tools.rst
@@ -1,0 +1,49 @@
+<!-- Source: https://opencode.ai/docs/tools/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# Tools Documentation - OpenCode
+
+## Overview
+
+"Tools allow the LLM to perform actions in your codebase." OpenCode includes built-in tools and supports extensions through custom tools or MCP servers. By default, all tools are enabled without requiring permission.
+
+## Permission Configuration
+
+Control tool behavior using the `permission` field in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny",
+    "bash": "ask",
+    "webfetch": "allow"
+  }
+}
+```
+
+Wildcards support multiple tools: `"mymcp_*": "ask"`
+
+## Built-in Tools
+
+| Tool | Function |
+|------|----------|
+| **bash** | Execute shell commands in project environment |
+| **edit** | Modify existing files using exact string replacements |
+| **write** | Create new files or overwrite existing ones (controlled by `edit` permission) |
+| **read** | Read file contents from codebase |
+| **grep** | Search file contents using regular expressions |
+| **glob** | Find files by pattern matching |
+| **lsp** | Code intelligence features (experimental; requires `OPENCODE_EXPERIMENTAL_LSP_TOOL=true`) |
+| **apply_patch** | Apply patch files to codebase (controlled by `edit` permission) |
+| **skill** | Load SKILL.md file content into conversation |
+| **todowrite** | Manage todo lists during coding sessions |
+| **webfetch** | Fetch and read web pages |
+| **websearch** | Search web using Exa AI (requires `OPENCODE_ENABLE_EXA=1` or OpenCode provider) |
+| **question** | Ask users questions during execution |
+
+## Key Technical Details
+
+- **apply_patch** uses `output.args.patchText` with relative paths embedded in marker lines
+- **ripgrep** powers `grep` and `glob`, respecting `.gitignore` by default
+- Create `.ignore` file to explicitly allow ignored paths: `!node_modules/`
+- "todowrite is disabled for subagents by default"

--- a/plugins/rdl/.claude-plugin/plugin.json
+++ b/plugins/rdl/.claude-plugin/plugin.json
@@ -27,6 +27,7 @@
     "lychee",
     "charm-tui",
     "claude-code",
+    "opencode-dev",
     "rdl-team",
     "playwright",
     "skill",

--- a/registry/bundles/opencode-dev.yaml
+++ b/registry/bundles/opencode-dev.yaml
@@ -1,0 +1,26 @@
+schemaVersion: v1
+id: opencode-dev
+displayName: OpenCode Dev
+description: OpenCode development toolkit — author plugins, agents, the SDK, custom tools, skills, governance policies, and delegation harnesses
+keywords: [opencode, plugins, sdk, agents, mcp, policies, acp]
+owners:
+  - rdl
+channels:
+  - stable
+skills:
+  - {source: opencode-plugin, leaf: plugin}
+  - {source: opencode-sdk, leaf: sdk}
+  - {source: opencode-agent, leaf: agent}
+  - {source: opencode-tools, leaf: tools}
+  - {source: opencode-skill, leaf: skill}
+  - {source: opencode-policies, leaf: policies}
+  - {source: opencode-delegate, leaf: delegate}
+agents: []
+hooks: [opencode-doc-review]
+prompts: []
+mcp: []
+targets:
+  claude:
+    enabled: true
+    pluginName: opencode-dev
+    marketplaceName: rdl

--- a/registry/marketplace.yaml
+++ b/registry/marketplace.yaml
@@ -45,6 +45,7 @@ order:
   - lychee
   - charm-tui
   - claude-code
+  - opencode-dev
   - rdl-team
   - playwright
   - skill

--- a/skills/opencode-agent/SKILL.md
+++ b/skills/opencode-agent/SKILL.md
@@ -49,7 +49,7 @@ in `opencode.json` — no code required.
 | **Filename = name** | `description:`/`name:` field sets the id | The **markdown filename** is the id: `review.md` → `review` agent; `test.md` → `/test` command |
 | **No CLAUDE.md fallback awareness** | Assuming only `AGENTS.md` is read | OpenCode falls back to `CLAUDE.md` / `~/.claude/CLAUDE.md` when no `AGENTS.md` |
 
-Read `references/*.md` before writing — these are the only non-obvious bits.
+Read `references/*.rst` before writing — these are the only non-obvious bits.
 
 ---
 

--- a/skills/opencode-agent/SKILL.md
+++ b/skills/opencode-agent/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: opencode-agent
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode (SST's open-source coding agent, opencode.ai — NOT OpenAI
+  Codex) agents, custom commands, and project rules as markdown/JSON config. Use
+  when creating or editing files under `.opencode/agents/`, `.opencode/commands/`,
+  or `AGENTS.md`; setting an agent's `mode` (primary/subagent/all), `model`,
+  `permission`, `steps`, or `temperature`; templating commands with `$ARGUMENTS`,
+  `$1`, shell injection `` !`cmd` ``, or `@file` references; wiring the
+  `instructions` config key; or debugging why a `tools:` field, `maxSteps`, a
+  `/docs/modes/` link, or a `CLAUDE.md` fallback isn't behaving. Triggers: "opencode
+  subagent", "opencode custom command", "AGENTS.md", "opencode agent frontmatter".
+argument-hint: "What agent/command/rule do you want to build? (e.g. 'a read-only review subagent', 'a /test command with args', 'why is my CLAUDE.md ignored')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode agents, commands & rules
+
+OpenCode's config-as-markdown surface: **agents** (specialized assistants),
+**custom commands** (reusable prompt templates), and **rules** (`AGENTS.md`
+project instructions). All three are plain markdown-with-frontmatter or JSON keys
+in `opencode.json` — no code required.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing agent/command/rule config, read
+> `references/agents.rst`, `references/commands.rst`, or `references/rules.rst` AND
+> re-check <https://opencode.ai/docs/agents/> (and `/docs/commands/`, `/docs/rules/`)
+> for drift. The traps below are the deltas a fresh model gets wrong.
+>
+> Three claims here have **no dated vendored reference** and are author-knowledge —
+> re-check the live page before relying on them: the `/docs/modes/` 404 and "singular
+> dirs accepted for back-compat" (no `references/` source), and the config merge-order
+> chain under "Config & precedence" (a `/docs/config/` claim — no `references/config.rst`).
+
+---
+
+## The traps (what a fresh model gets wrong)
+
+| Trap | Wrong (don't) | Right (do) |
+|------|---------------|------------|
+| **Modes are gone** | Looking up `/docs/modes/` — it **404s** | `mode` is now an **agent field**: `primary` \| `subagent` \| `all` (default `all`) |
+| **`tools:` deprecated** | `tools: { write: false }` per agent | Use `permission:` (`allow`/`ask`/`deny`); `tools` still parses but is legacy |
+| **`maxSteps`** | `maxSteps: 5` | `steps: 5` — `maxSteps` is **deprecated** |
+| **Dir is plural** | `.opencode/agent/`, `.opencode/command/` | `.opencode/agents/`, `.opencode/commands/` (singular accepted for back-compat only) |
+| **Filename = name** | `description:`/`name:` field sets the id | The **markdown filename** is the id: `review.md` → `review` agent; `test.md` → `/test` command |
+| **No CLAUDE.md fallback awareness** | Assuming only `AGENTS.md` is read | OpenCode falls back to `CLAUDE.md` / `~/.claude/CLAUDE.md` when no `AGENTS.md` |
+
+Read `references/*.md` before writing — these are the only non-obvious bits.
+
+---
+
+## Agents
+
+Two types. **Primary** = main assistant you drive (Tab / `switch_agent` keybind to
+cycle); **subagent** = invoked by a primary or by `@mention`. Built-in primaries:
+`build` (all tools), `plan` (`edit`+`bash` default to `ask`). Built-in subagents:
+`general`, `explore`, `scout`. Declare in `opencode.json` under the `agent` key, or
+as one markdown file per agent in **plural** `.opencode/agents/` (project) or
+`~/.config/opencode/agents/` (global). **The filename is the agent name.**
+
+Frontmatter fields (see `references/agents.rst` for the full table):
+
+| Field | Notes |
+|-------|-------|
+| `description` | **Required.** What it does / when to use it (drives auto-invocation) |
+| `mode` | `primary` \| `subagent` \| `all` — defaults to `all` |
+| `permission` | **Preferred** access control — per-tool `allow`/`ask`/`deny`, or `{pattern: level}` |
+| `steps` | Max agentic iterations (**not** `maxSteps`) |
+| `prompt` | System prompt — inline string or `{file:./prompts/x.txt}` (relative to config) |
+| `disable` / `hidden` / `color` | Off / hide from `@`-menu (subagents only) / UI color |
+| `tools` | **Deprecated** — migrate to `permission` |
+
+`permission` keys gate tools (not 1:1 with tool names): `edit` covers
+**`write` + `edit` + `apply_patch`**; `todowrite` covers `todowrite` + `todoread`.
+Two disjoint sets (not a positional prefix — verify in `references/agents.rst`):
+**glob-capable** keys accept a shorthand action **or** a `{glob: action}` map —
+`read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `external_directory`, `lsp`,
+`skill`; **shorthand-only** keys take the action only — `todowrite`, `webfetch`,
+`websearch`, `question`, `doom_loop`. **Last matching rule wins** —
+put `"*"` first, exceptions after. `permission.task` (a glob map) controls which
+subagents this agent may invoke via the Task tool. Per-agent `permission` overrides
+top-level. Scaffold interactively with `opencode agent create`. See
+`assets/agent.md`.
+
+## Custom commands
+
+Markdown files in **plural** `.opencode/commands/` (or `~/.config/opencode/commands/`)
+— **filename = command name** (`test.md` → `/test`). The body is the **prompt
+template**; frontmatter configures it. JSON form lives under the `command` key and
+**requires `template`** (the body equivalent).
+
+Frontmatter / JSON fields: `description`, `agent` (which agent runs it — if that's a
+subagent, it triggers a subagent invocation **by default**), `subtask` (`true` forces
+subagent even for a `primary` agent; `false` disables the auto-subtask), `model`.
+
+Template syntax (in the body / `template`):
+
+- `$ARGUMENTS` — all args; `$1`, `$2`, `$3`, … — positional args.
+- `` !`command` `` — runs in the **project root**, splices stdout into the prompt.
+- `@path/to/file` — includes file content in the prompt.
+
+Built-ins `/init`, `/undo`, `/redo`, `/share`, `/help` are **overridable** by a
+same-named custom command. See `assets/command.md`.
+
+## Rules (AGENTS.md)
+
+Project instructions go in `AGENTS.md` at the repo root (commit it; `/init`
+generates/updates it). Global rules: `~/.config/opencode/AGENTS.md`.
+
+**Claude Code compatibility (the key delta):** when no `AGENTS.md` exists, OpenCode
+falls back to `CLAUDE.md` (project) and `~/.claude/CLAUDE.md` (global). Precedence on
+startup: (1) local files walking **up** from cwd (`AGENTS.md`, then `CLAUDE.md`),
+(2) global `~/.config/opencode/AGENTS.md`, (3) `~/.claude/CLAUDE.md`. **First match
+wins per category** — if both `AGENTS.md` and `CLAUDE.md` exist, only `AGENTS.md` is
+used. Disable the fallback with env vars:
+
+```bash
+export OPENCODE_DISABLE_CLAUDE_CODE=1        # all .claude support
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1 # only ~/.claude/CLAUDE.md
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # only .claude/skills
+```
+
+Add extra instruction files via the `instructions` config key (globs + remote URLs;
+URLs fetched with a 5s timeout) — these **combine** with `AGENTS.md`:
+
+```json
+{ "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", "packages/*/AGENTS.md"] }
+```
+
+> `AGENTS.md` does **not** auto-parse `@file` references — use `instructions` for
+> file inclusion, or write explicit "Read @x on demand" prose in the body.
+
+---
+
+## Config & precedence (shared)
+
+Config files **merge** (later overrides earlier): remote `.well-known/opencode` →
+global `~/.config/opencode/opencode.json` → `OPENCODE_CONFIG` → project
+`opencode.json` → `.opencode/` dirs → `OPENCODE_CONFIG_CONTENT` → managed files.
+Substitution: `{env:VAR}`, `{file:path}`. Full model: `/docs/config/`.
+
+## References
+
+| File | Source |
+|------|--------|
+| [references/agents.rst](references/agents.rst) | `/docs/agents/` — frontmatter, permission table, built-ins, `opencode agent create` |
+| [references/commands.rst](references/commands.rst) | `/docs/commands/` — templating, `$ARGUMENTS`/`!cmd`/`@file`, JSON `template` |
+| [references/rules.rst](references/rules.rst) | `/docs/rules/` — `AGENTS.md`, `CLAUDE.md` fallback, `instructions` key |
+
+## Assets
+
+| File | What it is |
+|------|------------|
+| [assets/agent.md](assets/agent.md) | A read-only review subagent (markdown, `permission`-based) |
+| [assets/command.md](assets/command.md) | A `/test` command using `$ARGUMENTS`, `` !`cmd` ``, and `@file` |

--- a/skills/opencode-agent/assets/agent.md
+++ b/skills/opencode-agent/assets/agent.md
@@ -1,0 +1,24 @@
+---
+# Save as .opencode/agents/review.md (project) or ~/.config/opencode/agents/review.md
+# The FILENAME is the agent name → this is the `review` subagent (@review).
+description: Reviews code for quality and best practices  # REQUIRED
+mode: subagent          # primary | subagent | all  (default: all)
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.1
+steps: 20               # max agentic iterations — NOT `maxSteps` (deprecated)
+permission:             # PREFERRED over the deprecated `tools:` field
+  edit: deny            # `edit` gates write + edit + apply_patch
+  bash:
+    "*": ask            # last matching rule wins → put "*" first
+    "git diff": allow
+    "git log*": allow
+  webfetch: deny
+---
+
+You are in code review mode. Focus on:
+
+- Code quality and best practices
+- Potential bugs and edge cases
+- Performance and security implications
+
+Provide constructive feedback without making direct changes.

--- a/skills/opencode-agent/assets/command.md
+++ b/skills/opencode-agent/assets/command.md
@@ -1,0 +1,19 @@
+---
+# Save as .opencode/commands/test.md (project) or ~/.config/opencode/commands/test.md
+# The FILENAME is the command name → run this as `/test`.
+# The body below is the prompt TEMPLATE (JSON form puts it under `command.test.template`).
+description: Run tests with coverage and triage failures
+agent: build         # which agent runs it; if a subagent, runs as a subtask by default
+# subtask: true      # force a subagent invocation even for a `primary` agent
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the test suite (focus area: $ARGUMENTS — first arg $1).
+
+Current results (shell output spliced in; runs in the project root):
+!`npm test`
+
+Project test config for reference:
+@vitest.config.ts
+
+Based on these results, list each failing test and suggest a concrete fix.

--- a/skills/opencode-agent/references/agents.rst
+++ b/skills/opencode-agent/references/agents.rst
@@ -1,0 +1,783 @@
+<!-- Source: https://opencode.ai/docs/agents/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Agents
+description: Configure and use specialized agents.
+---
+
+Agents are specialized AI assistants that can be configured for specific tasks and workflows. They allow you to create focused tools with custom prompts, models, and tool access.
+
+:::tip
+Use the plan agent to analyze code and review suggestions without making any code changes.
+:::
+
+You can switch between agents during a session or invoke them with the `@` mention.
+
+---
+
+## Types
+
+There are two types of agents in OpenCode; primary agents and subagents.
+
+---
+
+### Primary agents
+
+Primary agents are the main assistants you interact with directly. You can cycle through them using the **Tab** key, or your configured `switch_agent` keybind. These agents handle your main conversation. Tool access is configured via permissions — for example, Build has all tools enabled while Plan is restricted.
+
+:::tip
+You can use the **Tab** key to switch between primary agents during a session.
+:::
+
+OpenCode comes with two built-in primary agents, **Build** and **Plan**. We'll
+look at these below.
+
+---
+
+### Subagents
+
+Subagents are specialized assistants that primary agents can invoke for specific tasks. You can also manually invoke them by **@ mentioning** them in your messages.
+
+OpenCode comes with three built-in subagents, **General**, **Explore**, and **Scout**. We'll look at this below.
+
+---
+
+## Built-in
+
+OpenCode comes with two built-in primary agents and three built-in subagents.
+
+---
+
+### Use build
+
+_Mode_: `primary`
+
+Build is the **default** primary agent with all tools enabled. This is the standard agent for development work where you need full access to file operations and system commands.
+
+---
+
+### Use plan
+
+_Mode_: `primary`
+
+A restricted agent designed for planning and analysis. We use a permission system to give you more control and prevent unintended changes.
+By default, all of the following are set to `ask`:
+
+- `file edits`: All writes, patches, and edits
+- `bash`: All bash commands
+
+This agent is useful when you want the LLM to analyze code, suggest changes, or create plans without making any actual modifications to your codebase.
+
+---
+
+### Use general
+
+_Mode_: `subagent`
+
+A general-purpose agent for researching complex questions and executing multi-step tasks. Has full tool access (except todo), so it can make file changes when needed. Use this to run multiple units of work in parallel.
+
+---
+
+### Use explore
+
+_Mode_: `subagent`
+
+A fast, read-only agent for exploring codebases. Cannot modify files. Use this when you need to quickly find files by patterns, search code for keywords, or answer questions about the codebase.
+
+---
+
+### Use scout
+
+_Mode_: `subagent`
+
+A read-only agent for external docs and dependency research. Use this when you need to clone a dependency repository into OpenCode's managed cache, inspect library source, or cross-reference local code against upstream implementations without modifying your workspace.
+
+---
+
+### Use compaction
+
+_Mode_: `primary`
+
+Hidden system agent that compacts long context into a smaller summary. It runs automatically when needed and is not selectable in the UI.
+
+---
+
+### Use title
+
+_Mode_: `primary`
+
+Hidden system agent that generates short session titles. It runs automatically and is not selectable in the UI.
+
+---
+
+### Use summary
+
+_Mode_: `primary`
+
+Hidden system agent that creates session summaries. It runs automatically and is not selectable in the UI.
+
+---
+
+## Usage
+
+1. For primary agents, use the **Tab** key to cycle through them during a session. You can also use your configured `switch_agent` keybind.
+
+2. Subagents can be invoked:
+   - **Automatically** by primary agents for specialized tasks based on their descriptions.
+   - Manually by **@ mentioning** a subagent in your message. For example.
+
+     ```txt frame="none"
+     @general help me search for this function
+     ```
+
+3. **Navigation between sessions**: When subagents create child sessions, use `session_child_first` (default: **\<Leader>+Down**) to enter the first child session from the parent.
+
+4. Once you are in a child session, use:
+   - `session_child_cycle` (default: **Right**) to cycle to the next child session
+   - `session_child_cycle_reverse` (default: **Left**) to cycle to the previous child session
+   - `session_parent` (default: **Up**) to return to the parent session
+
+   This lets you switch between the main conversation and specialized subagent work.
+
+---
+
+## Configure
+
+You can customize the built-in agents or create your own through configuration. Agents can be configured in two ways:
+
+---
+
+### JSON
+
+Configure agents in your `opencode.json` config file:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "mode": "primary",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "{file:./prompts/build.txt}",
+      "permission": {
+        "edit": "allow",
+        "bash": "allow"
+      }
+    },
+    "plan": {
+      "mode": "primary",
+      "model": "anthropic/claude-haiku-4-20250514",
+      "permission": {
+        "edit": "deny",
+        "bash": "deny"
+      }
+    },
+    "code-reviewer": {
+      "description": "Reviews code for best practices and potential issues",
+      "mode": "subagent",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "permission": {
+        "edit": "deny"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Markdown
+
+You can also define agents using markdown files. Place them in:
+
+- Global: `~/.config/opencode/agents/`
+- Per-project: `.opencode/agents/`
+
+```markdown title="~/.config/opencode/agents/review.md"
+---
+description: Reviews code for quality and best practices
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.1
+permission:
+  edit: deny
+  bash: deny
+---
+
+You are in code review mode. Focus on:
+
+- Code quality and best practices
+- Potential bugs and edge cases
+- Performance implications
+- Security considerations
+
+Provide constructive feedback without making direct changes.
+```
+
+The markdown file name becomes the agent name. For example, `review.md` creates a `review` agent.
+
+---
+
+## Options
+
+Let's look at these configuration options in detail.
+
+---
+
+### Description
+
+Use the `description` option to provide a brief description of what the agent does and when to use it.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "description": "Reviews code for best practices and potential issues"
+    }
+  }
+}
+```
+
+This is a **required** config option.
+
+---
+
+### Temperature
+
+Control the randomness and creativity of the LLM's responses with the `temperature` config.
+
+Lower values make responses more focused and deterministic, while higher values increase creativity and variability.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "plan": {
+      "temperature": 0.1
+    },
+    "creative": {
+      "temperature": 0.8
+    }
+  }
+}
+```
+
+Temperature values typically range from 0.0 to 1.0:
+
+- **0.0-0.2**: Very focused and deterministic responses, ideal for code analysis and planning
+- **0.3-0.5**: Balanced responses with some creativity, good for general development tasks
+- **0.6-1.0**: More creative and varied responses, useful for brainstorming and exploration
+
+```json title="opencode.json"
+{
+  "agent": {
+    "analyze": {
+      "temperature": 0.1,
+      "prompt": "{file:./prompts/analysis.txt}"
+    },
+    "build": {
+      "temperature": 0.3
+    },
+    "brainstorm": {
+      "temperature": 0.7,
+      "prompt": "{file:./prompts/creative.txt}"
+    }
+  }
+}
+```
+
+If no temperature is specified, OpenCode uses model-specific defaults; typically 0 for most models, 0.55 for Qwen models.
+
+---
+
+### Max steps
+
+Control the maximum number of agentic iterations an agent can perform before being forced to respond with text only. This allows users who wish to control costs to set a limit on agentic actions.
+
+If this is not set, the agent will continue to iterate until the model chooses to stop or the user interrupts the session.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "quick-thinker": {
+      "description": "Fast reasoning with limited iterations",
+      "prompt": "You are a quick thinker. Solve problems with minimal steps.",
+      "steps": 5
+    }
+  }
+}
+```
+
+When the limit is reached, the agent receives a special system prompt instructing it to respond with a summarization of its work and recommended remaining tasks.
+
+:::caution
+The legacy `maxSteps` field is deprecated. Use `steps` instead.
+:::
+
+---
+
+### Disable
+
+Set to `true` to disable the agent.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "disable": true
+    }
+  }
+}
+```
+
+---
+
+### Prompt
+
+Specify a custom system prompt file for this agent with the `prompt` config. The prompt file should contain instructions specific to the agent's purpose.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "prompt": "{file:./prompts/code-review.txt}"
+    }
+  }
+}
+```
+
+This path is relative to where the config file is located. So this works for both the global OpenCode config and the project specific config.
+
+---
+
+### Model
+
+Use the `model` config to override the model for this agent. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
+
+:::tip
+If you don’t specify a model, primary agents use the [model globally configured](/docs/config#models) while subagents will use the model of the primary agent that invoked the subagent.
+:::
+
+```json title="opencode.json"
+{
+  "agent": {
+    "plan": {
+      "model": "anthropic/claude-haiku-4-20250514"
+    }
+  }
+}
+```
+
+The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
+
+---
+
+### Tools (deprecated)
+
+`tools` is **deprecated**. Prefer the agent's [`permission`](#permissions) field for new configs, updates and more fine-grained control.
+
+Allows you to control which tools are available in this agent. You can enable or disable specific tools by setting them to `true` or `false`. In an agent's `tools` config, `true` is equivalent to `{"*": "allow"}` permission and `false` is equivalent to `{"*": "deny"}` permission.
+
+```json title="opencode.json" {3-6,9-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tools": {
+    "write": true,
+    "bash": true
+  },
+  "agent": {
+    "plan": {
+      "tools": {
+        "write": false,
+        "bash": false
+      }
+    }
+  }
+}
+```
+
+:::note
+The agent-specific config overrides the global config.
+:::
+
+You can also use wildcards in legacy `tools` entries to control multiple tools at once. For example, to disable all tools from an MCP server:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "readonly": {
+      "tools": {
+        "mymcp_*": false,
+        "write": false,
+        "edit": false
+      }
+    }
+  }
+}
+```
+
+[Learn more about tools](/docs/tools).
+
+---
+
+### Permissions
+
+You can configure permissions to manage what actions an agent can take. Each permission key can be set to:
+
+- `"ask"` — Prompt for approval before running the tool
+- `"allow"` — Allow all operations without approval
+- `"deny"` — Disable the tool
+
+The available permission keys are:
+
+| Key                  | Tools it gates                                                   |
+| -------------------- | ---------------------------------------------------------------- |
+| `read`               | `read`                                                           |
+| `edit`               | `write`, `edit`, `apply_patch`                                   |
+| `glob`               | `glob`                                                           |
+| `grep`               | `grep`                                                           |
+| `list`               | `list`                                                           |
+| `bash`               | `bash`                                                           |
+| `task`               | `task`                                                           |
+| `external_directory` | Any tool that reads or writes files outside the project worktree |
+| `todowrite`          | `todowrite`, `todoread`                                          |
+| `webfetch`           | `webfetch`                                                       |
+| `websearch`          | `websearch`                                                      |
+| `lsp`                | `lsp`                                                            |
+| `skill`              | `skill`                                                          |
+| `question`           | `question`                                                       |
+| `doom_loop`          | Recovery prompts when an agent appears stuck                     |
+
+`read`, `edit`, `glob`, `grep`, `list`, `bash`, `task`, `external_directory`, `lsp`, and `skill` accept either a shorthand action (`"allow" | "ask" | "deny"`) or an object of glob/pattern → action for fine-grained control. The remaining keys accept the shorthand action only.
+
+:::note
+Permission keys are matched as wildcard patterns against the underlying tool name, so the same syntax works for built-ins, custom tools, and MCP tools — for example `"mymcp_*": "deny"` denies every tool from an MCP server, and `"mymcp_search": "ask"` targets a single one.
+:::
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny"
+  }
+}
+```
+
+You can override these permissions per agent.
+
+```json title="opencode.json" {3-5,8-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny"
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "edit": "ask"
+      }
+    }
+  }
+}
+```
+
+You can also set permissions in Markdown agents.
+
+```markdown title="~/.config/opencode/agents/review.md"
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash:
+    "*": ask
+    "git diff": allow
+    "git log*": allow
+    "grep *": allow
+  webfetch: deny
+---
+
+Only analyze code and suggest changes.
+```
+
+You can set permissions for specific bash commands.
+
+```json title="opencode.json" {7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git push": "ask",
+          "grep *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+This can take a glob pattern.
+
+```json title="opencode.json" {7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "git *": "ask"
+        }
+      }
+    }
+  }
+}
+```
+
+And you can also use the `*` wildcard to manage permissions for all commands.
+Since the last matching rule takes precedence, put the `*` wildcard first and specific rules after.
+
+```json title="opencode.json" {8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git status *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+[Learn more about permissions](/docs/permissions).
+
+---
+
+### Mode
+
+Control the agent's mode with the `mode` config. The `mode` option is used to determine how the agent can be used.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "review": {
+      "mode": "subagent"
+    }
+  }
+}
+```
+
+The `mode` option can be set to `primary`, `subagent`, or `all`. If no `mode` is specified, it defaults to `all`.
+
+---
+
+### Hidden
+
+Hide a subagent from the `@` autocomplete menu with `hidden: true`. Useful for internal subagents that should only be invoked programmatically by other agents via the Task tool.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "internal-helper": {
+      "mode": "subagent",
+      "hidden": true
+    }
+  }
+}
+```
+
+This only affects user visibility in the autocomplete menu. Hidden agents can still be invoked by the model via the Task tool if permissions allow.
+
+:::note
+Only applies to `mode: subagent` agents.
+:::
+
+---
+
+### Task permissions
+
+Control which subagents an agent can invoke via the Task tool with `permission.task`. Uses glob patterns for flexible matching.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "orchestrator": {
+      "mode": "primary",
+      "permission": {
+        "task": {
+          "*": "deny",
+          "orchestrator-*": "allow",
+          "code-reviewer": "ask"
+        }
+      }
+    }
+  }
+}
+```
+
+When set to `deny`, the subagent is removed from the Task tool description entirely, so the model won't attempt to invoke it.
+
+:::tip
+Rules are evaluated in order, and the **last matching rule wins**. In the example above, `orchestrator-planner` matches both `*` (deny) and `orchestrator-*` (allow), but since `orchestrator-*` comes after `*`, the result is `allow`.
+:::
+
+:::tip
+Users can always invoke any subagent directly via the `@` autocomplete menu, even if the agent's task permissions would deny it.
+:::
+
+---
+
+### Color
+
+Customize the agent's visual appearance in the UI with the `color` option. This affects how the agent appears in the interface.
+
+Use a valid hex color (e.g., `#FF5733`) or theme color: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "creative": {
+      "color": "#ff6b6b"
+    },
+    "code-reviewer": {
+      "color": "accent"
+    }
+  }
+}
+```
+
+---
+
+### Top P
+
+Control response diversity with the `top_p` option. Alternative to temperature for controlling randomness.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "brainstorm": {
+      "top_p": 0.9
+    }
+  }
+}
+```
+
+Values range from 0.0 to 1.0. Lower values are more focused, higher values more diverse.
+
+---
+
+### Additional
+
+Any other options you specify in your agent configuration will be **passed through directly** to the provider as model options. This allows you to use provider-specific features and parameters.
+
+For example, with OpenAI's reasoning models, you can control the reasoning effort:
+
+```json title="opencode.json" {6,7}
+{
+  "agent": {
+    "deep-thinker": {
+      "description": "Agent that uses high reasoning effort for complex problems",
+      "model": "openai/gpt-5",
+      "reasoningEffort": "high",
+      "textVerbosity": "low"
+    }
+  }
+}
+```
+
+These additional options are model and provider-specific. Check your provider's documentation for available parameters.
+
+:::tip
+Run `opencode models` to see a list of the available models.
+:::
+
+---
+
+## Create agents
+
+You can create new agents using the following command:
+
+```bash
+opencode agent create
+```
+
+This interactive command will:
+
+1. Ask where to save the agent; global or project-specific.
+2. Description of what the agent should do.
+3. Generate an appropriate system prompt and identifier.
+4. Let you select which permissions the agent should be allowed (anything you don't select is denied).
+5. Finally, create a markdown file with the agent configuration.
+
+---
+
+## Use cases
+
+Here are some common use cases for different agents.
+
+- **Build agent**: Full development work with all tools enabled
+- **Plan agent**: Analysis and planning without making changes
+- **Review agent**: Code review with read-only access plus documentation tools
+- **Debug agent**: Focused on investigation with bash and read tools enabled
+- **Docs agent**: Documentation writing with file operations but no system commands
+
+---
+
+## Examples
+
+Here are some example agents you might find useful.
+
+:::tip
+Do you have an agent you'd like to share? [Submit a PR](https://github.com/anomalyco/opencode).
+:::
+
+---
+
+### Documentation agent
+
+```markdown title="~/.config/opencode/agents/docs-writer.md"
+---
+description: Writes and maintains project documentation
+mode: subagent
+permission:
+  bash: deny
+---
+
+You are a technical writer. Create clear, comprehensive documentation.
+
+Focus on:
+
+- Clear explanations
+- Proper structure
+- Code examples
+- User-friendly language
+```
+
+---
+
+### Security auditor
+
+```markdown title="~/.config/opencode/agents/security-auditor.md"
+---
+description: Performs security audits and identifies vulnerabilities
+mode: subagent
+permission:
+  edit: deny
+---
+
+You are a security expert. Focus on identifying potential security issues.
+
+Look for:
+
+- Input validation vulnerabilities
+- Authentication and authorization flaws
+- Data exposure risks
+- Dependency vulnerabilities
+- Configuration security issues
+```

--- a/skills/opencode-agent/references/commands.rst
+++ b/skills/opencode-agent/references/commands.rst
@@ -1,0 +1,325 @@
+<!-- Source: https://opencode.ai/docs/commands/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Commands
+description: Create custom commands for repetitive tasks.
+---
+
+Custom commands let you specify a prompt you want to run when that command is executed in the TUI.
+
+```bash frame="none"
+/my-command
+```
+
+Custom commands are in addition to the built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`. [Learn more](/docs/tui#commands).
+
+---
+
+## Create command files
+
+Create markdown files in the `commands/` directory to define custom commands.
+
+Create `.opencode/commands/test.md`:
+
+```md title=".opencode/commands/test.md"
+---
+description: Run tests with coverage
+agent: build
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the full test suite with coverage report and show any failures.
+Focus on the failing tests and suggest fixes.
+```
+
+The frontmatter defines command properties. The content becomes the template.
+
+Use the command by typing `/` followed by the command name.
+
+```bash frame="none"
+"/test"
+```
+
+---
+
+## Configure
+
+You can add custom commands through the OpenCode config or by creating markdown files in the `commands/` directory.
+
+---
+
+### JSON
+
+Use the `command` option in your OpenCode [config](/docs/config):
+
+```json title="opencode.jsonc" {4-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "command": {
+    // This becomes the name of the command
+    "test": {
+      // This is the prompt that will be sent to the LLM
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
+      // This is shown as the description in the TUI
+      "description": "Run tests with coverage",
+      "agent": "build",
+      "model": "anthropic/claude-3-5-sonnet-20241022"
+    }
+  }
+}
+```
+
+Now you can run this command in the TUI:
+
+```bash frame="none"
+/test
+```
+
+---
+
+### Markdown
+
+You can also define commands using markdown files. Place them in:
+
+- Global: `~/.config/opencode/commands/`
+- Per-project: `.opencode/commands/`
+
+```markdown title="~/.config/opencode/commands/test.md"
+---
+description: Run tests with coverage
+agent: build
+model: anthropic/claude-3-5-sonnet-20241022
+---
+
+Run the full test suite with coverage report and show any failures.
+Focus on the failing tests and suggest fixes.
+```
+
+The markdown file name becomes the command name. For example, `test.md` lets
+you run:
+
+```bash frame="none"
+/test
+```
+
+---
+
+## Prompt config
+
+The prompts for the custom commands support several special placeholders and syntax.
+
+---
+
+### Arguments
+
+Pass arguments to commands using the `$ARGUMENTS` placeholder.
+
+```md title=".opencode/commands/component.md"
+---
+description: Create a new component
+---
+
+Create a new React component named $ARGUMENTS with TypeScript support.
+Include proper typing and basic structure.
+```
+
+Run the command with arguments:
+
+```bash frame="none"
+/component Button
+```
+
+And `$ARGUMENTS` will be replaced with `Button`.
+
+You can also access individual arguments using positional parameters:
+
+- `$1` - First argument
+- `$2` - Second argument
+- `$3` - Third argument
+- And so on...
+
+For example:
+
+```md title=".opencode/commands/create-file.md"
+---
+description: Create a new file with content
+---
+
+Create a file named $1 in the directory $2
+with the following content: $3
+```
+
+Run the command:
+
+```bash frame="none"
+/create-file config.json src "{ \"key\": \"value\" }"
+```
+
+This replaces:
+
+- `$1` with `config.json`
+- `$2` with `src`
+- `$3` with `{ "key": "value" }`
+
+---
+
+### Shell output
+
+Use _!`command`_ to inject [bash command](/docs/tui#bash-commands) output into your prompt.
+
+For example, to create a custom command that analyzes test coverage:
+
+```md title=".opencode/commands/analyze-coverage.md"
+---
+description: Analyze test coverage
+---
+
+Here are the current test results:
+!`npm test`
+
+Based on these results, suggest improvements to increase coverage.
+```
+
+Or to review recent changes:
+
+```md title=".opencode/commands/review-changes.md"
+---
+description: Review recent changes
+---
+
+Recent git commits:
+!`git log --oneline -10`
+
+Review these changes and suggest any improvements.
+```
+
+Commands run in your project's root directory and their output becomes part of the prompt.
+
+---
+
+### File references
+
+Include files in your command using `@` followed by the filename.
+
+```md title=".opencode/commands/review-component.md"
+---
+description: Review component
+---
+
+Review the component in @src/components/Button.tsx.
+Check for performance issues and suggest improvements.
+```
+
+The file content gets included in the prompt automatically.
+
+---
+
+## Options
+
+Let's look at the configuration options in detail.
+
+---
+
+### Template
+
+The `template` option defines the prompt that will be sent to the LLM when the command is executed.
+
+```json title="opencode.json"
+{
+  "command": {
+    "test": {
+      "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes."
+    }
+  }
+}
+```
+
+This is a **required** config option.
+
+---
+
+### Description
+
+Use the `description` option to provide a brief description of what the command does.
+
+```json title="opencode.json"
+{
+  "command": {
+    "test": {
+      "description": "Run tests with coverage"
+    }
+  }
+}
+```
+
+This is shown as the description in the TUI when you type in the command.
+
+---
+
+### Agent
+
+Use the `agent` config to optionally specify which [agent](/docs/agents) should execute this command.
+If this is a [subagent](/docs/agents/#subagents) the command will trigger a subagent invocation by default.
+To disable this behavior, set `subtask` to `false`.
+
+```json title="opencode.json"
+{
+  "command": {
+    "review": {
+      "agent": "plan"
+    }
+  }
+}
+```
+
+This is an **optional** config option. If not specified, defaults to your current agent.
+
+---
+
+### Subtask
+
+Use the `subtask` boolean to force the command to trigger a [subagent](/docs/agents/#subagents) invocation.
+This is useful if you want the command to not pollute your primary context and will **force** the agent to act as a subagent,
+even if `mode` is set to `primary` on the [agent](/docs/agents) configuration.
+
+```json title="opencode.json"
+{
+  "command": {
+    "analyze": {
+      "subtask": true
+    }
+  }
+}
+```
+
+This is an **optional** config option.
+
+---
+
+### Model
+
+Use the `model` config to override the default model for this command.
+
+```json title="opencode.json"
+{
+  "command": {
+    "analyze": {
+      "model": "anthropic/claude-3-5-sonnet-20241022"
+    }
+  }
+}
+```
+
+This is an **optional** config option.
+
+---
+
+## Built-in
+
+opencode includes several built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`; [learn more](/docs/tui#commands).
+
+:::note
+Custom commands can override built-in commands.
+:::
+
+If you define a custom command with the same name, it will override the built-in command.

--- a/skills/opencode-agent/references/rules.rst
+++ b/skills/opencode-agent/references/rules.rst
@@ -1,0 +1,190 @@
+<!-- Source: https://opencode.ai/docs/rules/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode agent code. -->
+
+---
+title: Rules
+description: Set custom instructions for opencode.
+---
+
+You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
+
+---
+
+## Initialize
+
+To create a new `AGENTS.md` file, you can run the `/init` command in opencode.
+
+:::tip
+You should commit your project's `AGENTS.md` file to Git.
+:::
+
+`/init` scans the important files in your repo, may ask a couple of targeted questions when the codebase cannot answer them, and then creates or updates `AGENTS.md` with concise project-specific guidance.
+
+It focuses on the things future agent sessions are most likely to need:
+
+- build, lint, and test commands
+- command order and focused verification steps when they matter
+- architecture and repo structure that are not obvious from filenames alone
+- project-specific conventions, setup quirks, and operational gotchas
+- references to existing instruction sources like Cursor or Copilot rules
+
+If you already have an `AGENTS.md`, `/init` will improve it in place instead of blindly replacing it.
+
+---
+
+## Example
+
+You can also just create this file manually. Here's an example of some things you can put into an `AGENTS.md` file.
+
+```markdown title="AGENTS.md"
+# SST v3 Monorepo Project
+
+This is an SST v3 monorepo with TypeScript. The project uses bun workspaces for package management.
+
+## Project Structure
+
+- `packages/` - Contains all workspace packages (functions, core, web, etc.)
+- `infra/` - Infrastructure definitions split by service (storage.ts, api.ts, web.ts)
+- `sst.config.ts` - Main SST configuration with dynamic imports
+
+## Code Standards
+
+- Use TypeScript with strict mode enabled
+- Shared code goes in `packages/core/` with proper exports configuration
+- Functions go in `packages/functions/`
+- Infrastructure should be split into logical files in `infra/`
+
+## Monorepo Conventions
+
+- Import shared modules using workspace names: `@my-app/core/example`
+```
+
+We are adding project-specific instructions here and this will be shared across your team.
+
+---
+
+## Types
+
+opencode also supports reading the `AGENTS.md` file from multiple locations. And this serves different purposes.
+
+### Project
+
+Place an `AGENTS.md` in your project root for project-specific rules. These only apply when you are working in this directory or its sub-directories.
+
+### Global
+
+You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This gets applied across all opencode sessions.
+
+Since this isn't committed to Git or shared with your team, we recommend using this to specify any personal rules that the LLM should follow.
+
+### Claude Code Compatibility
+
+For users migrating from Claude Code, OpenCode supports Claude Code's file conventions as fallbacks:
+
+- **Project rules**: `CLAUDE.md` in your project directory (used if no `AGENTS.md` exists)
+- **Global rules**: `~/.claude/CLAUDE.md` (used if no `~/.config/opencode/AGENTS.md` exists)
+- **Skills**: `~/.claude/skills/` — see [Agent Skills](/docs/skills/) for details
+
+To disable Claude Code compatibility, set one of these environment variables:
+
+```bash
+export OPENCODE_DISABLE_CLAUDE_CODE=1        # Disable all .claude support
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1 # Disable only ~/.claude/CLAUDE.md
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # Disable only .claude/skills
+```
+
+---
+
+## Precedence
+
+When opencode starts, it looks for rule files in this order:
+
+1. **Local files** by traversing up from the current directory (`AGENTS.md`, `CLAUDE.md`)
+2. **Global file** at `~/.config/opencode/AGENTS.md`
+3. **Claude Code file** at `~/.claude/CLAUDE.md` (unless disabled)
+
+The first matching file wins in each category. For example, if you have both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` is used. Similarly, `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`.
+
+---
+
+## Custom Instructions
+
+You can specify custom instruction files in your `opencode.json` or the global `~/.config/opencode/opencode.json`. This allows you and your team to reuse existing rules rather than having to duplicate them to AGENTS.md.
+
+Example:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRIBUTING.md", "docs/guidelines.md", ".cursor/rules/*.md"]
+}
+```
+
+You can also use remote URLs to load instructions from the web.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["https://raw.githubusercontent.com/my-org/shared-rules/main/style.md"]
+}
+```
+
+Remote instructions are fetched with a 5 second timeout.
+
+All instruction files are combined with your `AGENTS.md` files.
+
+---
+
+## Referencing External Files
+
+While opencode doesn't automatically parse file references in `AGENTS.md`, you can achieve similar functionality in two ways:
+
+### Using opencode.json
+
+The recommended approach is to use the `instructions` field in `opencode.json`:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["docs/development-standards.md", "test/testing-guidelines.md", "packages/*/AGENTS.md"]
+}
+```
+
+### Manual Instructions in AGENTS.md
+
+You can teach opencode to read external files by providing explicit instructions in your `AGENTS.md`. Here's a practical example:
+
+```markdown title="AGENTS.md"
+# TypeScript Project Rules
+
+## External File Loading
+
+CRITICAL: When you encounter a file reference (e.g., @rules/general.md), use your Read tool to load it on a need-to-know basis. They're relevant to the SPECIFIC task at hand.
+
+Instructions:
+
+- Do NOT preemptively load all references - use lazy loading based on actual need
+- When loaded, treat content as mandatory instructions that override defaults
+- Follow references recursively when needed
+
+## Development Guidelines
+
+For TypeScript code style and best practices: @docs/typescript-guidelines.md
+For React component architecture and hooks patterns: @docs/react-patterns.md
+For REST API design and error handling: @docs/api-standards.md
+For testing strategies and coverage requirements: @test/testing-guidelines.md
+
+## General Guidelines
+
+Read the following file immediately as it's relevant to all workflows: @rules/general-guidelines.md.
+```
+
+This approach allows you to:
+
+- Create modular, reusable rule files
+- Share rules across projects via symlinks or git submodules
+- Keep AGENTS.md concise while referencing detailed guidelines
+- Ensure opencode loads files only when needed for the specific task
+
+:::tip
+For monorepos or projects with shared standards, using `opencode.json` with glob patterns (like `packages/*/AGENTS.md`) is more maintainable than manual instructions.
+:::

--- a/skills/opencode-delegate/SKILL.md
+++ b/skills/opencode-delegate/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: opencode-delegate
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Build a Claude Code plugin that delegates coding work to OpenCode (SST's open-source
+  agent, opencode.ai) — the OpenCode analog of openai/codex-plugin-cc. Maps the
+  codex-plugin-cc template (thin bash forwarders → a Node `.mjs` companion holding a
+  persistent connection to the OpenCode daemon → a detached background-job store with
+  status/result/cancel) onto OpenCode's three drive paths. Use when building a
+  CC→OpenCode delegation/handoff plugin, porting codex-plugin-cc to OpenCode, or
+  choosing between `opencode acp`, `opencode serve` + `@opencode-ai/sdk`
+  (`createOpencodeClient`), and `opencode run --format json --attach
+  --dangerously-skip-permissions` as the transport for delegated tasks.
+argument-hint: "e.g. 'build a CC plugin that hands a task off to OpenCode and polls for the result'"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# Delegate to OpenCode from Claude Code
+
+Build a Claude Code plugin that hands work to **OpenCode** (SST; `opencode.ai`,
+GitHub `sst/opencode` — **not** OpenAI Codex). This skill teaches *only* OpenCode's
+drive paths and how the codex-plugin-cc architecture maps onto them.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing delegate code, read `references/cli.rst` and
+> `references/acp.rst` AND re-check <https://opencode.ai/docs/acp/> (and
+> `/docs/cli/`, `/docs/server/`) for drift. The ACP wire protocol is **not** in
+> these references — its JSON-RPC method schema lives at
+> <https://agentclientprotocol.com>; verify there, don't recall it.
+
+**Scope guard — do NOT re-teach here:**
+- Claude Code plugin authoring (`commands/`, subagents, `hooks/`,
+  `${CLAUDE_PLUGIN_ROOT}`) → the `claude-code` bundle + `plugin-dev`.
+- OpenCode SDK client surface, server endpoints, `GET /doc` OpenAPI → `opencode-dev:sdk`.
+
+This skill is the **delta**: which OpenCode transport to drive, and the
+codex-plugin-cc template mapped onto it.
+
+**Version pins** (verify current before authoring): JS packages `@opencode-ai/sdk`,
+`@opencode-ai/plugin`; Go module `github.com/sst/opencode-sdk-go` **v0.19.2**, Go
+**1.22+** — verify this exact module path (other namesake Go modules exist).
+
+---
+
+## Pick a drive path
+
+OpenCode exposes three ways an external process can drive it. Choose by how the
+delegating plugin needs to talk to it:
+
+| Path | Command | Transport | Persistence / sessions | Cancel | When |
+|---|---|---|---|---|---|
+| **ACP** | `opencode acp` | JSON-RPC over **stdin/stdout, nd-JSON** (newline-delimited) | Persistent subprocess, editor-style threads | protocol-level (see ACP schema) | Richest; closest analog to codex `app-server`. Editors (Zed/JetBrains) already drive it this way. |
+| **serve + SDK** | `opencode serve` + `@opencode-ai/sdk` `createOpencodeClient({baseUrl})` | HTTP + **SSE** (`client.event.subscribe`) | Long-lived daemon, multi-session, default `127.0.0.1:4096` | `client.session.abort(...)` | **Best fit for a codex-plugin-cc-style job store.** Most documented, easiest to keep alive. |
+| **run (one-shot)** | `opencode run [msg..] --format json` | child process; **raw JSON event stream on stdout** | Stateless per invocation (`--continue`/`--session`/`--fork` to chain) | kill the (detached) pid | Simplest fire-and-forget subprocess. |
+
+**Default recommendation:** start with **serve + SDK**. It is the verifiable,
+documented analog of a persistent daemon and gives you a clean `abort`. Reach for
+`acp` only if you need ACP's editor-grade thread protocol; reach for `run` for the
+simplest possible one-shot.
+
+### codex `app-server` ↔ `opencode acp` — concept-level only
+
+codex-plugin-cc's companion held a persistent JSON-RPC connection to `codex
+app-server` (methods like `turn/start`, `turn/resume`, `turn/interrupt`). **Those
+are codex methods — they do NOT exist in OpenCode/ACP.** The analogy is structural:
+both are persistent JSON-RPC over stdio. OpenCode's `acp` speaks the **Agent Client
+Protocol** (Zed's open standard) with its *own* method namespace — get the actual
+method names from <https://agentclientprotocol.com>, not from the codex surface.
+
+---
+
+## Drive-path traps (the things a fresh model gets wrong)
+
+- **`--format json` is the streaming opt-in.** `opencode run` defaults to `--format
+  default` (formatted, human text). For a companion you parse, you **must** pass
+  `--format json` to get "raw JSON events." The event object shape is **not
+  documented here** — capture it empirically (run once, log stdout) before parsing;
+  don't hardcode an invented shape.
+- **`--attach http://localhost:4096` reuses a running `serve`** — verbatim purpose:
+  "to avoid MCP server cold boot times on every run." Without `--attach`, each
+  `opencode run` spins up its own server (random port via `--port`) and re-boots MCP
+  servers. For a delegation plugin doing many runs, **`serve` once + `run --attach`**
+  (or the SDK) is the difference between snappy and sluggish.
+- **`--dangerously-skip-permissions` auto-approves only permissions that are NOT
+  explicitly denied** — `deny` rules in config/agent still block. It is not a
+  blanket bypass. A delegated headless run needs this (no TTY to answer prompts), so
+  pair it with a tight `permission` policy on the OpenCode side.
+- **Basic auth:** set `OPENCODE_SERVER_PASSWORD` on `serve`/`web`; the companion
+  passes `--password/-p` (or `OPENCODE_SERVER_PASSWORD`) and `--username/-u`
+  (default `opencode`). The SDK client needs the matching credential too.
+- **ACP loses `/undo` and `/redo`** (and only those slash commands) — verbatim
+  caveat. Everything else (tools, MCP, AGENTS.md rules, agents, permissions) works
+  identically over ACP.
+- **`createOpencodeClient` (connect-only) vs `createOpencode` (starts server +
+  client).** There is **no `createOpencodeServer`** in the SDK — ignore third-party
+  material that uses it. Full SDK detail lives in `opencode-dev:sdk`.
+
+---
+
+## The codex-plugin-cc template, mapped onto OpenCode
+
+The thing users clone is a Claude Code plugin whose entire CC-facing surface is
+**transport-agnostic**; porting Codex→OpenCode means **swapping only the transport
+layer** inside the companion.
+
+```
+Claude Code plugin (UNCHANGED across Codex/OpenCode)
+  commands/{review,transfer,status,result,cancel,setup}.md   ← thin bash forwarders
+  agents/<delegator>.md                                       ← delegation subagent
+        │  every command/agent shells out to ONE call:
+        ▼
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs" <verb> ...
+        │
+        ▼
+  companion.mjs  ← THE ONLY LAYER YOU PORT
+     • owns the connection to the OpenCode daemon (swap transport here)
+     • spawns a DETACHED worker per task; never blocks Claude Code
+     • persists a job store: {id,status,phase,pid,logFile,sessionID,request}
+     • verbs: task | status | result | cancel
+        │
+        ▼
+  OpenCode daemon  ← serve+SDK  |  acp  |  run --attach
+```
+
+**What stays identical** when porting from codex-plugin-cc: the slash commands, the
+delegation subagent, the `${CLAUDE_PLUGIN_ROOT}/scripts/*.mjs` forwarder convention,
+the detached-job store with `status`/`result`/`cancel`, and the `/<plugin>:setup`
+command that checks/installs the foreign CLI (here: `opencode`; needs Node 18+).
+
+**What you swap** — the companion's transport (pick from the table above):
+
+| codex-plugin-cc | OpenCode equivalent |
+|---|---|
+| persistent JSON-RPC to `codex app-server` | `opencode serve` + `createOpencodeClient` **(recommended)**, or `opencode acp` (ACP JSON-RPC/stdio) |
+| `turn/start` start a turn | SDK `client.session.create` + `client.session.prompt` *(verify signatures in `opencode-dev:sdk` + `GET /doc`)* |
+| `turn/interrupt` | SDK `client.session.abort(...)`; for the `run` path, kill the detached pid |
+| streamed turn events | SDK `client.event.subscribe()` (SSE), or `run --format json` stdout stream |
+
+### Detached background jobs — the load-bearing pattern
+
+A delegated task must outlive the (synchronous, fast) Claude Code tool call. Spawn
+the worker truly detached, record its pid, and poll via separate `status`/`result`
+verbs:
+
+```js
+const child = spawn(process.execPath, [worker, jobId], {
+  detached: true,
+  stdio: "ignore",   // or redirect to logFile
+});
+child.unref();       // REQUIRED — without unref the parent won't exit / job isn't detached
+```
+
+Then `status` reads the job-store file; `result` tails `logFile`; `cancel` calls
+`client.session.abort(...)` (serve+SDK) or `process.kill(job.pid)` (run path).
+
+See `assets/companion.skeleton.mjs` for a minimal serve+SDK companion and
+`assets/delegate-command.md` for a starter forwarder command.
+
+---
+
+## Before you ship
+
+1. Read `references/cli.rst` (every `run`/`serve`/`acp` flag) + `references/acp.rst`
+   and confirm flags against your installed `opencode --version`.
+2. Decide one drive path; keep the CC-facing surface transport-agnostic so the other
+   two remain swap-in options.
+3. Capture the real `run --format json` event shape (or the SDK event stream)
+   empirically before parsing it.
+4. Cross-reference `opencode-dev:sdk` for client signatures and server auth — do not
+   re-derive them here.

--- a/skills/opencode-delegate/assets/companion.skeleton.mjs
+++ b/skills/opencode-delegate/assets/companion.skeleton.mjs
@@ -1,0 +1,67 @@
+// companion.skeleton.mjs — minimal CC→OpenCode delegation companion.
+//
+// Anchored on the verifiable drive path: `opencode serve` + `@opencode-ai/sdk`
+// (`createOpencodeClient`). This is the OpenCode analog of codex-plugin-cc's
+// persistent-connection companion. The CC-facing surface (verbs below) is the same
+// regardless of transport — to use `opencode acp` or `opencode run` instead, swap
+// only the connect()/start()/cancel() bodies.
+//
+// VERIFY before relying on signatures: SDK method arg shapes are generated from the
+// server's OpenAPI spec (`GET http://localhost:4096/doc`) — see the `opencode-dev:sdk`
+// skill. Pins: @opencode-ai/sdk; node 18+.
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { createOpencodeClient } from "@opencode-ai/sdk";
+
+const STORE = `${process.env.HOME}/.cache/cc-opencode/jobs.json`;
+const BASE_URL = process.env.OPENCODE_BASE_URL ?? "http://localhost:4096";
+
+const client = () =>
+  createOpencodeClient({ baseUrl: BASE_URL }); // connect-only; assumes `opencode serve` is up
+
+// --- job store: {id,status,phase,pid,logFile,sessionID,request} ----------------
+const load = () => (existsSync(STORE) ? JSON.parse(readFileSync(STORE, "utf8")) : {});
+const save = (jobs) => writeFileSync(STORE, JSON.stringify(jobs, null, 2));
+const put = (job) => { const j = load(); j[job.id] = job; save(j); };
+
+// --- verbs ---------------------------------------------------------------------
+async function task(request) {
+  const id = `job_${Date.now()}`;
+  const logFile = `${process.env.HOME}/.cache/cc-opencode/${id}.log`;
+  // Spawn the worker TRULY detached so it outlives this fast CC tool call.
+  const child = spawn(process.execPath, [import.meta.filename, "__worker", id, logFile, request], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref(); // REQUIRED — without unref the job is not detached.
+  put({ id, status: "running", phase: "dispatched", pid: child.pid, logFile, request });
+  console.log(JSON.stringify({ id }));
+}
+
+async function worker(id, logFile, request) {
+  const c = client();
+  // Verify these signatures against `opencode-dev:sdk` + GET /doc before shipping.
+  const session = await c.session.create({});                       // returns session id
+  put({ ...load()[id], sessionID: session.id, phase: "prompting" });
+  await c.session.prompt({ path: { id: session.id }, body: { parts: [{ type: "text", text: request }] } });
+  put({ ...load()[id], status: "done", phase: "complete" });
+  writeFileSync(logFile, JSON.stringify({ sessionID: session.id }, null, 2));
+}
+
+function status(id) { console.log(JSON.stringify(load()[id] ?? { error: "unknown job" })); }
+function result(id) { const j = load()[id]; console.log(existsSync(j?.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)"); }
+
+async function cancel(id) {
+  const j = load()[id];
+  if (j?.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
+  else if (j?.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
+  put({ ...j, status: "cancelled" });
+}
+
+// --- dispatch ------------------------------------------------------------------
+const [verb, ...args] = process.argv.slice(2);
+const verbs = { task: () => task(args.join(" ")), status: () => status(args[0]),
+  result: () => result(args[0]), cancel: () => cancel(args[0]),
+  __worker: () => worker(args[0], args[1], args.slice(2).join(" ")) };
+await (verbs[verb] ?? (() => { console.error(`usage: companion.mjs task|status|result|cancel`); process.exit(1); }))();

--- a/skills/opencode-delegate/assets/companion.skeleton.mjs
+++ b/skills/opencode-delegate/assets/companion.skeleton.mjs
@@ -11,10 +11,13 @@
 // skill. Pins: @opencode-ai/sdk; node 18+.
 
 import { spawn } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 
-const STORE = `${process.env.HOME}/.cache/cc-opencode/jobs.json`;
+const SELF = fileURLToPath(import.meta.url); // node 18+ has no import.meta.filename
+const CACHE_DIR = `${process.env.HOME}/.cache/cc-opencode`;
+const STORE = `${CACHE_DIR}/jobs.json`;
 const BASE_URL = process.env.OPENCODE_BASE_URL ?? "http://localhost:4096";
 
 const client = () =>
@@ -22,15 +25,15 @@ const client = () =>
 
 // --- job store: {id,status,phase,pid,logFile,sessionID,request} ----------------
 const load = () => (existsSync(STORE) ? JSON.parse(readFileSync(STORE, "utf8")) : {});
-const save = (jobs) => writeFileSync(STORE, JSON.stringify(jobs, null, 2));
+const save = (jobs) => { mkdirSync(CACHE_DIR, { recursive: true }); writeFileSync(STORE, JSON.stringify(jobs, null, 2)); };
 const put = (job) => { const j = load(); j[job.id] = job; save(j); };
 
 // --- verbs ---------------------------------------------------------------------
 async function task(request) {
   const id = `job_${Date.now()}`;
-  const logFile = `${process.env.HOME}/.cache/cc-opencode/${id}.log`;
+  const logFile = `${CACHE_DIR}/${id}.log`;
   // Spawn the worker TRULY detached so it outlives this fast CC tool call.
-  const child = spawn(process.execPath, [import.meta.filename, "__worker", id, logFile, request], {
+  const child = spawn(process.execPath, [SELF, "__worker", id, logFile, request], {
     detached: true,
     stdio: "ignore",
   });
@@ -42,20 +45,26 @@ async function task(request) {
 async function worker(id, logFile, request) {
   const c = client();
   // Verify these signatures against `opencode-dev:sdk` + GET /doc before shipping.
-  const session = await c.session.create({});                       // returns session id
-  put({ ...load()[id], sessionID: session.id, phase: "prompting" });
-  await c.session.prompt({ path: { id: session.id }, body: { parts: [{ type: "text", text: request }] } });
+  const created = await c.session.create({ body: {} });             // {data}-wrapped response
+  const sessionID = created.data.id;
+  put({ ...load()[id], sessionID, phase: "prompting" });
+  await c.session.prompt({ path: { id: sessionID }, body: { parts: [{ type: "text", text: request }] } });
   put({ ...load()[id], status: "done", phase: "complete" });
-  writeFileSync(logFile, JSON.stringify({ sessionID: session.id }, null, 2));
+  writeFileSync(logFile, JSON.stringify({ sessionID }, null, 2));
 }
 
 function status(id) { console.log(JSON.stringify(load()[id] ?? { error: "unknown job" })); }
-function result(id) { const j = load()[id]; console.log(existsSync(j?.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)"); }
+function result(id) {
+  const j = load()[id];
+  if (!j) { console.log(JSON.stringify({ error: "unknown job" })); return; }
+  console.log(existsSync(j.logFile) ? readFileSync(j.logFile, "utf8") : "(no result yet)");
+}
 
 async function cancel(id) {
   const j = load()[id];
-  if (j?.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
-  else if (j?.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
+  if (!j) { console.log(JSON.stringify({ error: "unknown job" })); return; }
+  if (j.sessionID) await client().session.abort({ path: { id: j.sessionID } }); // serve+SDK cancel
+  else if (j.pid) try { process.kill(j.pid); } catch {}                          // run-path cancel
   put({ ...j, status: "cancelled" });
 }
 

--- a/skills/opencode-delegate/assets/delegate-command.md
+++ b/skills/opencode-delegate/assets/delegate-command.md
@@ -1,0 +1,29 @@
+---
+description: Delegate a coding task to OpenCode and return a job id to poll
+argument-hint: "<task description>"
+---
+<!--
+  Starter Claude Code slash command — a THIN BASH FORWARDER into the companion.
+  No logic lives here; the companion owns the OpenCode connection + job store.
+  Companion paths: `${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs`.
+  Prereqs (handle in a /<plugin>:setup command, not here): `opencode` CLI on PATH,
+  a running `opencode serve` (default 127.0.0.1:4096), Node 18+.
+  Sibling forwarders reuse the same one-line pattern: status / result / cancel.
+-->
+
+Delegate this task to OpenCode and report the job id:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/companion.mjs" task "$ARGUMENTS"
+```
+
+Then tell the user the returned `id` and that they can poll with
+`/<plugin>:status <id>`, fetch output with `/<plugin>:result <id>`, or stop it with
+`/<plugin>:cancel <id>`. Do not block waiting for completion — the companion ran the
+work in a detached worker.
+
+<!--
+  Transport note: this forwarder is identical whether the companion drives OpenCode
+  via `serve`+SDK, `opencode acp`, or `opencode run --format json --attach ...`.
+  Swap the companion's transport, not this command. See SKILL.md.
+-->

--- a/skills/opencode-delegate/references/acp.rst
+++ b/skills/opencode-delegate/references/acp.rst
@@ -1,0 +1,178 @@
+<!-- Source: https://opencode.ai/docs/acp/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode delegate code. -->
+
+# ACP Support
+
+Use OpenCode in any ACP-compatible editor.
+
+OpenCode supports the [Agent Client Protocol](https://agentclientprotocol.com) or (ACP), allowing you to use it directly in compatible editors and IDEs.
+
+> For a list of editors and tools that support ACP, check out the [ACP progress report](https://zed.dev/blog/acp-progress-report#available-now).
+
+ACP is an open protocol that standardizes communication between code editors and AI coding agents.
+
+---
+
+## Configure
+
+To use OpenCode via ACP, configure your editor to run the `opencode acp` command.
+
+The command starts OpenCode as an ACP-compatible subprocess that communicates with your editor over JSON-RPC via stdio.
+
+Below are examples for popular editors that support ACP.
+
+---
+
+### Zed
+
+Add to your [Zed](https://zed.dev) configuration (`~/.config/zed/settings.json`):
+
+```json title="~/.config/zed/settings.json"
+{
+  "agent_servers": {
+    "OpenCode": {
+      "command": "opencode",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+To open it, use the `agent: new thread` action in the **Command Palette**.
+
+You can also bind a keyboard shortcut by editing your `keymap.json`:
+
+```json title="keymap.json"
+[
+  {
+    "bindings": {
+      "cmd-alt-o": [
+        "agent::NewExternalAgentThread",
+        {
+          "agent": {
+            "custom": {
+              "name": "OpenCode",
+              "command": {
+                "command": "opencode",
+                "args": ["acp"]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```
+
+---
+
+### JetBrains IDEs
+
+Add to your [JetBrains IDE](https://www.jetbrains.com/) acp.json according to the [documentation](https://www.jetbrains.com/help/ai-assistant/acp.html):
+
+```json title="acp.json"
+{
+  "agent_servers": {
+    "OpenCode": {
+      "command": "/absolute/path/bin/opencode",
+      "args": ["acp"]
+    }
+  }
+}
+```
+
+To open it, use the new 'OpenCode' agent in the AI Chat agent selector.
+
+---
+
+### Avante.nvim
+
+Add to your [Avante.nvim](https://github.com/yetone/avante.nvim) configuration:
+
+```lua
+{
+  acp_providers = {
+    ["opencode"] = {
+      command = "opencode",
+      args = { "acp" }
+    }
+  }
+}
+```
+
+If you need to pass environment variables:
+
+```lua {6-8}
+{
+  acp_providers = {
+    ["opencode"] = {
+      command = "opencode",
+      args = { "acp" },
+      env = {
+        OPENCODE_API_KEY = os.getenv("OPENCODE_API_KEY")
+      }
+    }
+  }
+}
+```
+
+---
+
+### CodeCompanion.nvim
+
+To use OpenCode as an ACP agent in [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim), add the following to your Neovim config:
+
+```lua
+require("codecompanion").setup({
+  interactions = {
+    chat = {
+      adapter = {
+        name = "opencode",
+        model = "claude-sonnet-4",
+      },
+    },
+  },
+})
+```
+
+This config sets up CodeCompanion to use OpenCode as the ACP agent for chat.
+
+If you need to pass environment variables (like `OPENCODE_API_KEY`), refer to [Configuring Adapters: Environment Variables](https://codecompanion.olimorris.dev/getting-started#setting-an-api-key) in the CodeCompanion.nvim documentation for full details.
+
+## Support
+
+OpenCode works the same via ACP as it does in the terminal. All features are supported:
+
+> Some built-in slash commands like `/undo` and `/redo` are currently unsupported.
+
+- Built-in tools (file operations, terminal commands, etc.)
+- Custom tools and slash commands
+- MCP servers configured in your OpenCode config
+- Project-specific rules from `AGENTS.md`
+- Custom formatters and linters
+- Agents and permissions system
+
+---
+
+## CLI page note (from /docs/cli/ — the `acp` command)
+
+### acp
+
+Start an ACP (Agent Client Protocol) server.
+
+```bash
+opencode acp
+```
+
+This command starts an ACP server that communicates via stdin/stdout using **nd-JSON** (newline-delimited JSON).
+
+#### Flags
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--cwd`         | Working directory                          |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |

--- a/skills/opencode-delegate/references/cli.rst
+++ b/skills/opencode-delegate/references/cli.rst
@@ -1,0 +1,539 @@
+<!-- Source: https://opencode.ai/docs/cli/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode delegate code. -->
+
+# CLI
+
+OpenCode CLI options and commands.
+
+The OpenCode CLI by default starts the [TUI](/docs/tui) when run without any arguments.
+
+```bash
+opencode
+```
+
+But it also accepts commands as documented on this page. This allows you to interact with OpenCode programmatically.
+
+```bash
+opencode run "Explain how closures work in JavaScript"
+```
+
+---
+
+### tui
+
+Start the OpenCode terminal user interface.
+
+```bash
+opencode [project]
+```
+
+#### Flags
+
+| Flag            | Short | Description                                                             |
+| --------------- | ----- | ----------------------------------------------------------------------- |
+| `--continue`    | `-c`  | Continue the last session                                               |
+| `--session`     | `-s`  | Session ID to continue                                                  |
+| `--fork`        |       | Fork the session when continuing (use with `--continue` or `--session`) |
+| `--prompt`      |       | Prompt to use                                                           |
+| `--model`       | `-m`  | Model to use in the form of provider/model                              |
+| `--agent`       |       | Agent to use                                                            |
+| `--port`        |       | Port to listen on                                                       |
+| `--hostname`    |       | Hostname to listen on                                                   |
+| `--mdns`        |       | Enable mDNS discovery                                                   |
+| `--mdns-domain` |       | Custom mDNS domain name                                                 |
+| `--cors`        |       | Additional browser origin(s) to allow CORS                              |
+
+---
+
+## Commands
+
+The OpenCode CLI also has the following commands.
+
+---
+
+### agent
+
+Manage agents for OpenCode.
+
+```bash
+opencode agent [command]
+```
+
+#### create
+
+Create a new agent with custom configuration.
+
+```bash
+opencode agent create
+```
+
+This command will guide you through creating a new agent with a custom system prompt and permission configuration. Anything you don't allow is denied in the generated agent's frontmatter.
+
+#### Flags
+
+| Flag            | Short | Description                                                                                                                                                                                                                |
+| --------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--path`        |       | Directory to write the agent file to (defaults to global or `.opencode/agent` based on the prompt)                                                                                                                         |
+| `--description` |       | What the agent should do                                                                                                                                                                                                   |
+| `--mode`        |       | Agent mode: `all`, `primary`, or `subagent`                                                                                                                                                                                |
+| `--permissions` |       | Comma-separated list of permissions to allow (default: all). Available: `bash`, `read`, `edit`, `glob`, `grep`, `webfetch`, `task`, `todowrite`, `websearch`, `lsp`, `skill`. Anything omitted is denied. Alias: `--tools` |
+| `--model`       | `-m`  | Model to use, in `provider/model` format                                                                                                                                                                                   |
+
+Passing all of `--path`, `--description`, `--mode`, and `--permissions` runs the command non-interactively.
+
+#### list
+
+List all available agents.
+
+```bash
+opencode agent list
+```
+
+---
+
+### attach
+
+Attach a terminal to an already running OpenCode backend server started via `serve` or `web` commands.
+
+```bash
+opencode attach [url]
+```
+
+This allows using the TUI with a remote OpenCode backend. For example:
+
+```bash
+# Start the backend server for web/mobile access
+opencode web --port 4096 --hostname 0.0.0.0
+
+# In another terminal, attach the TUI to the running backend
+opencode attach http://10.20.30.40:4096
+```
+
+#### Flags
+
+| Flag         | Short | Description                                                                |
+| ------------ | ----- | -------------------------------------------------------------------------- |
+| `--dir`      |       | Working directory to start TUI in                                          |
+| `--continue` | `-c`  | Continue the last session                                                  |
+| `--session`  | `-s`  | Session ID to continue                                                     |
+| `--fork`     |       | Fork the session when continuing (use with `--continue` or `--session`)    |
+| `--password` | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
+| `--username` | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+
+---
+
+### auth
+
+Command to manage credentials and login for providers.
+
+```bash
+opencode auth [command]
+```
+
+#### login
+
+`opencode auth login` configures API keys. Stored in `~/.local/share/opencode/auth.json`.
+
+```bash
+opencode auth login
+```
+
+| Flag         | Short | Description                                          |
+| ------------ | ----- | ---------------------------------------------------- |
+| `--provider` | `-p`  | Provider ID or name to log in to                     |
+| `--method`   | `-m`  | Login method label to use, skipping method selection |
+
+#### list
+
+```bash
+opencode auth list
+opencode auth ls
+```
+
+#### logout
+
+```bash
+opencode auth logout
+```
+
+---
+
+### github
+
+Manage the GitHub agent for repository automation.
+
+```bash
+opencode github [command]
+```
+
+#### install
+
+```bash
+opencode github install
+```
+
+#### run
+
+Run the GitHub agent. This is typically used in GitHub Actions.
+
+```bash
+opencode github run
+```
+
+| Flag      | Description                            |
+| --------- | -------------------------------------- |
+| `--event` | GitHub mock event to run the agent for |
+| `--token` | GitHub personal access token           |
+
+---
+
+### mcp
+
+Manage Model Context Protocol servers.
+
+```bash
+opencode mcp [command]
+```
+
+- `opencode mcp add` — Add a local or remote MCP server.
+- `opencode mcp list` / `opencode mcp ls` — List configured MCP servers and connection status.
+- `opencode mcp auth [name]` — Authenticate with an OAuth-enabled MCP server. `opencode mcp auth list` / `ls` lists OAuth-capable servers.
+- `opencode mcp logout [name]` — Remove OAuth credentials.
+- `opencode mcp debug <name>` — Debug OAuth connection issues.
+
+---
+
+### models
+
+List all available models from configured providers.
+
+```bash
+opencode models [provider]
+opencode models anthropic
+opencode models --refresh
+```
+
+| Flag        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| `--refresh` | Refresh the models cache from models.dev                     |
+| `--verbose` | Use more verbose model output (includes metadata like costs) |
+
+---
+
+### run
+
+Run opencode in non-interactive mode by passing a prompt directly.
+
+```bash
+opencode run [message..]
+```
+
+```bash
+opencode run Explain the use of context in Go
+```
+
+You can also attach to a running `opencode serve` instance to avoid MCP server cold boot times on every run:
+
+```bash
+# Start a headless server in one terminal
+opencode serve
+
+# In another terminal, run commands that attach to it
+opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
+```
+
+#### Flags
+
+| Flag                              | Short | Description                                                                |
+| --------------------------------- | ----- | -------------------------------------------------------------------------- |
+| `--command`                       |       | The command to run, use message for args                                   |
+| `--continue`                      | `-c`  | Continue the last session                                                  |
+| `--session`                       | `-s`  | Session ID to continue                                                     |
+| `--fork`                          |       | Fork the session when continuing (use with `--continue` or `--session`)    |
+| `--share`                         |       | Share the session                                                          |
+| `--model`                         | `-m`  | Model to use in the form of provider/model                                 |
+| `--agent`                         |       | Agent to use                                                               |
+| `--file`                          | `-f`  | File(s) to attach to message                                               |
+| `--format`                        |       | Format: default (formatted) or json (raw JSON events)                      |
+| `--title`                         |       | Title for the session (uses truncated prompt if no value provided)         |
+| `--attach`                        |       | Attach to a running opencode server (e.g., http://localhost:4096)          |
+| `--password`                      | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
+| `--username`                      | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+| `--dir`                           |       | Directory to run in, or path on the remote server when attaching           |
+| `--port`                          |       | Port for the local server (defaults to random port)                        |
+| `--variant`                       |       | Model variant (provider-specific reasoning effort)                         |
+| `--thinking`                      |       | Show thinking blocks                                                       |
+| `--dangerously-skip-permissions`  |       | Auto-approve permissions that are not explicitly denied (dangerous!)       |
+
+---
+
+### serve
+
+Start a headless OpenCode server for API access. Check out the [server docs](/docs/server) for the full HTTP interface.
+
+```bash
+opencode serve
+```
+
+This starts an HTTP server that provides API access to opencode functionality without the TUI interface. Set `OPENCODE_SERVER_PASSWORD` to enable HTTP basic auth (username defaults to `opencode`).
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### session
+
+Manage OpenCode sessions.
+
+```bash
+opencode session [command]
+```
+
+#### list
+
+```bash
+opencode session list
+```
+
+| Flag          | Short | Description                          |
+| ------------- | ----- | ------------------------------------ |
+| `--max-count` | `-n`  | Limit to N most recent sessions      |
+| `--format`    |       | Output format: table or json (table) |
+
+#### delete
+
+```bash
+opencode session delete <sessionID>
+```
+
+---
+
+### stats
+
+```bash
+opencode stats
+```
+
+| Flag        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `--days`    | Show stats for the last N days (all time)                                   |
+| `--tools`   | Number of tools to show (all)                                               |
+| `--models`  | Show model usage breakdown (hidden by default). Pass a number to show top N |
+| `--project` | Filter by project (all projects, empty string: current project)             |
+
+---
+
+### export
+
+Export session data as JSON.
+
+```bash
+opencode export [sessionID]
+```
+
+| Flag         | Description                           |
+| ------------ | ------------------------------------- |
+| `--sanitize` | Redact sensitive transcript/file data |
+
+---
+
+### import
+
+Import session data from a JSON file or OpenCode share URL.
+
+```bash
+opencode import <file>
+opencode import session.json
+opencode import https://opncd.ai/s/abc123
+```
+
+---
+
+### web
+
+Start a headless OpenCode server with a web interface.
+
+```bash
+opencode web
+```
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### acp
+
+Start an ACP (Agent Client Protocol) server.
+
+```bash
+opencode acp
+```
+
+This command starts an ACP server that communicates via stdin/stdout using nd-JSON.
+
+| Flag            | Description                                |
+| --------------- | ------------------------------------------ |
+| `--cwd`         | Working directory                          |
+| `--port`        | Port to listen on                          |
+| `--hostname`    | Hostname to listen on                      |
+| `--mdns`        | Enable mDNS discovery                      |
+| `--mdns-domain` | Custom mDNS domain name                    |
+| `--cors`        | Additional browser origin(s) to allow CORS |
+
+---
+
+### plugin
+
+Install a plugin and update your config.
+
+```bash
+opencode plugin <module>
+opencode plug <module>
+```
+
+| Flag       | Short | Description                     |
+| ---------- | ----- | ------------------------------- |
+| `--global` | `-g`  | Install in global config        |
+| `--force`  | `-f`  | Replace existing plugin version |
+
+---
+
+### pr
+
+Fetch and checkout a GitHub PR branch, then run OpenCode.
+
+```bash
+opencode pr <number>
+```
+
+---
+
+### db
+
+Database tools.
+
+```bash
+opencode db [query]
+opencode db path
+```
+
+| Flag       | Description                    |
+| ---------- | ------------------------------ |
+| `--format` | Output format: `json` or `tsv` |
+
+---
+
+### debug
+
+Debugging and troubleshooting tools.
+
+```bash
+opencode debug [command]
+```
+
+---
+
+### uninstall
+
+```bash
+opencode uninstall
+```
+
+| Flag            | Short | Description                                 |
+| --------------- | ----- | ------------------------------------------- |
+| `--keep-config` | `-c`  | Keep configuration files                    |
+| `--keep-data`   | `-d`  | Keep session data and snapshots             |
+| `--dry-run`     |       | Show what would be removed without removing |
+| `--force`       | `-f`  | Skip confirmation prompts                   |
+
+---
+
+### upgrade
+
+```bash
+opencode upgrade [target]
+opencode upgrade
+opencode upgrade v0.1.48
+```
+
+| Flag       | Short | Description                                                       |
+| ---------- | ----- | ----------------------------------------------------------------- |
+| `--method` | `-m`  | The installation method that was used; curl, npm, pnpm, bun, brew |
+
+---
+
+## Global Flags
+
+| Flag           | Short | Description                          |
+| -------------- | ----- | ------------------------------------ |
+| `--help`       | `-h`  | Display help                         |
+| `--version`    | `-v`  | Print version number                 |
+| `--print-logs` |       | Print logs to stderr                 |
+| `--log-level`  |       | Log level (DEBUG, INFO, WARN, ERROR) |
+| `--pure`       |       | Run without external plugins         |
+
+---
+
+## Environment variables
+
+| Variable                              | Type    | Description                                       |
+| ------------------------------------- | ------- | ------------------------------------------------- |
+| `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
+| `OPENCODE_CONFIG`                     | string  | Path to config file                               |
+| `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
+| `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                          |
+| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content                        |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks                   |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data                       |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
+| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
+| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
+| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
+| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
+| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
+| `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
+| `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
+| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
+| `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
+| `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
+
+### Experimental
+
+| Variable                                        | Type    | Description                             |
+| ----------------------------------------------- | ------- | --------------------------------------- |
+| `OPENCODE_EXPERIMENTAL`                         | boolean | Enable the experimental umbrella flag   |
+| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | Enable icon discovery                   |
+| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | Disable copy on select in TUI           |
+| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | Default timeout for bash commands in ms |
+| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | Max output tokens for LLM responses     |
+| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | Enable file watcher for entire dir      |
+| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | Enable oxfmt formatter                  |
+| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | Enable experimental LSP tool            |
+| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disable file watcher                    |
+| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
+| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |
+| `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS`    | boolean | Enable background subagent tasks        |
+| `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM`            | boolean | Enable experimental event system        |
+| `OPENCODE_EXPERIMENTAL_NATIVE_LLM`              | boolean | Enable native LLM request path          |
+| `OPENCODE_EXPERIMENTAL_PARALLEL`                | boolean | Enable parallel web search execution    |
+| `OPENCODE_EXPERIMENTAL_SCOUT`                   | boolean | Enable Scout subagent                   |
+| `OPENCODE_EXPERIMENTAL_WORKSPACES`              | boolean | Enable workspace support                |

--- a/skills/opencode-plugin/SKILL.md
+++ b/skills/opencode-plugin/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: opencode-plugin
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode plugins and hooks — JS/TS modules that hook into OpenCode's
+  lifecycle to block tools, mutate args, inject env, react to events, or register
+  custom tools. Use when building or debugging anything under `.opencode/plugins/`,
+  importing `@opencode-ai/plugin`, writing a `tool.execute.before` /
+  `tool.execute.after` / `permission.ask` / `shell.env` / `command.execute.before`
+  handler, subscribing to OpenCode events via the `event` handler (`session.idle`,
+  `command.executed`), registering a custom tool from a plugin, or looking for an
+  OpenCode "stop hook" or a settings.json hook table. Distinct from OpenAI Codex.
+argument-hint: "What OpenCode plugin/hook do you want? (e.g. 'block reads of .env', 'notify when a session finishes', 'add a custom tool from a plugin')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Plugins & Hooks
+
+OpenCode (SST's open-source coding agent, `opencode.ai`, `sst/opencode` — **not**
+OpenAI Codex) extends via **plugins**: a JS/TS module exporting
+`async (input, options?) => Promise<Hooks>`. There is **no settings-file hook
+table like Claude Code** — "hooks" exist *only* as keys of the object your plugin
+returns. Get the vocabulary layering right and most plugins are a few lines.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's
+> training cutoff — before writing plugin code, read `references/plugins.rst` AND
+> re-check <https://opencode.ai/docs/plugins/> for drift. The handler-key set is
+> defined in `interface Hooks` (`packages/plugin/src/index.ts`).
+
+**Version pins.** Packages `@opencode-ai/plugin` (types + `tool` helper) and
+`@opencode-ai/sdk` (the `client`). The `interface Hooks` key set and field names
+encoded below were validated against `references/plugins.rst` as fetched
+**2026-06-29**; re-check that baseline for drift before pinning a version. SDK/Go
+specifics (Go SDK `v0.19.2`, Go 1.22+) belong to the **sdk** facet, not here.
+
+---
+
+## The one trap that breaks most plugins: handlers vs. events
+
+The docs print a single **"Events"** list that silently mixes two different
+layers. They share nouns but differ in **tense and access mechanism**:
+
+| Layer | How you use it | Tense | Examples |
+|---|---|---|---|
+| **Handler keys you RETURN** | top-level keys of the returned object; called with `(input, output)` | **imperative** | `tool.execute.before`, `tool.execute.after`, `permission.ask`, `command.execute.before`, `shell.env`, `chat.message` |
+| **Bus events you READ** | only inside the `event` handler, via `event.type` | **past-tense / `.updated` / `.idle`** | `command.executed`, `session.idle`, `session.updated`, `permission.asked`, `file.edited`, `lsp.updated` |
+
+Same word, two layers: `command.execute.before` is a **handler key** you return;
+`command.executed` is an **`event.type`** you match. `permission.ask` is a handler;
+`permission.asked` is an event. Never write `event: { "session.idle": ... }` — the
+`event` handler is one function that switches on `event.type`.
+
+```js
+return {
+  "command.execute.before": async (input, output) => { /* imperative handler */ },
+  event: async ({ event }) => {                          // bus reader
+    if (event.type === "session.idle") { /* … */ }
+  },
+}
+```
+
+## Full handler-key set (`interface Hooks`)
+
+Returnable keys, all optional: `dispose`, `event`, `config`, `tool` (a **map**,
+not a function), `auth`, `provider`, `chat.message`, `chat.params`, `chat.headers`,
+`permission.ask`, `command.execute.before`, `tool.execute.before`,
+`tool.execute.after`, `shell.env`, `tool.definition`, and experimental
+`experimental.{chat.messages.transform, chat.system.transform, provider.small_model,
+session.compacting, compaction.autocontinue, text.complete}`.
+
+- **There is no `stop` hook** — a community gist invents one; it does not exist.
+  For "session finished," read `event` + `event.type === "session.idle"`.
+- There is **`command.execute.before`** but no `command.execute.after` handler —
+  the after-the-fact signal is the `command.executed` *event*.
+
+## The `(input, output)` contract
+
+Imperative handlers receive two args: **`input` is read-only; mutate `output` in
+place; `throw` to block** the action.
+
+| Handler | `input` (read) | `output` (mutate) | Block by |
+|---|---|---|---|
+| `tool.execute.before` | `{ tool, sessionID, callID }` | `{ args }` | `throw` |
+| `tool.execute.after` | `{ tool, … }` | `{ title, output, metadata }` | — |
+| `permission.ask` | the `Permission` | `{ status: "ask" \| "deny" \| "allow" }` | set `status` |
+| `shell.env` | `{ cwd, … }` | `{ env }` | — |
+| `command.execute.before` | command info | command args | `throw` |
+| `tool.definition` | tool id | `{ description, parameters }` | — |
+
+Gotcha: the field is `output.args`, keyed by tool. For `read` it's
+`output.args.filePath`; for the **`apply_patch`** tool it's `output.args.patchText`
+(there is no `filePath`). Don't assume a uniform arg shape.
+
+## Where plugins live, and how they load
+
+- **Plural** `.opencode/plugins/` (project) or `~/.config/opencode/plugins/`
+  (global) — auto-loaded at startup. (A widely-copied community gist writes the
+  singular `.opencode/plugin/`; that is **wrong** and silently loads nothing.)
+- **npm packages** via the config `"plugin": [...]` array — Bun-installed to
+  `~/.cache/opencode/node_modules/`. Both bare and `@scoped` names work.
+- **Local runtime deps**: add `.opencode/package.json`; OpenCode runs `bun install`
+  at startup, then your plugin/tool can `import` them.
+
+## PluginInput — the context you destructure
+
+`PluginInput` is `{ client, project, directory, worktree, serverUrl, $ }` (plus
+`experimental_workspace`). Two non-obvious points: `$` is **Bun's shell**, and to
+log you must use the SDK client — `client.app.log({ body: { service, level,
+message, extra } })`, level `debug|info|warn|error` — **not** `console.log`, which
+is swallowed.
+
+## Registering a custom tool from a plugin
+
+The `tool` key is a **map** (`{ name: tool(...) }`), not a function — `import
+{ tool } from "@opencode-ai/plugin"`, build arg schemas off `tool.schema.*`. A
+plugin tool whose name matches a built-in **takes precedence**.
+
+> This is the *programmatic* route. Filesystem-discovered custom tools in
+> `.opencode/tools/*.ts` and the full `tool()` API are the **tools** facet
+> (`/opencode-dev:tools`) — cross-reference, don't duplicate.
+
+---
+
+## Recipes (full code in `references/plugins.rst`)
+
+| Goal | Key | Sketch |
+|---|---|---|
+| Block reading `.env` | `tool.execute.before` | `if (input.tool === "read" && output.args.filePath.includes(".env")) throw …` |
+| Sanitize bash args | `tool.execute.before` | mutate `output.args.command` (e.g. `shescape`) |
+| Notify on session done | `event` | `if (event.type === "session.idle") await $\`…\`` |
+| Inject shell env | `shell.env` | `output.env.MY_API_KEY = "…"` |
+| Persist context across compaction | `experimental.session.compacting` | `output.context.push("…")` or set `output.prompt` |
+| Add a custom tool | `tool` map | `tool({ description, args, execute })` |
+
+Starter scaffold pairing one imperative handler with the `event` reader:
+[`assets/starter-plugin.ts`](assets/starter-plugin.ts).
+
+## Reference files
+
+| File | Contents |
+|---|---|
+| [references/plugins.rst](references/plugins.rst) | Verbatim `/docs/plugins/` (load order, all examples, logging, compaction) + the `interface Hooks` key set and `PluginInput` type surface |

--- a/skills/opencode-plugin/assets/starter-plugin.ts
+++ b/skills/opencode-plugin/assets/starter-plugin.ts
@@ -1,0 +1,32 @@
+// .opencode/plugins/starter.ts  (note the PLURAL `plugins/` directory)
+//
+// Minimal OpenCode plugin showing the two-layer model side by side:
+//   - an IMPERATIVE handler key  -> (input, output), mutate output / throw to block
+//   - the `event` BUS reader      -> switch on past-tense `event.type`
+//
+// Verify the Hooks key set against `interface Hooks` in @opencode-ai/plugin
+// (packages/plugin/src/index.ts) and https://opencode.ai/docs/plugins/ — the API
+// moves fast. There is NO `stop` hook; "session finished" is event.type "session.idle".
+
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const Starter: Plugin = async ({ client, $, directory, worktree }) => {
+  return {
+    // IMPERATIVE handler: input is read-only, mutate `output` in place, throw to block.
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "read" && output.args.filePath?.includes(".env")) {
+        throw new Error("Blocked: do not read .env files")
+      }
+    },
+
+    // BUS reader: one function, switch on the past-tense event.type.
+    event: async ({ event }) => {
+      if (event.type === "session.idle") {
+        // Structured logging — prefer client.app.log over console.log.
+        await client.app.log({
+          body: { service: "starter", level: "info", message: "session idle" },
+        })
+      }
+    },
+  }
+}

--- a/skills/opencode-plugin/references/plugins.rst
+++ b/skills/opencode-plugin/references/plugins.rst
@@ -1,0 +1,397 @@
+<!-- Source: https://opencode.ai/docs/plugins/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode plugin code. -->
+
+# Plugins
+
+> Write your own plugins to extend OpenCode.
+
+Plugins allow you to extend OpenCode by hooking into various events and customizing behavior. You can create plugins to add new features, integrate with external services, or modify OpenCode's default behavior.
+
+For examples, check out the [plugins](https://opencode.ai/docs/ecosystem#plugins) created by the community.
+
+---
+
+## Use a plugin
+
+There are two ways to load plugins.
+
+### From local files
+
+Place JavaScript or TypeScript files in the plugin directory.
+
+- `.opencode/plugins/` - Project-level plugins
+- `~/.config/opencode/plugins/` - Global plugins
+
+Files in these directories are automatically loaded at startup.
+
+### From npm
+
+Specify npm packages in your config file.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
+}
+```
+
+Both regular and scoped npm packages are supported.
+
+Browse available plugins in the [ecosystem](https://opencode.ai/docs/ecosystem#plugins).
+
+### How plugins are installed
+
+**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/node_modules/`.
+
+**Local plugins** are loaded directly from the plugin directory. To use external packages, you must create a `package.json` within your config directory (see [Dependencies](#dependencies)), or publish the plugin to npm and add it to your config.
+
+### Load order
+
+Plugins are loaded from all sources and all hooks run in sequence. The load order is:
+
+1. Global config (`~/.config/opencode/opencode.json`)
+2. Project config (`opencode.json`)
+3. Global plugin directory (`~/.config/opencode/plugins/`)
+4. Project plugin directory (`.opencode/plugins/`)
+
+Duplicate npm packages with the same name and version are loaded once. However, a local plugin and an npm plugin with similar names are both loaded separately.
+
+---
+
+## Create a plugin
+
+A plugin is a **JavaScript/TypeScript module** that exports one or more plugin functions. Each function receives a context object and returns a hooks object.
+
+### Dependencies
+
+Local plugins and custom tools can use external npm packages. Add a `package.json` to your config directory with the dependencies you need.
+
+```json title=".opencode/package.json"
+{
+  "dependencies": {
+    "shescape": "^2.1.0"
+  }
+}
+```
+
+OpenCode runs `bun install` at startup to install these. Your plugins and tools can then import them.
+
+```ts title=".opencode/plugins/my-plugin.ts"
+import { escape } from "shescape"
+
+export const MyPlugin = async (ctx) => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "bash") {
+        output.args.command = escape(output.args.command)
+      }
+    },
+  }
+}
+```
+
+### Basic structure
+
+```js title=".opencode/plugins/example.js"
+export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
+  console.log("Plugin initialized!")
+
+  return {
+    // Hook implementations go here
+  }
+}
+```
+
+The plugin function receives:
+
+- `project`: The current project information.
+- `directory`: The current working directory.
+- `worktree`: The git worktree path.
+- `client`: An opencode SDK client for interacting with the AI.
+- `$`: Bun's [shell API](https://bun.com/docs/runtime/shell) for executing commands.
+
+### TypeScript support
+
+For TypeScript plugins, you can import types from the plugin package:
+
+```ts title="my-plugin.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree }) => {
+  return {
+    // Type-safe hook implementations
+  }
+}
+```
+
+### Events
+
+Plugins can subscribe to events as seen below in the Examples section. Here is a list of the different events available.
+
+#### Command Events
+
+- `command.executed`
+
+#### File Events
+
+- `file.edited`
+- `file.watcher.updated`
+
+#### Installation Events
+
+- `installation.updated`
+
+#### LSP Events
+
+- `lsp.client.diagnostics`
+- `lsp.updated`
+
+#### Message Events
+
+- `message.part.removed`
+- `message.part.updated`
+- `message.removed`
+- `message.updated`
+
+#### Permission Events
+
+- `permission.asked`
+- `permission.replied`
+
+#### Server Events
+
+- `server.connected`
+
+#### Session Events
+
+- `session.created`
+- `session.compacted`
+- `session.deleted`
+- `session.diff`
+- `session.error`
+- `session.idle`
+- `session.status`
+- `session.updated`
+
+#### Todo Events
+
+- `todo.updated`
+
+#### Shell Events
+
+- `shell.env`
+
+#### Tool Events
+
+- `tool.execute.after`
+- `tool.execute.before`
+
+#### TUI Events
+
+- `tui.prompt.append`
+- `tui.command.execute`
+- `tui.toast.show`
+
+---
+
+## Examples
+
+Here are some examples of plugins you can use to extend opencode.
+
+### Send notifications
+
+Send notifications when certain events occur:
+
+```js title=".opencode/plugins/notification.js"
+export const NotificationPlugin = async ({ project, client, $, directory, worktree }) => {
+  return {
+    event: async ({ event }) => {
+      // Send notification on session completion
+      if (event.type === "session.idle") {
+        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+      }
+    },
+  }
+}
+```
+
+We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications.
+
+> **Note:** If you're using the OpenCode desktop app, it can send system notifications automatically when a response is ready or when a session errors.
+
+### .env protection
+
+Prevent opencode from reading `.env` files:
+
+```javascript title=".opencode/plugins/env-protection.js"
+export const EnvProtection = async ({ project, client, $, directory, worktree }) => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "read" && output.args.filePath.includes(".env")) {
+        throw new Error("Do not read .env files")
+      }
+    },
+  }
+}
+```
+
+### Inject environment variables
+
+Inject environment variables into all shell execution (AI tools and user terminals):
+
+```javascript title=".opencode/plugins/inject-env.js"
+export const InjectEnvPlugin = async () => {
+  return {
+    "shell.env": async (input, output) => {
+      output.env.MY_API_KEY = "secret"
+      output.env.PROJECT_ROOT = input.cwd
+    },
+  }
+}
+```
+
+### Custom tools
+
+Plugins can also add custom tools to opencode:
+
+```ts title=".opencode/plugins/custom-tools.ts"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+
+export const CustomToolsPlugin: Plugin = async (ctx) => {
+  return {
+    tool: {
+      mytool: tool({
+        description: "This is a custom tool",
+        args: {
+          foo: tool.schema.string(),
+        },
+        async execute(args, context) {
+          const { directory, worktree } = context
+          return `Hello ${args.foo} from ${directory} (worktree: ${worktree})`
+        },
+      }),
+    },
+  }
+}
+```
+
+The `tool` helper creates a custom tool that opencode can call. It takes a Zod schema function and returns a tool definition with:
+
+- `description`: What the tool does
+- `args`: Zod schema for the tool's arguments
+- `execute`: Function that runs when the tool is called
+
+Your custom tools will be available to opencode alongside built-in tools.
+
+> **Note:** If a plugin tool uses the same name as a built-in tool, the plugin tool takes precedence.
+
+### Logging
+
+Use `client.app.log()` instead of `console.log` for structured logging:
+
+```ts title=".opencode/plugins/my-plugin.ts"
+export const MyPlugin = async ({ client }) => {
+  await client.app.log({
+    body: {
+      service: "my-plugin",
+      level: "info",
+      message: "Plugin initialized",
+      extra: { foo: "bar" },
+    },
+  })
+}
+```
+
+Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://opencode.ai/docs/sdk) for details.
+
+### Compaction hooks
+
+Customize the context included when a session is compacted:
+
+```ts title=".opencode/plugins/compaction.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Inject additional context into the compaction prompt
+      output.context.push(`
+## Custom Context
+
+Include any state that should persist across compaction:
+- Current task status
+- Important decisions made
+- Files being actively worked on
+`)
+    },
+  }
+}
+```
+
+The `experimental.session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.
+
+You can also replace the compaction prompt entirely by setting `output.prompt`:
+
+```ts title=".opencode/plugins/custom-compaction.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CustomCompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "experimental.session.compacting": async (input, output) => {
+      // Replace the entire compaction prompt
+      output.prompt = `
+You are generating a continuation prompt for a multi-agent swarm session.
+
+Summarize:
+1. The current task and its status
+2. Which files are being modified and by whom
+3. Any blockers or dependencies between agents
+4. The next steps to complete the work
+
+Format as a structured prompt that a new agent can use to resume work.
+`
+    },
+  }
+}
+```
+
+When `output.prompt` is set, it completely replaces the default compaction prompt. The `output.context` array is ignored in this case.
+
+---
+
+## Plugin type surface (from `@opencode-ai/plugin`, type source `packages/plugin/src/index.ts`)
+
+A plugin's signature and the full handler-key set (not all are shown on the live docs page; verify against the package types):
+
+```ts
+export type Plugin = (input: PluginInput, options?: PluginOptions) => Promise<Hooks>
+
+export type PluginInput = {
+  client: ReturnType<typeof createOpencodeClient> // @opencode-ai/sdk
+  project: Project
+  directory: string
+  worktree: string
+  experimental_workspace: { register(type, adapter): void }
+  serverUrl: URL
+  $: BunShell
+}
+```
+
+**Handler hook keys (the callable keys you return — `interface Hooks`):**
+`dispose`, `event`, `config`, `tool` (a MAP, registers custom tools — not a function),
+`auth`, `provider`, `chat.message`, `chat.params`, `chat.headers`,
+`permission.ask` (output `{ status: "ask" | "deny" | "allow" }`),
+`command.execute.before`,
+`tool.execute.before` (input `{ tool, sessionID, callID }`, output `{ args }`),
+`tool.execute.after` (output `{ title, output, metadata }`),
+`shell.env` (output `{ env }`),
+`tool.definition` (output `{ description, parameters }`),
+and experimental: `experimental.chat.messages.transform`,
+`experimental.chat.system.transform`, `experimental.provider.small_model`,
+`experimental.session.compacting`, `experimental.compaction.autocontinue`,
+`experimental.text.complete`.
+
+There is **no `stop` hook** in the official `Hooks` type.
+
+Exported types: `Plugin, PluginInput, PluginOptions, PluginModule, Hooks, Config, AuthHook, ProviderHook, WorkspaceAdapter`, plus `tool` / `ToolDefinition`.
+
+For the patch tool, check `input.tool === "apply_patch"` and read `output.args.patchText` (not `filePath`).

--- a/skills/opencode-policies/SKILL.md
+++ b/skills/opencode-policies/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: opencode-policies
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode enterprise governance — the `experimental.policies` provider
+  allow/deny layer and the `permission` per-tool gate — for `opencode.json` /
+  `.opencode/`. Use when configuring which LLM providers OpenCode may use,
+  migrating off `disabled_providers`/`enabled_providers`, locking down a fleet,
+  or setting tool permissions (`allow`/`ask`/`deny`) for `bash`, `edit`, `read`,
+  `external_directory`, `doom_loop`, etc. Trigger on mentions of OpenCode
+  policies, `experimental.policies`, `provider.use`, `permission` config, OpenCode
+  `.env` access, doom-loop / external-directory guards, per-agent permission
+  overrides, or "restrict OpenCode to Anthropic only".
+argument-hint: "What governance do you want? (e.g. 'allow only Anthropic provider', 'deny edit but allow docs', 'why can OpenCode still read .env?')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Policies & Permissions
+
+Two **separate** governance layers in OpenCode config. Don't conflate them:
+
+| Layer | Key | Governs | Values |
+|---|---|---|---|
+| **Policies** | `experimental.policies` (array) | *Whether OpenCode may use a resource* — today only **LLM providers** | `effect: allow\|deny` |
+| **Permissions** | `permission` (top-level) | *What tools may do in a session* — per tool, per pattern | `allow` \| `ask` \| `deny` |
+
+> OpenCode's API moves fast and predates the model's training cutoff — before
+> writing policies code, read `references/policies.rst` + `references/permissions.rst`
+> AND re-check https://opencode.ai/docs/policies/ and
+> https://opencode.ai/docs/permissions/ for drift. The official config schema is
+> `https://opencode.ai/config.json`. Policies are still under `experimental.`.
+
+Verbatim docs live in `references/`. This file is the **delta a fresh model gets
+wrong** — read it before authoring, then verify against the references.
+
+---
+
+## Layer 1 — Policies (`experimental.policies`)
+
+The traps that bite, in order of how often a fresh model gets them wrong:
+
+1. **It's nested under `experimental.`, not a top-level `policies` key.**
+   `{ "experimental": { "policies": [ … ] } }`. A bare top-level `"policies"` is
+   silently ignored.
+2. **`provider.use` is the ONLY `action` that exists today.** Policies govern
+   **LLM providers, not tools/commands/permissions.** You cannot deny a tool or a
+   slash command with a policy — that's the permission layer (Layer 2). If you
+   catch yourself writing `"action": "tool.use"` or `"bash"`, you're in the wrong
+   layer.
+3. **Precedence is INVERTED vs normal config merge.** Everywhere else in OpenCode,
+   project config overrides global. For policies, **global beats project** — a repo
+   `opencode.json` *cannot* re-enable a provider the global config denied. This is
+   the enforcement guarantee an enterprise relies on.
+4. **Default-when-no-match is `allow`.** Policies are a denylist by default. To run
+   an allowlist ("only Anthropic"), you must put a broad `deny *` FIRST, then
+   `allow` the specific providers.
+5. **Last-matching statement wins** (within a list). Order broad → specific. With
+   default-allow + last-match-wins, the allowlist idiom is: `deny *` then
+   `allow anthropic`.
+6. **Policies REPLACE the deprecated `disabled_providers` / `enabled_providers`.**
+   Don't emit those legacy keys — translate them:
+   - `disabled_providers: [openai, google]` → one `deny provider.use` per id.
+   - `enabled_providers: [anthropic, openai]` → `deny *` then `allow` each id.
+
+Statement shape (all three fields required):
+
+```json
+{ "effect": "deny", "action": "provider.use", "resource": "openai" }
+```
+
+`resource` is a provider id or wildcard (`*` = zero-or-more chars, `?` = one char),
+e.g. `"company-*"`. See `assets/policies.json` for the allowlist template.
+
+### Allowlist (only Anthropic) — the canonical pattern
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      { "effect": "deny",  "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" }
+    ]
+  }
+}
+```
+
+If you flipped the order (`allow anthropic` then `deny *`), last-match-wins means
+`deny *` wins for *every* provider including Anthropic — nothing works. Broad first.
+
+---
+
+## Layer 2 — Permissions (`permission`)
+
+Per-tool / per-pattern gate over tool **actions** in a session. Three resolved
+states: `allow` (run silently), `ask` (prompt), `deny` (block).
+
+### The non-uniform-defaults trap
+
+There is no single default. A fresh model assumes "everything defaults to allow" —
+wrong on three counts:
+
+| Key | Default | Why it surprises |
+|---|---|---|
+| most tools | `allow` | the baseline |
+| `doom_loop` | **`ask`** | fires when the **same tool repeats 3× with identical input** |
+| `external_directory` | **`ask`** | fires when a tool touches a path **outside the project cwd** |
+| `read` of `.env` | **`deny`** | `*.env` + `*.env.*` deny, `*.env.example` allow |
+
+So "why can't OpenCode read `.env`?" / "why did it pause on the 3rd identical call?"
+are *defaults*, not bugs. To let OpenCode read a secret file you must explicitly
+`allow` it under `read`; to silence the loop guard set `doom_loop: "allow"`.
+
+### Other delta to pin
+
+- **One `edit` permission covers `edit`, `write`, and the patch tool** (named
+  `apply_patch` in OpenCode's built-in tool list; the `/docs/permissions/` page
+  refers to it loosely as "patch"). There is no separate `write` or `patch`
+  permission key.
+- **Last-matching pattern wins** (same as policies). Put `"*"` first, exceptions
+  after. `{ "bash": { "*": "ask", "git *": "allow", "rm *": "deny" } }`.
+- **Pattern needs the trailing wildcard for args.** `"grep *"` matches
+  `grep foo file.txt`; bare `"grep"` matches only the literal word and blocks the
+  call. Commands with arguments require the explicit `*`.
+- `~` / `$HOME` expand at the **start** of a pattern.
+- Full key list (matches against): `read, edit, glob, grep, bash, task, skill,
+  lsp, question, webfetch, websearch, external_directory, doom_loop`. `lsp` is
+  non-granular (no object form). See `references/permissions.rst` for what each
+  matches on.
+- Set everything at once with a string: `"permission": "allow"`.
+
+### Per-agent override
+
+Agent-level permission rules **beat** the top-level `permission` block. This is a
+separate axis from policies — don't assume the policy global>project rule carries
+over to permissions; it doesn't. Override via `agent.<name>.permission` in JSON, or
+`permission:` in a markdown agent's frontmatter:
+
+```yaml
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash: ask
+  webfetch: deny
+---
+Only analyze code and suggest changes.
+```
+
+See `assets/permission.json` for a JSON template with `bash`, `edit`, and a
+per-agent block.
+
+### "Ask" outcomes
+
+When OpenCode prompts: `once` (this request only), `always` (future matching
+requests, **current session only** — not persisted), `reject`.
+
+---
+
+## Quick checklist before you ship a governance config
+
+- Provider lock-down → `experimental.policies`; tool lock-down → `permission`.
+  Never `provider.use` for a tool.
+- Allowlist = `deny *` FIRST, then `allow <id>` (default is allow; last match wins).
+- Enterprise floor goes in **global** config (project can't override policies).
+- Migrating? Delete `disabled_providers`/`enabled_providers`; emit policies instead.
+- Remember the non-uniform permission defaults: `.env` already denied, `doom_loop`
+  + `external_directory` already `ask`.
+- One `edit` key = edit + write + apply_patch.
+- Validate against `https://opencode.ai/config.json` and re-check the live docs.

--- a/skills/opencode-policies/assets/permission.json
+++ b/skills/opencode-policies/assets/permission.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "rm *": "deny"
+    },
+    "edit": {
+      "*": "deny",
+      "packages/web/src/content/docs/*.mdx": "allow"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow"
+    },
+    "doom_loop": "allow",
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    }
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git *": "allow",
+          "git push *": "deny"
+        }
+      }
+    }
+  }
+}

--- a/skills/opencode-policies/assets/policies.json
+++ b/skills/opencode-policies/assets/policies.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" }
+    ]
+  }
+}

--- a/skills/opencode-policies/references/permissions.rst
+++ b/skills/opencode-policies/references/permissions.rst
@@ -1,0 +1,200 @@
+<!-- Source: https://opencode.ai/docs/permissions/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode permissions code. -->
+
+# Permissions (OpenCode)
+
+## Overview
+
+OpenCode uses permission configuration to control whether actions run automatically, require approval, or are blocked. The system resolves each permission rule to one of three states:
+
+- `"allow"` — execute without approval
+- `"ask"` — prompt user for approval
+- `"deny"` — block the action
+
+## Configuration Structure
+
+### Global and Tool-Specific Permissions
+
+Permissions can be set globally using `"*"` and overridden for specific tools:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "*": "ask",
+    "bash": "allow",
+    "edit": "deny"
+  }
+}
+```
+
+Alternatively, set all permissions uniformly:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": "allow"
+}
+```
+
+## Granular Rules (Object Syntax)
+
+Most permissions support object-based rules that apply different actions based on tool input:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "npm *": "allow",
+      "rm *": "deny",
+      "grep *": "allow"
+    },
+    "edit": {
+      "*": "deny",
+      "packages/web/src/content/docs/*.mdx": "allow"
+    }
+  }
+}
+```
+
+**Evaluation Rule:** Last matching pattern wins. Place catch-all `"*"` first, then more specific rules.
+
+### Wildcard Matching
+
+- `*` — zero or more characters
+- `?` — exactly one character
+- All other characters match literally
+
+### Home Directory Expansion
+
+Patterns support `~` or `$HOME` at the start:
+
+- `~/projects/*` → `/Users/username/projects/*`
+- `$HOME/projects/*` → `/Users/username/projects/*`
+- `~` → `/Users/username`
+
+### External Directories
+
+The `external_directory` permission allows tool calls affecting paths outside the project working directory. This applies to tools accepting path inputs (read, edit, glob, grep, bash commands):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    }
+  }
+}
+```
+
+Allowed directories inherit workspace defaults. Add explicit denial rules when restricting specific tools:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/projects/personal/**": "allow"
+    },
+    "edit": {
+      "~/projects/personal/**": "deny"
+    }
+  }
+}
+```
+
+## Available Permissions
+
+- `read` — reading files (matches file path)
+- `edit` — file modifications (covers edit, write, patch)
+- `glob` — file globbing (matches glob pattern)
+- `grep` — content search (matches regex pattern)
+- `bash` — shell command execution (matches parsed commands)
+- `task` — launching subagents (matches subagent type)
+- `skill` — loading skills (matches skill name)
+- `lsp` — running LSP queries (non-granular)
+- `question` — asking users during execution
+- `webfetch` — URL fetching (matches URL)
+- `websearch` — web search (matches query)
+- `external_directory` — triggered when tools access paths outside project
+- `doom_loop` — triggered when same tool repeats 3 times with identical input
+
+## Default Permissions
+
+```json
+{
+  "permission": {
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow"
+    }
+  }
+}
+```
+
+- Most permissions default to `"allow"`
+- `doom_loop` and `external_directory` default to `"ask"`
+- `.env` files are denied by default
+
+## "Ask" Behavior
+
+When OpenCode prompts for approval, three outcomes are available:
+
+- `once` — approve only this request
+- `always` — approve future matching requests (current session only)
+- `reject` — deny the request
+
+Tools provide suggested patterns for `always` approval (e.g., bash suggests command prefixes like `git status*`).
+
+## Agent-Level Overrides
+
+Agent permissions override global configuration. Agent rules take precedence:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "bash": {
+      "*": "ask",
+      "git *": "allow",
+      "git commit *": "deny",
+      "git push *": "deny",
+      "grep *": "allow"
+    }
+  },
+  "agent": {
+    "build": {
+      "permission": {
+        "bash": {
+          "*": "ask",
+          "git *": "allow",
+          "git commit *": "ask",
+          "git push *": "deny",
+          "grep *": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+Markdown-based agent permissions:
+
+```yaml
+---
+description: Code review without edits
+mode: subagent
+permission:
+  edit: deny
+  bash: ask
+  webfetch: deny
+---
+Only analyze code and suggest changes.
+```
+
+**Note on pattern matching:** Commands with arguments require explicit patterns. `"grep *"` permits `grep pattern file.txt`, while `"grep"` alone blocks it.

--- a/skills/opencode-policies/references/policies.rst
+++ b/skills/opencode-policies/references/policies.rst
@@ -1,0 +1,118 @@
+<!-- Source: https://opencode.ai/docs/policies/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode policies code. -->
+
+# Policies (OpenCode)
+
+## Overview
+
+Policies control which configured resources OpenCode may use. They are configured via the `experimental.policies` array in `opencode.json` and function separately from permissions — permissions govern tool capabilities during sessions, while policies regulate resource access like LLM providers.
+
+## Configuration Structure
+
+Each policy statement requires three fields:
+
+- **`effect`** — `"allow"` or `"deny"`
+- **`action`** — The operation being controlled
+- **`resource`** — Resource ID or wildcard pattern
+
+### Example: Deny OpenAI Provider
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "openai"
+      }
+    ]
+  }
+}
+```
+
+A denied provider becomes unavailable for model selection or use, regardless of configuration status.
+
+## Supported Policy Actions
+
+| Action | Resource | Description |
+|--------|----------|-------------|
+| `provider.use` | Provider ID (e.g., `openai`) | Allow/deny LLM provider usage |
+
+## Wildcard Matching
+
+The `resource` field supports wildcards: `*` matches zero or more characters; `?` matches one character.
+
+```json
+{
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "company-*"
+      }
+    ]
+  }
+}
+```
+
+## Rule Precedence
+
+**Last matching rule wins.** Place broad rules first, then specific exceptions after them.
+
+### Allow Only Anthropic
+
+```json
+{
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "*"
+      },
+      {
+        "effect": "allow",
+        "action": "provider.use",
+        "resource": "anthropic"
+      }
+    ]
+  }
+}
+```
+
+Default behavior: provider use is allowed if no policy matches.
+
+**Priority hierarchy:** Global policies override project policies, preventing repository-level re-enablement of globally denied providers.
+
+## Provider Lists Migration
+
+Replace legacy `disabled_providers` and `enabled_providers` settings with policies.
+
+### Replace `disabled_providers`
+
+```json
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "openai" },
+      { "effect": "deny", "action": "provider.use", "resource": "google" }
+    ]
+  }
+}
+```
+
+### Replace `enabled_providers`
+
+```json
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" },
+      { "effect": "allow", "action": "provider.use", "resource": "openai" }
+    ]
+  }
+}
+```

--- a/skills/opencode-sdk/SKILL.md
+++ b/skills/opencode-sdk/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: opencode-sdk
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Drive OpenCode (the SST coding agent, opencode.ai) programmatically — the
+  @opencode-ai/sdk JS/TS client, the github.com/sst/opencode-sdk-go Go client,
+  and the `opencode serve` HTTP/OpenAPI server it talks to. Use when building an
+  integration on top of OpenCode, calling createOpencode / createOpencodeClient,
+  running `opencode serve`, hitting the OpenAPI spec at /doc, listing or prompting
+  sessions over HTTP, wiring OPENCODE_SERVER_PASSWORD auth, requesting structured
+  (json_schema) output, or using opencode.NewClient / Session.List / the Field
+  param wrappers in Go. NOT OpenAI Codex; NOT the opencode.ai/docs/go Zen
+  subscription.
+argument-hint: "What do you want to build on the OpenCode SDK/server? (e.g. 'prompt a session over HTTP and get JSON back', 'spin up a server from Node', 'list sessions in Go')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode SDK & server
+
+Control OpenCode the way the TUI does: the TUI is itself a client of the `opencode serve`
+HTTP server, so the SDK can do anything the TUI does. SDK types are **generated from the
+server's OpenAPI 3.1 spec** — the spec at `/doc` is the real contract; the SDK is a typed
+shell over it.
+
+> **OpenCode's API moves fast and predates the model's training cutoff** — before writing
+> sdk code, read `references/sdk.rst` (+ `server.rst`, `go.rst`) AND re-check
+> <https://opencode.ai/docs/sdk/> for drift. Pin versions; don't trust memory of method names.
+
+## Pick your entry point
+
+| You want to… | Use | From |
+|---|---|---|
+| Spawn a server **and** get a client in one Node call | **`createOpencode()`** | `@opencode-ai/sdk` |
+| Connect to an **already-running** server | **`createOpencodeClient({ baseUrl })`** | `@opencode-ai/sdk` |
+| Drive from Go | **`opencode.NewClient()`** | `github.com/sst/opencode-sdk-go` |
+| Talk raw HTTP / any language | `opencode serve` + the endpoints in `references/server.rst` | OpenAPI at `/doc` |
+
+> **There is NO `createOpencodeServer`.** It appears only in third-party material and is
+> not on the official SDK page. The canonical JS surface is exactly two factories:
+> `createOpencode` (server + client) and `createOpencodeClient` (client only). Do not
+> propagate `createOpencodeServer`.
+
+## Version pins (record + verify current)
+
+| Thing | Pin | Note |
+|---|---|---|
+| Go SDK module | `github.com/sst/opencode-sdk-go@v0.19.2` | **official path** — other namesake Go modules exist; verify this one |
+| Go toolchain | **Go 1.22+** | required by the SDK |
+| JS package | `@opencode-ai/sdk` | `npm install @opencode-ai/sdk` |
+| Plugin/tool types | `@opencode-ai/plugin` | for in-plugin clients (see `/opencode-dev:plugin`) |
+
+`createOpencode`'s `client` is the same type as `PluginInput.client` — code written here
+is reusable inside a plugin.
+
+## `opencode serve` — the server
+
+```
+opencode serve [--port 4096] [--hostname 127.0.0.1] [--cors <origin>] [--mdns] [--mdns-domain <d>]
+```
+
+- Defaults: **port `4096`, host `127.0.0.1`** (loopback-only — not exposed to the network).
+- **Auth is opt-in via env, not flags:** set `OPENCODE_SERVER_PASSWORD` to require HTTP basic
+  auth; username defaults to `opencode` (override with `OPENCODE_SERVER_USERNAME`). No password
+  set ⇒ no auth.
+- `--cors` is **repeatable** (pass once per origin); browsers need it, server-to-server doesn't.
+- **OpenAPI 3.1 spec lives at `GET /doc`** — fetch it to regenerate types or to find any
+  endpoint not yet wrapped by the SDK. This is the source of truth, not this file.
+
+Endpoint traps (full list in `references/server.rst`):
+- Health is **`GET /global/health`** (returns `{ healthy, version }`), not `/health`.
+- Send-and-wait is `POST /session/:id/message`; fire-and-forget is **`POST /session/:id/prompt_async`**.
+- Search is `GET /find?pattern=`, files `GET /find/file?query=`, symbols `GET /find/symbol?query=`,
+  read `GET /file/content?path=`.
+- SSE event stream: `GET /event` (per-session) / `GET /global/event`.
+
+## JS/TS client
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+const { client, server } = await createOpencode()   // server.url, server.close()
+```
+
+`createOpencode` options: `hostname` (`127.0.0.1`), `port` (`4096`), `timeout` (`5000`),
+`signal`, `config` (an inline `Config` that **overrides `opencode.json`**). Always
+`await server.close()` when done — the factory owns the spawned process.
+
+`createOpencodeClient` options: `baseUrl` (`http://localhost:4096`), `fetch`, `parseAs`,
+**`responseStyle`** (`"data"` | `"fields"`), **`throwOnError`** (bool). Default style returns
+`{ data, ... }` — note results are accessed as **`result.data.…`** (e.g.
+`result.data.info.structured_output`), so a missing `.data` is the usual "why is my field
+undefined" bug.
+
+API surfaces are **namespaced objects**, not flat: `client.global.health()`,
+`client.app.log()/agents()`, `client.project.list()/current()`, `client.session.*`
+(`list/get/create/update/delete/prompt/command/shell/messages/abort/share/init/revert/…`),
+`client.find.text/files/symbols`, `client.file.read/status`, `client.tui.*`,
+`client.auth.set`, `client.event.subscribe()`. Full method list in `references/sdk.rst`.
+
+### Structured output (the json_schema path)
+
+```javascript
+const result = await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    parts: [{ type: "text", text: "…" }],
+    format: { type: "json_schema", schema: { /* JSON Schema */ }, retryCount: 2 },
+  },
+})
+result.data.info.structured_output            // the parsed object
+result.data.info.error?.name === "StructuredOutputError"  // check this before reading output
+```
+
+- `format.type` is `"text"` (default) or **`"json_schema"`**; the schema goes in
+  `format.schema`, retries in `format.retryCount` (default `2`).
+- Under the hood the model is forced through a `StructuredOutput` tool. On failure
+  `info.error.name === "StructuredOutputError"` (with `.message`, `.retries`) — **the call
+  still resolves**, so guard on the error field rather than a `try/catch`.
+
+See `assets/hello-sdk.ts` for a runnable spawn → prompt → structured-output → close flow.
+
+## Go client
+
+```go
+import "github.com/sst/opencode-sdk-go"
+client := opencode.NewClient()
+sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+```
+
+- **Every request param is wrapped in a `Field`** to separate zero/null/omitted. Build with
+  `opencode.F(v)`, `opencode.Null[T]()`, `opencode.Raw[T](any)` (and `String/Int/Float`
+  helpers). A bare `""`/`0` is **not sent** unless wrapped — forgetting `F()` silently omits it.
+- Response fields are plain value types; inspect presence via the per-field
+  `res.JSON.<Field>.IsNull()/IsMissing()/IsInvalid()` and undocumented keys via
+  `res.JSON.ExtraFields[...]`.
+- Errors: `errors.As(err, &apiErr)` into **`*opencode.Error`** (`StatusCode`,
+  `DumpRequest/DumpResponse`). Retries default to **2** (connection errors, 408/409/429/≥500);
+  **no default timeout** — set one via `context` + `option.WithRequestTimeout()`.
+- Reach undocumented endpoints with `client.Get/Post(...)` and `option.WithJSONSet/WithQuerySet`.
+
+`NewClient()` targets `127.0.0.1:4096` by default; configure base URL/headers/auth via the
+`option` package. See `assets/hello-sdk.go`. Full API in the SDK's own `api.md`.
+
+## Traps to avoid
+
+- ⚠️ **`opencode.ai/docs/go/` is the wrong page for the Go SDK** — it documents the paid
+  "OpenCode Zen Go" model subscription, not the library. The Go *SDK* is
+  `github.com/sst/opencode-sdk-go` (see `references/go.rst`).
+- ⚠️ **This is SST OpenCode, not OpenAI Codex.** Don't import Codex/`app-server` APIs.
+- ⚠️ No `createOpencodeServer`; no Python package is officially verified (JS/TS + Go only).
+- ⚠️ JS results are under **`result.data`** (default `responseStyle`); structured-output
+  failures surface as `info.error`, not a thrown exception (unless `throwOnError`).
+
+## Reference & example files
+
+| File | Contents |
+|---|---|
+| [references/sdk.rst](references/sdk.rst) | JS/TS SDK — factories, options, all `client.*` methods, structured output |
+| [references/server.rst](references/server.rst) | `opencode serve` flags, env auth, full endpoint list, OpenAPI `/doc` |
+| [references/go.rst](references/go.rst) | Go SDK — install/pin, `NewClient`, `Field` wrappers, errors, retries, options |
+| [assets/hello-sdk.ts](assets/hello-sdk.ts) | Node: spawn server → create session → structured prompt → close |
+| [assets/hello-sdk.go](assets/hello-sdk.go) | Go: `NewClient` → `Session.List` with `*opencode.Error` handling |
+
+Related facets: programmatic tool/hook code → `/opencode-dev:plugin`; delegating from a
+Claude Code plugin (ACP / `serve` / `opencode run`) → `/opencode-dev:delegate`.

--- a/skills/opencode-sdk/assets/hello-sdk.go
+++ b/skills/opencode-sdk/assets/hello-sdk.go
@@ -1,5 +1,5 @@
 // Drive OpenCode from Go via the official SDK.
-// Verify the surface in references/go.md and re-check github.com/sst/opencode-sdk-go for drift.
+// Verify the surface in references/go.rst and re-check github.com/sst/opencode-sdk-go for drift.
 //
 // Official module (NOT the anomalyco/manno23 forks):
 //   go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'   // requires Go 1.22+

--- a/skills/opencode-sdk/assets/hello-sdk.go
+++ b/skills/opencode-sdk/assets/hello-sdk.go
@@ -1,0 +1,34 @@
+// Drive OpenCode from Go via the official SDK.
+// Verify the surface in references/go.md and re-check github.com/sst/opencode-sdk-go for drift.
+//
+// Official module (NOT the anomalyco/manno23 forks):
+//   go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'   // requires Go 1.22+
+//
+// NewClient() targets a running `opencode serve` (default http://127.0.0.1:4096).
+// Point it elsewhere or add auth with option.With* (e.g. option.WithBaseURL,
+// option.WithHeader for OPENCODE_SERVER_PASSWORD basic auth).
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sst/opencode-sdk-go"
+)
+
+func main() {
+	client := opencode.NewClient()
+
+	sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+	if err != nil {
+		// All request params are wrapped in opencode.F(...) / Null[T]() / Raw[T]().
+		var apiErr *opencode.Error
+		if errors.As(err, &apiErr) {
+			fmt.Println(string(apiErr.DumpRequest(true)))
+		}
+		panic(err.Error())
+	}
+
+	fmt.Printf("%+v\n", sessions)
+}

--- a/skills/opencode-sdk/assets/hello-sdk.ts
+++ b/skills/opencode-sdk/assets/hello-sdk.ts
@@ -1,0 +1,45 @@
+// Drive OpenCode from JS/TS via @opencode-ai/sdk.
+// Verify the surface in references/sdk.md and re-check https://opencode.ai/docs/sdk/ for drift.
+//   npm install @opencode-ai/sdk
+//
+// createOpencode() spawns `opencode serve` AND returns a connected client.
+// To attach to an already-running server instead, use:
+//   import { createOpencodeClient } from "@opencode-ai/sdk"
+//   const client = createOpencodeClient({ baseUrl: "http://localhost:4096" })
+// There is NO createOpencodeServer in the official SDK — do not use it.
+
+import { createOpencode } from "@opencode-ai/sdk"
+
+const { client, server } = await createOpencode({ hostname: "127.0.0.1", port: 4096 })
+
+try {
+  const health = await client.global.health() // { healthy: true, version }
+  console.log("server", server.url, health)
+
+  const session = await client.session.create({ body: {} })
+  const id = session.data.id
+
+  // Structured output: model is forced through a json_schema StructuredOutput tool.
+  const result = await client.session.prompt({
+    path: { id },
+    body: {
+      parts: [{ type: "text", text: "Summarize this repo in one sentence." }],
+      format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { summary: { type: "string" } },
+          required: ["summary"],
+        },
+      },
+    },
+  })
+
+  if (result.data.info.error?.name === "StructuredOutputError") {
+    console.error("structured output failed:", result.data.info.error.message)
+  } else {
+    console.log(result.data.info.structured_output)
+  }
+} finally {
+  await server.close()
+}

--- a/skills/opencode-sdk/assets/hello-sdk.ts
+++ b/skills/opencode-sdk/assets/hello-sdk.ts
@@ -1,5 +1,5 @@
 // Drive OpenCode from JS/TS via @opencode-ai/sdk.
-// Verify the surface in references/sdk.md and re-check https://opencode.ai/docs/sdk/ for drift.
+// Verify the surface in references/sdk.rst and re-check https://opencode.ai/docs/sdk/ for drift.
 //   npm install @opencode-ai/sdk
 //
 // createOpencode() spawns `opencode serve` AND returns a connected client.

--- a/skills/opencode-sdk/references/go.rst
+++ b/skills/opencode-sdk/references/go.rst
@@ -1,0 +1,177 @@
+<!-- Source: https://github.com/sst/opencode-sdk-go (README, main) — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+> TRAP: `https://opencode.ai/docs/go/` is NOT the Go SDK — it documents the "OpenCode Zen Go" subscription (curated coding models, billing). The Go *SDK* truth is this repo: `github.com/sst/opencode-sdk-go`. Full API in its `api.md`.
+
+# Opencode Go API Library
+
+The Opencode Go library provides convenient access to the [Opencode REST API](https://opencode.ai/docs) from applications written in Go. Generated with Stainless.
+
+## Installation
+
+```go
+import (
+	"github.com/sst/opencode-sdk-go" // imported as opencode
+)
+```
+
+Pin the version:
+
+```sh
+go get -u 'github.com/sst/opencode-sdk-go@v0.19.2'
+```
+
+## Requirements
+
+This library requires Go 1.22+.
+
+## Usage
+
+The full API of this library can be found in `api.md`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sst/opencode-sdk-go"
+)
+
+func main() {
+	client := opencode.NewClient()
+	sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+	if err != nil {
+		panic(err.Error())
+	}
+	fmt.Printf("%+v\n", sessions)
+}
+```
+
+### Request fields
+
+All request parameters are wrapped in a generic `Field` type, used to distinguish zero values from null or omitted fields. Construct fields with `String()`, `Int()`, `Float()`, or the generic `F[T]()`. To send a null, use `Null[T]()`; to send a nonconforming value, use `Raw[T](any)`. Any field not specified is not sent.
+
+```go
+params := FooParams{
+	Name: opencode.F("hello"),
+
+	// Explicitly send `"description": null`
+	Description: opencode.Null[string](),
+
+	Point: opencode.F(opencode.Point{
+		X: opencode.Int(0),
+		Y: opencode.Int(1),
+
+		// In cases where the API specifies a given type,
+		// but you want to send something else, use `Raw`:
+		Z: opencode.Raw[int64](0.01), // sends a float
+	}),
+}
+```
+
+### Response objects
+
+All fields in response structs are value types (not pointers or wrappers). If a field is `null`, not present, or invalid, it is its zero value. Each response struct includes a special `JSON` field:
+
+```go
+if res.Name == "" {
+	res.JSON.Name.IsNull()    // true if `"name"` is not present or explicitly null
+	res.JSON.Name.IsMissing() // true if the `"name"` key was not present at all
+	if res.JSON.Name.IsInvalid() {
+		raw := res.JSON.Name.Raw()
+		// ...
+	}
+}
+```
+
+`.JSON` structs include an `Extras`/`ExtraFields` map for properties not in the struct:
+
+```go
+body := res.JSON.ExtraFields["my_unexpected_field"].Raw()
+```
+
+### RequestOptions (functional options pattern)
+
+Functions in the `option` package return a `RequestOption`. Supply to client or per-request:
+
+```go
+client := opencode.NewClient(
+	option.WithHeader("X-Some-Header", "custom_header_info"),
+)
+
+client.Session.List(context.TODO(), ...,
+	option.WithHeader("X-Some-Header", "some_other_custom_header_info"),
+	option.WithJSONSet("some.json.path", map[string]string{"my": "object"}),
+)
+```
+
+### Pagination
+
+`.ListAutoPaging()` iterates items across all pages; `.List()` fetches a single page with helpers like `.GetNextPage()`.
+
+### Errors
+
+Non-success status codes return `*opencode.Error` (with `StatusCode`, `*http.Request`, `*http.Response`). Use `errors.As`:
+
+```go
+_, err := client.Session.List(context.TODO(), opencode.SessionListParams{})
+if err != nil {
+	var apierr *opencode.Error
+	if errors.As(err, &apierr) {
+		println(string(apierr.DumpRequest(true)))  // serialized HTTP request
+		println(string(apierr.DumpResponse(true))) // serialized HTTP response
+	}
+	panic(err.Error()) // GET "/session": 400 Bad Request { ... }
+}
+```
+
+### Timeouts
+
+Requests do not time out by default; use context. Per-retry timeout via `option.WithRequestTimeout()`:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+defer cancel()
+client.Session.List(ctx, opencode.SessionListParams{},
+	option.WithRequestTimeout(20*time.Second),
+)
+```
+
+### File uploads
+
+Parameters for file uploads are typed `param.Field[io.Reader]`. Default multipart file name `anonymous_file`, content-type `application/octet-stream`. Helper: `opencode.FileParam(reader io.Reader, filename string, contentType string)`.
+
+### Retries
+
+Retries 2 times by default (connection errors, 408, 409, 429, >=500). Configure with `option.WithMaxRetries()`:
+
+```go
+client := opencode.NewClient(option.WithMaxRetries(0)) // default is 2
+client.Session.List(context.TODO(), opencode.SessionListParams{}, option.WithMaxRetries(5))
+```
+
+### Accessing raw response data
+
+```go
+var response *http.Response
+sessions, err := client.Session.List(context.TODO(), opencode.SessionListParams{},
+	option.WithResponseInto(&response))
+fmt.Printf("Status Code: %d\n", response.StatusCode)
+```
+
+### Custom/undocumented requests
+
+Use `client.Get`, `client.Post`, etc. for undocumented endpoints; `option.WithQuerySet()` / `option.WithJSONSet()` for undocumented params; `result.JSON.RawJSON()` / `result.JSON.Foo.Raw()` for undocumented response properties.
+
+### Middleware
+
+```go
+func Logger(req *http.Request, next option.MiddlewareNext) (res *http.Response, err error) {
+	res, err = next(req)
+	return res, err
+}
+client := opencode.NewClient(option.WithMiddleware(Logger))
+```
+
+Replace the default `http.Client` with `option.WithHTTPClient(client)`.

--- a/skills/opencode-sdk/references/sdk.rst
+++ b/skills/opencode-sdk/references/sdk.rst
@@ -1,0 +1,178 @@
+<!-- Source: https://opencode.ai/docs/sdk/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+# OpenCode SDK
+
+A type-safe JS client for interacting with the OpenCode server, to build integrations and control it programmatically. The TUI is itself a client, so the SDK can do anything the TUI does. SDK types are generated from the server's OpenAPI 3.1 spec.
+
+## Installation
+
+```
+npm install @opencode-ai/sdk
+```
+
+## Client Creation
+
+### Full instance — `createOpencode()` (starts server + client)
+
+```javascript
+import { createOpencode } from "@opencode-ai/sdk"
+const { client } = await createOpencode()
+```
+
+Options:
+- `hostname` (string, default: `127.0.0.1`)
+- `port` (number, default: `4096`)
+- `signal` (AbortSignal)
+- `timeout` (number, default: `5000`)
+- `config` (Config object)
+
+Returns an object exposing the `client` plus the spawned server (`server.url`, `server.close()`).
+
+### Client-only connection — `createOpencodeClient({ baseUrl })`
+
+```javascript
+import { createOpencodeClient } from "@opencode-ai/sdk"
+const client = createOpencodeClient({
+  baseUrl: "http://localhost:4096",
+})
+```
+
+Options:
+- `baseUrl` (string, default: `http://localhost:4096`)
+- `fetch` (custom function)
+- `parseAs` (string)
+- `responseStyle` (string: `data` or `fields`)
+- `throwOnError` (boolean)
+
+> NOTE: `createOpencodeServer` does NOT appear on the official SDK page. The canonical surface is `createOpencode` + `createOpencodeClient`.
+
+## Configuration
+
+Configuration can be passed inline, overriding `opencode.json`:
+
+```javascript
+const opencode = await createOpencode({
+  hostname: "127.0.0.1",
+  port: 4096,
+  config: {
+    model: "anthropic/claude-3-5-sonnet-20241022",
+  },
+})
+```
+
+## Types
+
+```javascript
+import type { Session, Message, Part } from "@opencode-ai/sdk"
+```
+
+## Structured Output
+
+Format types:
+- `text` – Standard text response (default)
+- `json_schema` – Validated JSON matching provided schema
+
+`json_schema` format fields:
+- `type` (required): `'json_schema'`
+- `schema` (required): JSON Schema object
+- `retryCount` (optional): Validation retry attempts (default: 2)
+
+```javascript
+const result = await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    parts: [{ type: "text", text: "Research Anthropic and provide company info" }],
+    format: {
+      type: "json_schema",
+      schema: {
+        type: "object",
+        properties: {
+          company: { type: "string", description: "Company name" },
+          founded: { type: "number", description: "Year founded" },
+          products: {
+            type: "array",
+            items: { type: "string" },
+            description: "Main products",
+          },
+        },
+        required: ["company", "founded"],
+      },
+    },
+  },
+})
+console.log(result.data.info.structured_output)
+```
+
+Error handling:
+
+```javascript
+if (result.data.info.error?.name === "StructuredOutputError") {
+  console.error("Failed to produce structured output:", result.data.info.error.message)
+  console.error("Attempts:", result.data.info.error.retries)
+}
+```
+
+## API Methods
+
+### Global
+- `global.health()` – Returns `{ healthy: true, version: string }`
+
+### App
+- `app.log()` – Write log entry (returns `boolean`)
+- `app.agents()` – List available agents (returns `Agent[]`)
+
+### Project
+- `project.list()` – List all projects (returns `Project[]`)
+- `project.current()` – Get current project (returns `Project`)
+
+### Path
+- `path.get()` – Get current path info (returns `Path`)
+
+### Config
+- `config.get()` – Get config info (returns `Config`)
+- `config.providers()` – List providers and defaults
+
+### Sessions
+- `session.list()`
+- `session.get({ path })`
+- `session.children({ path })`
+- `session.create({ body })`
+- `session.delete({ path })`
+- `session.update({ path, body })`
+- `session.init({ path, body })` – Analyze app, create `AGENTS.md`
+- `session.abort({ path })`
+- `session.share({ path })`
+- `session.unshare({ path })`
+- `session.summarize({ path, body })`
+- `session.messages({ path })`
+- `session.message({ path })`
+- `session.prompt({ path, body })` – Supports `noReply: true` and `outputFormat`
+- `session.command({ path, body })`
+- `session.shell({ path, body })`
+- `session.revert({ path, body })`
+- `session.unrevert({ path })`
+- `postSessionByIdPermissionsByPermissionId({ path, body })`
+
+### Files
+- `find.text({ query })` – Search text in files
+- `find.files({ query })` – Find files/directories by name (query supports `type` ("file"/"directory"), `directory`, `limit` 1–200)
+- `find.symbols({ query })` – Find workspace symbols
+- `file.read({ query })` – Read file content
+- `file.status({ query? })` – Get tracked file status
+
+### TUI
+- `tui.appendPrompt({ body })`
+- `tui.openHelp()`
+- `tui.openSessions()`
+- `tui.openThemes()`
+- `tui.openModels()`
+- `tui.submitPrompt()`
+- `tui.clearPrompt()`
+- `tui.executeCommand({ body })`
+- `tui.showToast({ body })`
+
+### Auth
+- `auth.set({ ... })` – Set authentication credentials
+
+### Events
+- `event.subscribe()` – Server-sent events stream

--- a/skills/opencode-sdk/references/server.rst
+++ b/skills/opencode-sdk/references/server.rst
@@ -1,0 +1,133 @@
+<!-- Source: https://opencode.ai/docs/server/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode sdk code. -->
+
+# OpenCode Server
+
+OpenCode Server is a headless HTTP service that exposes an OpenAPI endpoint for programmatic interaction. The `opencode serve` command starts this server.
+
+## Usage
+
+```
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--port` | Port to listen on | `4096` |
+| `--hostname` | Hostname to listen on | `127.0.0.1` |
+| `--mdns` | Enable mDNS discovery | `false` |
+| `--mdns-domain` | Custom domain name for mDNS service | `opencode.local` |
+| `--cors` | Additional browser origins to allow | `[]` |
+
+Pass `--cors` multiple times for multiple origins:
+
+```
+opencode serve --cors http://localhost:5173 --cors https://app.example.com
+```
+
+## Authentication
+
+Set environment variables to protect the server:
+- `OPENCODE_SERVER_PASSWORD` — required password
+- `OPENCODE_SERVER_USERNAME` — defaults to `opencode`
+
+```
+OPENCODE_SERVER_PASSWORD=your-password opencode serve
+```
+
+## API Specification
+
+Access the OpenAPI 3.1 spec at: `http://<hostname>:<port>/doc`
+
+## Core API Endpoints
+
+### Global
+- `GET /global/health` — Server health/version
+- `GET /global/event` — Global events (SSE stream)
+
+### Project
+- `GET /project` — List all projects
+- `GET /project/current` — Current project
+
+### Path & VCS
+- `GET /path` — Current path
+- `GET /vcs` — VCS info
+
+### Config
+- `GET /config` — Get config
+- `PATCH /config` — Update config
+- `GET /config/providers` — List providers
+
+### Provider
+- `GET /provider` — List providers
+- `GET /provider/auth` — Auth methods
+- `POST /provider/{id}/oauth/authorize` — OAuth authorization
+- `POST /provider/{id}/oauth/callback` — OAuth callback
+
+### Sessions
+- `GET /session` — List sessions
+- `POST /session` — Create session
+- `GET /session/:id` — Get session
+- `DELETE /session/:id` — Delete session
+- `PATCH /session/:id` — Update session
+- `POST /session/:id/abort` — Abort session
+- `POST /session/:id/fork` — Fork session
+- `POST /session/:id/init` — Initialize/analyze app
+- `GET /session/:id/diff` — Get session diff
+- `POST /session/:id/share` — Share session
+- `DELETE /session/:id/share` — Unshare session
+- `POST /session/:id/revert` — Revert message
+- `POST /session/:id/unrevert` — Restore reverted messages
+
+### Messages
+- `GET /session/:id/message` — List messages
+- `POST /session/:id/message` — Send message (wait for response)
+- `GET /session/:id/message/:messageID` — Get message
+- `POST /session/:id/prompt_async` — Send async message
+- `POST /session/:id/command` — Execute slash command
+- `POST /session/:id/shell` — Run shell command
+
+### Commands
+- `GET /command` — List all commands
+
+### Files
+- `GET /find?pattern=<pat>` — Search text in files
+- `GET /find/file?query=<q>` — Find files/directories
+- `GET /find/symbol?query=<q>` — Find workspace symbols
+- `GET /file?path=<path>` — List files
+- `GET /file/content?path=<p>` — Read file
+- `GET /file/status` — Get tracked file status
+
+### Tools (Experimental)
+- `GET /experimental/tool/ids` — List tool IDs
+- `GET /experimental/tool?provider=<p>&model=<m>` — List tools with schemas
+
+### LSP, Formatters & MCP
+- `GET /lsp` — LSP server status
+- `GET /formatter` — Formatter status
+- `GET /mcp` — MCP server status
+- `POST /mcp` — Add MCP server dynamically
+
+### Agents
+- `GET /agent` — List available agents
+
+### Logging
+- `POST /log` — Write log entry
+
+### TUI
+- `POST /tui/append-prompt` — Append prompt text
+- `POST /tui/submit-prompt` — Submit prompt
+- `POST /tui/clear-prompt` — Clear prompt
+- `POST /tui/execute-command` — Execute command
+- `POST /tui/show-toast` — Show notification
+- `POST /tui/open-help` — Open help
+- `POST /tui/open-sessions` — Open session selector
+- `POST /tui/open-themes` — Open theme selector
+- `POST /tui/open-models` — Open model selector
+
+### Auth
+- `PUT /auth/:id` — Set authentication credentials
+
+### Events
+- `GET /event` — Server-sent events stream

--- a/skills/opencode-skill/SKILL.md
+++ b/skills/opencode-skill/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: opencode-skill
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Author OpenCode Agent Skills (SKILL.md) and wire external References for the
+  SST OpenCode coding agent (opencode.ai, github.com/sst/opencode — NOT OpenAI
+  Codex). Covers the on-demand `skill` tool, the `permission.skill` glob gate vs
+  the `tools.skill: false` kill-switch, the name-matches-directory + regex rule,
+  the six discovery paths, and the `references` config key (named external roots
+  via `@alias`). Use when the user mentions an OpenCode SKILL.md, `.opencode/skills/`,
+  `.claude/skills/` drop-in compatibility, `skill({ name })`, the `skill` permission,
+  `<available_skills>`, the `references` key, `@alias`, or making a Claude Code skill
+  work in OpenCode.
+argument-hint: "What OpenCode skill or reference are you authoring? (e.g. 'add a git-release SKILL.md', 'expose ../docs as @docs', 'why isn't my skill loading')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode Agent Skills + References
+
+Author OpenCode **Agent Skills** (`SKILL.md` instruction bundles loaded on demand) and
+**References** (external dirs/repos attached via `@alias`). OpenCode is SST's open-source
+coding agent — **not OpenAI Codex** — and its skill format is Claude-Code-compatible by
+design, which is exactly where the wrong assumptions creep in.
+
+> **Verify-canonical guard.** OpenCode's API moves fast and predates the model's training
+> cutoff — before writing skill code, read `references/skills.rst` (and `references/references.rst`
+> for the `references` key) AND re-check <https://opencode.ai/docs/skills/> for drift.
+
+---
+
+## The big shortcut: Claude Code skills are drop-in
+
+OpenCode reads `.claude/skills/<name>/SKILL.md` and `~/.claude/skills/<name>/SKILL.md`
+**verbatim** — no conversion, no port. If a Claude Code skill already exists, **do not
+rewrite it**; just confirm its `name` matches its directory and its frontmatter passes the
+rules below. The six discovery locations (project + global × three roots):
+
+| Root | Project | Global |
+|------|---------|--------|
+| OpenCode-native | `.opencode/skills/<name>/SKILL.md` | `~/.config/opencode/skills/<name>/SKILL.md` |
+| Claude-compatible | `.claude/skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` |
+| agent-compatible | `.agents/skills/<name>/SKILL.md` | `~/.agents/skills/<name>/SKILL.md` |
+
+Project discovery **walks up from cwd to the git worktree root**, loading every match along
+the way. Skill `name`s **must be unique across all six locations** — a duplicate name is a
+common silent-failure cause.
+
+---
+
+## Frontmatter — only five fields exist
+
+OpenCode recognizes **exactly** these; everything else is **silently ignored**:
+
+| Field | Required | Rule |
+|-------|----------|------|
+| `name` | yes | 1–64 chars, regex `^[a-z0-9]+(-[a-z0-9]+)*$`, **must equal the containing directory name** |
+| `description` | yes | 1–1024 chars; specific enough for the agent to choose it |
+| `license` | no | license identifier (e.g. `MIT`) |
+| `compatibility` | no | e.g. `opencode` |
+| `metadata` | no | **string→string map only** — no nested objects, no numbers/booleans |
+
+Traps a fresh model hits:
+
+- **`name` must match the folder name exactly.** `skills/git-release/SKILL.md` ⇒ `name: git-release`.
+  No start/end hyphen, no `--`.
+- **Claude Code frontmatter keys are inert here.** `argument-hint`, `user-invocable`,
+  `allowed-tools`, `allowed_directories`, etc. are **not recognized** — they don't error, they
+  just do nothing. Don't rely on them for OpenCode behavior.
+- **`metadata` is flat string→string.** `metadata: { audience: maintainers }` ✅;
+  `metadata: { steps: 3 }` or nested maps ❌.
+- The file **must be named `SKILL.md` in all caps**.
+
+Minimal valid skill (see `assets/SKILL.template.md`):
+
+```markdown
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+---
+## What I do
+- Draft release notes from merged PRs
+```
+
+---
+
+## How a skill is invoked
+
+The agent sees only `name` + `description` in the `skill` tool description, rendered as:
+
+```xml
+<available_skills>
+  <skill><name>git-release</name><description>Create consistent releases and changelogs</description></skill>
+</available_skills>
+```
+
+and loads the full body **on demand** by calling the native tool:
+
+```
+skill({ name: "git-release" })
+```
+
+So the `description` is the **only** trigger signal — write it like a good Claude Code
+description (concrete "use when…" terms), not a title.
+
+---
+
+## Gating skills — two distinct mechanisms (don't conflate)
+
+| Goal | Key | Shape | Effect |
+|------|-----|-------|--------|
+| Allow/deny/ask **per skill name** | `permission.skill` | glob map → `allow`\|`deny`\|`ask` | `deny` **hides** the skill from the agent; `ask` prompts the user before load |
+| **Disable the skill tool entirely** | `tools.skill` | `false` | drops the whole `<available_skills>` section from context |
+
+`permission.skill` is a **permission glob map**, not a boolean:
+
+```json
+{ "permission": { "skill": {
+    "*": "allow", "pr-review": "allow", "internal-*": "deny", "experimental-*": "ask" } } }
+```
+
+Per-agent overrides (agents beat global):
+
+```yaml
+# custom agent frontmatter
+---
+permission:
+  skill: { "documents-*": "allow" }
+---
+```
+
+```json
+// built-in agent in opencode.json
+{ "agent": { "plan": { "permission": { "skill": { "internal-*": "allow" } } } } }
+```
+
+To kill skills for an agent entirely use `tools: { skill: false }` (frontmatter) or
+`agent.<name>.tools.skill: false` (config) — **not** a permission entry.
+
+---
+
+## References — named external roots via `@alias`
+
+A separate feature (`references` config key) that exposes dirs/repos **outside the project**.
+Config in `opencode.json`/`opencode.jsonc`, keyed by alias. Full detail in
+`references/references.rst`.
+
+```jsonc
+{ "references": {
+    "docs":   { "path": "../docs", "description": "Product behavior + doc conventions" },
+    "effect": { "repository": "Effect-TS/effect", "branch": "main" } } }
+```
+
+| Type | Field | Shorthand |
+|------|-------|-----------|
+| Local dir | `path` (relative-to-config, absolute, or `~/`) | `"docs": "../docs"` |
+| Git repo | `repository` (Git URL / `host/path` / GitHub `owner/repo`) + optional `branch` | `"effect": "Effect-TS/effect"` |
+
+Optional for both: `description`, `hidden`.
+
+Non-inferable traps:
+
+- **Alias charset is restricted.** An alias **cannot be empty or contain `/`, whitespace,
+  backticks, or commas.** (So `@my-docs` ✅, `@my/docs` ✗.)
+- **Git references refresh asynchronously** — a newly configured `repository` may take a
+  moment to finish cloning/updating; it won't be there instantly.
+- **Only references *with a `description`* are advertised to the agent** (injected into system
+  context). Without a description a reference is reachable solely via `@`-autocomplete / manual
+  `@alias` — the agent won't know it exists.
+- `@alias` attaches the **root**; `@alias/` searches **files inside** it.
+- `hidden: true` only removes the alias from TUI `@`-autocomplete; a hidden ref **with** a
+  description is still in agent context.
+- References are auto-allowed through OpenCode's **external-directory permission boundary**, but
+  **normal tool permissions still apply** — a read-only agent doesn't gain edit access just
+  because a dir is a reference.
+
+---
+
+## Troubleshooting "my skill won't load"
+
+1. Filename is `SKILL.md` (all caps).
+2. Frontmatter has both `name` and `description`, and `name` == directory name and matches the regex.
+3. The name is unique across all six discovery locations.
+4. It isn't `deny`'d by `permission.skill` (deny ⇒ hidden), and `tools.skill` isn't `false` for the active agent.
+
+---
+
+## Reference files
+
+| File | Contents |
+|------|----------|
+| [references/skills.rst](references/skills.rst) | Verbatim Agent Skills doc — discovery paths, frontmatter rules, regex, `skill` tool, `permission.skill`, per-agent overrides, troubleshooting |
+| [references/references.rst](references/references.rst) | Verbatim References doc — `references` key, `path`/`repository` fields, shorthands, `@alias` usage, alias charset, async git refresh, field table |
+| [assets/SKILL.template.md](assets/SKILL.template.md) | Minimal OpenCode-valid `SKILL.md` skeleton |
+
+## Version pins
+
+OpenCode SDK packages: `@opencode-ai/sdk`, `@opencode-ai/plugin` (JS/TS); official Go module
+`github.com/sst/opencode-sdk-go` (Go SDK **v0.19.2**, **Go 1.22+**) — verify this exact module
+path. Skills themselves are plain markdown and need no SDK; these pins matter only if
+a skill shells out to OpenCode tooling. Re-verify current versions before pinning.

--- a/skills/opencode-skill/assets/SKILL.template.md
+++ b/skills/opencode-skill/assets/SKILL.template.md
@@ -1,0 +1,34 @@
+<!--
+Minimal OpenCode Agent Skill skeleton.
+Place at one of (folder name MUST equal the `name` below):
+  .opencode/skills/<name>/SKILL.md          (project, OpenCode-native)
+  ~/.config/opencode/skills/<name>/SKILL.md (global, OpenCode-native)
+  .claude/skills/<name>/SKILL.md            (project, Claude Code skills are read VERBATIM)
+  ~/.claude/skills/<name>/SKILL.md          (global, Claude Code drop-in)
+  .agents/skills/<name>/ or ~/.agents/skills/<name>/
+File MUST be named SKILL.md (all caps). Only the five frontmatter fields below
+are recognized; any other key (argument-hint, user-invocable, allowed-tools, …)
+is silently ignored by OpenCode.
+-->
+---
+name: my-skill                 # 1–64 chars, ^[a-z0-9]+(-[a-z0-9]+)*$, MUST equal the directory name
+description: One specific sentence the agent uses to decide when to load this skill. 1–1024 chars; name concrete triggers.
+license: MIT                   # optional
+compatibility: opencode        # optional
+metadata:                      # optional — string→string ONLY (no nesting, no numbers)
+  audience: maintainers
+---
+
+## What I do
+
+- Step or capability one
+- Step or capability two
+
+## When to use me
+
+Describe the trigger conditions. Ask clarifying questions if inputs are ambiguous.
+
+<!-- The agent sees only `name` + `description` until it calls skill({ name: "my-skill" });
+     this body loads on demand. Gate access with permission.skill globs in opencode.json:
+       { "permission": { "skill": { "*": "allow", "internal-*": "deny" } } }
+     Disable the tool entirely for an agent with tools: { skill: false }. -->

--- a/skills/opencode-skill/references/references.rst
+++ b/skills/opencode-skill/references/references.rst
@@ -1,0 +1,158 @@
+<!-- Source: https://opencode.ai/docs/references/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode skill code. -->
+
+# References
+
+> title: References — description: Add local directories and Git repositories as project references.
+
+References give OpenCode access to directories outside the current project. Use them to make documentation, shared libraries, examples, or another repository available while you work.
+
+References are configured by alias in `opencode.json` or `opencode.jsonc`.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "references": {
+    "docs": {
+      "path": "../product-docs",
+      "description": "Use for product behavior and documentation conventions",
+    },
+    "sdk": {
+      "repository": "anomalyco/opencode-sdk-js",
+      "branch": "main",
+      "description": "Use for JavaScript SDK implementation details",
+    },
+  },
+}
+```
+
+---
+
+## Local directories
+
+Use `path` to reference a local directory.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "docs": {
+      "path": "../docs",
+    },
+  },
+}
+```
+
+Paths can be:
+
+- Relative to the config file that defines the reference
+- Absolute, such as `/home/user/docs`
+- Relative to your home directory, such as `~/docs`
+
+You can also use a string shorthand:
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "docs": "../docs",
+  },
+}
+```
+
+---
+
+## Git repositories
+
+Use `repository` to reference a Git repository. OpenCode materializes the repository in its local repository cache and makes the checked-out source available as a reference directory.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "effect": {
+      "repository": "Effect-TS/effect",
+      "branch": "main",
+    },
+  },
+}
+```
+
+`repository` accepts Git URLs, host/path references, and GitHub `owner/repo` shorthand. The optional `branch` field selects a branch or ref. Without `branch`, OpenCode uses the repository's default branch.
+
+You can use string shorthand when you do not need a branch, description, or other options:
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "effect": "Effect-TS/effect",
+  },
+}
+```
+
+:::note
+Git references are refreshed asynchronously. A newly configured repository may take a moment to finish cloning or updating.
+:::
+
+---
+
+## Describe usage
+
+Add `description` to explain when an agent should use a reference.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "design-system": {
+      "path": "../design-system",
+      "description": "Use when implementing UI components or design tokens",
+    },
+  },
+}
+```
+
+OpenCode includes references with descriptions in agent context. Descriptions should be short and specific enough to distinguish references with similar content. References without descriptions remain available through autocomplete and direct use, but are not advertised to agents.
+
+---
+
+## Hide autocomplete entries
+
+Set `hidden` to `true` to omit a reference from `@` autocomplete in the TUI.
+
+```jsonc title="opencode.jsonc"
+{
+  "references": {
+    "internal": {
+      "path": "../internal",
+      "description": "Use for internal implementation details",
+      "hidden": true,
+    },
+  },
+}
+```
+
+`hidden` only affects autocomplete. A hidden reference with a description remains included in agent context.
+
+---
+
+## Use references
+
+Configured references appear in TUI `@` autocomplete. Type `@alias` to attach the reference root, or `@alias/` to search for files inside it.
+
+```text
+Compare this implementation with @sdk/src/client.ts
+```
+
+Agents also receive the resolved paths and descriptions of configured references that have descriptions in their system context, so they can inspect a reference when it is relevant without you attaching it manually.
+
+OpenCode automatically allows reference directories through its external-directory permission boundary. Normal tool permissions still apply; for example, an agent that cannot edit files does not gain edit access because a directory is configured as a reference.
+
+---
+
+## Configure fields
+
+| Field         | Local | Git | Description                                      |
+| ------------- | ----- | --- | ------------------------------------------------ |
+| `path`        | Yes   | No  | Local reference directory                        |
+| `repository`  | No    | Yes | Git URL, host/path, or GitHub `owner/repo` value |
+| `branch`      | No    | Yes | Optional Git branch or ref                       |
+| `description` | Yes   | Yes | Guidance describing when to use the reference    |
+| `hidden`      | Yes   | Yes | Hide the reference from TUI `@` autocomplete     |
+
+Reference aliases cannot be empty or contain `/`, whitespace, backticks, or commas.

--- a/skills/opencode-skill/references/skills.rst
+++ b/skills/opencode-skill/references/skills.rst
@@ -1,0 +1,223 @@
+<!-- Source: https://opencode.ai/docs/skills/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode skill code. -->
+
+# Agent Skills
+
+> title: "Agent Skills" — description: "Define reusable behavior via SKILL.md definitions"
+
+Agent skills let OpenCode discover reusable instructions from your repo or home directory.
+Skills are loaded on-demand via the native `skill` tool—agents see available skills and can load the full content when needed.
+
+---
+
+## Place files
+
+Create one folder per skill name and put a `SKILL.md` inside it.
+OpenCode searches these locations:
+
+- Project config: `.opencode/skills/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
+- Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
+- Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
+- Project agent-compatible: `.agents/skills/<name>/SKILL.md`
+- Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
+
+---
+
+## Understand discovery
+
+For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
+It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` along the way.
+
+Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
+
+---
+
+## Write frontmatter
+
+Each `SKILL.md` must start with YAML frontmatter.
+Only these fields are recognized:
+
+- `name` (required)
+- `description` (required)
+- `license` (optional)
+- `compatibility` (optional)
+- `metadata` (optional, string-to-string map)
+
+Unknown frontmatter fields are ignored.
+
+---
+
+## Validate names
+
+`name` must:
+
+- Be 1–64 characters
+- Be lowercase alphanumeric with single hyphen separators
+- Not start or end with `-`
+- Not contain consecutive `--`
+- Match the directory name that contains `SKILL.md`
+
+Equivalent regex:
+
+```text
+^[a-z0-9]+(-[a-z0-9]+)*$
+```
+
+---
+
+## Follow length rules
+
+`description` must be 1-1024 characters.
+Keep it specific enough for the agent to choose correctly.
+
+---
+
+## Use an example
+
+Create `.opencode/skills/git-release/SKILL.md` like this:
+
+```markdown
+---
+name: git-release
+description: Create consistent releases and changelogs
+license: MIT
+compatibility: opencode
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## What I do
+
+- Draft release notes from merged PRs
+- Propose a version bump
+- Provide a copy-pasteable `gh release create` command
+
+## When to use me
+
+Use this when you are preparing a tagged release.
+Ask clarifying questions if the target versioning scheme is unclear.
+```
+
+---
+
+## Recognize tool description
+
+OpenCode lists available skills in the `skill` tool description.
+Each entry includes the skill name and description:
+
+```xml
+<available_skills>
+  <skill>
+    <name>git-release</name>
+    <description>Create consistent releases and changelogs</description>
+  </skill>
+</available_skills>
+```
+
+The agent loads a skill by calling the tool:
+
+```
+skill({ name: "git-release" })
+```
+
+---
+
+## Configure permissions
+
+Control which skills agents can access using pattern-based permissions in `opencode.json`:
+
+```json
+{
+  "permission": {
+    "skill": {
+      "*": "allow",
+      "pr-review": "allow",
+      "internal-*": "deny",
+      "experimental-*": "ask"
+    }
+  }
+}
+```
+
+| Permission | Behavior                                  |
+| ---------- | ----------------------------------------- |
+| `allow`    | Skill loads immediately                   |
+| `deny`     | Skill hidden from agent, access rejected  |
+| `ask`      | User prompted for approval before loading |
+
+Patterns support wildcards: `internal-*` matches `internal-docs`, `internal-tools`, etc.
+
+---
+
+## Override per agent
+
+Give specific agents different permissions than the global defaults.
+
+**For custom agents** (in agent frontmatter):
+
+```yaml
+---
+permission:
+  skill:
+    "documents-*": "allow"
+---
+```
+
+**For built-in agents** (in `opencode.json`):
+
+```json
+{
+  "agent": {
+    "plan": {
+      "permission": {
+        "skill": {
+          "internal-*": "allow"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Disable the skill tool
+
+Completely disable skills for agents that shouldn't use them:
+
+**For custom agents**:
+
+```yaml
+---
+tools:
+  skill: false
+---
+```
+
+**For built-in agents**:
+
+```json
+{
+  "agent": {
+    "plan": {
+      "tools": {
+        "skill": false
+      }
+    }
+  }
+}
+```
+
+When disabled, the `<available_skills>` section is omitted entirely.
+
+---
+
+## Troubleshoot loading
+
+If a skill does not show up:
+
+1. Verify `SKILL.md` is spelled in all caps
+2. Check that frontmatter includes `name` and `description`
+3. Ensure skill names are unique across all locations
+4. Check permissions—skills with `deny` are hidden from agents

--- a/skills/opencode-tools/SKILL.md
+++ b/skills/opencode-tools/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: opencode-tools
+license: CC-BY-4.0
+compatibility: opencode
+description: >-
+  Extend OpenCode's capabilities with the three add-on mechanisms: standalone
+  custom tools (`.opencode/tools/*.ts`), MCP servers (the `mcp` config key), and
+  LSP servers (the `lsp` config key). Encodes the traps a fresh model gets wrong —
+  plural dir + filename-is-toolname + built-in override, the `environment` (MCP)
+  vs `env` (LSP) spelling split, MCP tool namespacing + the `tools` glob gate,
+  the `lsp` boolean-or-object shape, the built-in tool list, and `apply_patch`
+  (not `patch`) sharing the one `edit` permission. Use when the user is writing
+  an OpenCode custom tool, importing `tool` from `@opencode-ai/plugin`,
+  overriding a built-in like `bash`, wiring an MCP server, configuring `lsp`,
+  setting `permission`/`tools` gates, or asks about `.opencode/tools/`,
+  `apply_patch`, `patchText`, `environment`, or namespaced MCP tools.
+argument-hint: "e.g. 'add a custom .opencode tool that overrides bash' or 'wire a remote MCP server'"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# OpenCode: extending tools (custom tools, MCP, LSP)
+
+OpenCode's API moves fast and predates the model's training cutoff — before
+writing tools code, read `references/custom-tools.rst`, `references/mcp-servers.rst`,
+`references/lsp.rst`, `references/tools.rst` AND re-check
+https://opencode.ai/docs/custom-tools/ (and the `/mcp-servers/`, `/lsp/`, `/tools/`
+pages) for drift.
+
+**Three distinct extension mechanisms — pick one:**
+
+| Want | Mechanism | Where | Surface |
+|---|---|---|---|
+| Your own callable function | **Custom tool** | file `.opencode/tools/<name>.ts` | `tool()` from `@opencode-ai/plugin` |
+| An external MCP toolset | **MCP server** | `mcp` key in `opencode.json` | config only |
+| Diagnostics for the agent | **LSP server** | `lsp` key in `opencode.json` | config only |
+
+**Pin:** the load-bearing package is `@opencode-ai/plugin@1.17.11` (frontmatter
+`compatibility:`; source of `tool` / `tool.schema`). Re-check the installed
+version (`npm view @opencode-ai/plugin version`) against the API recital below
+before relying on it. (Go SDK `v0.19.2` / Go 1.22+ belong to `/opencode-dev:sdk`,
+not this facet.)
+
+**Facet boundary:** this skill covers **filesystem-discovered** standalone tools.
+Registering a tool **programmatically from inside a plugin** (the `tool` map hook)
+is `/opencode-dev:plugin` — both import `tool` from `@opencode-ai/plugin`, but
+don't duplicate the plugin route here. Permission `allow|ask|deny` *semantics* are
+owned by `/opencode-dev:policies`; this skill only shows the `tools` enable/disable
+gate and points there.
+
+## 1. Custom tools — the filename/override traps
+
+```ts
+// .opencode/tools/database.ts  → tool name is "database" (filename == tool name)
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Query the project database",
+  args: { query: tool.schema.string().describe("SQL query to execute") },
+  async execute(args, context) { return `ran: ${args.query}` },
+})
+```
+
+- **Dir is plural `.opencode/tools/`** (project) or `~/.config/opencode/tools/`
+  (global). Singular is wrong.
+- **Filename = tool name.** `database.ts` → `database`.
+- **A file named after a built-in OVERRIDES it.** Drop `bash.ts` in
+  `.opencode/tools/` and your tool replaces the built-in `bash` (keyed by name).
+  This is the supported way to sandbox/restrict a built-in.
+- **Multiple named exports → `<filename>_<export>`.** `math.ts` exporting `add`
+  and `multiply` yields `math_add` and `math_multiply` (NOT `add`/`multiply`).
+- Args use `tool.schema` (Zod re-export). Plain-object form is allowed if you
+  `import { z } from "zod"` yourself.
+- `execute(args, context)` — `context` = `{ agent, sessionID, messageID,
+  directory, worktree }`. Shell out to any language via `Bun.$` (see
+  `references/custom-tools.rst` Python example).
+
+## 2. MCP servers — `mcp` key, two transports
+
+```jsonc
+{ "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-srv":  { "type": "local",  "command": ["npx","-y","my-mcp"],
+                    "enabled": true, "environment": { "MY_VAR": "v" } },
+    "remote-srv": { "type": "remote", "url": "https://x.com", "enabled": true,
+                    "headers": { "Authorization": "Bearer KEY" } } } }
+```
+
+- **Local env key is `environment`** (full word). This is the #1 trap — see §4.
+- `type` (`"local"`/`"remote"`) is required. Non-obvious optionals: `timeout`
+  (ms, default **5000**), plus `cwd` and `oauth`.
+- **OAuth:** omit it and OpenCode auto-detects 401 → Dynamic Client Registration
+  (RFC 7591). `"oauth": {}` triggers DCR explicitly; `"oauth": false` disables it.
+  CLI: `opencode mcp auth|list|logout|debug <srv>`.
+- **MCP tools are namespaced by the server name as prefix** — server `sentry`
+  exposes `sentry_*`. You reference and gate them by that prefix.
+- Caveat: MCP servers add to context; enabling a heavy one (e.g. GitHub MCP) can
+  blow the context window.
+
+### Gating MCP tools — `tools` (enable/disable), not `permission`
+
+Two separate mechanisms, do not conflate:
+
+- **`tools`** = top-level glob map that **enables/disables** tools:
+  `"tools": { "sentry_*": false }`. Re-enable per agent:
+  `"agent": { "my-agent": { "tools": { "sentry_*": true } } }`.
+- **`permission`** = `allow|ask|deny` over actions (owned by
+  `/opencode-dev:policies`). Different axis.
+
+## 3. LSP servers — `lsp` key is boolean-or-object
+
+Disabled by default. The `lsp` key accepts a **boolean OR an object**:
+
+| Value | Effect |
+|---|---|
+| `true` | Enable all 30+ built-in servers |
+| `false` | Disable all LSP |
+| `{}` | Keep built-ins + add/override custom entries |
+| `{ "<srv>": { "disabled": true } }` | Disable one server, keep the rest |
+
+```json
+{ "$schema": "https://opencode.ai/config.json",
+  "lsp": { "typescript": { "disabled": true },
+           "custom-lsp": { "command": ["custom-lsp-server","--stdio"],
+                           "extensions": [".custom"] } } }
+```
+
+Per-server fields beyond the example: `env` (object — NOT `environment`; see §4)
+and `initialization` (object). Suppress auto-download with
+`OPENCODE_DISABLE_LSP_DOWNLOAD=true`.
+
+## 4. The two cross-cutting traps
+
+**`environment` vs `env` — same concept, two spellings:**
+
+| Layer | Env key |
+|---|---|
+| MCP local server (`mcp.<srv>`) | **`environment`** (full word) |
+| LSP server (`lsp.<srv>`) | **`env`** (short) |
+| Custom tool `tool()` | neither — use `Bun.$` / `process.env` in `execute` |
+
+**`lsp` is overloaded three ways — keep them separate:**
+
+| `lsp` as… | What it is |
+|---|---|
+| top-level **config key** | wires LSP *servers* (boolean-or-object, §3) |
+| built-in **tool** named `lsp` | experimental; needs `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` |
+| **permission** key `lsp` | gates that tool's actions (policies facet) |
+
+## 5. Built-in tools + the `apply_patch` / `edit` trap
+
+Built-in tool names (this is the permission/gating vocabulary): `bash`, `edit`,
+`write`, `read`, `grep`, `glob`, `lsp` (experimental), `apply_patch`, `skill`,
+`todowrite`, `webfetch`, `websearch`, `question`.
+
+- **`edit`, `write`, and `apply_patch` share ONE `edit` permission** — denying
+  `edit` blocks all three. There is no separate `write`/`apply_patch` permission.
+- The patch tool is **`apply_patch`**, NOT `patch`. Its argument is
+  **`output.args.patchText`** (NOT `filePath`) — relevant when a plugin's
+  `tool.execute.before` inspects patch operations. Marker lines
+  (`*** Add File:` / `*** Update File:` / `*** Delete File:`) carry relative
+  paths inside `patchText`.
+- `grep`/`glob` are powered by ripgrep and respect `.gitignore`; add a `.ignore`
+  with `!node_modules/` to allow ignored paths.
+- `todowrite` is disabled for subagents by default; `websearch` needs Exa
+  (`OPENCODE_ENABLE_EXA=1` or the OpenCode provider).
+
+## Assets
+- `assets/custom-tool.ts` — minimal standalone tool template.
+- `assets/mcp.json` — local + remote MCP server config (note `environment`).
+- `assets/lsp.json` — custom + disabled LSP server config (note `env`).

--- a/skills/opencode-tools/assets/custom-tool.ts
+++ b/skills/opencode-tools/assets/custom-tool.ts
@@ -1,0 +1,19 @@
+// .opencode/tools/database.ts
+// Filename == tool name → this registers a tool called "database".
+// (A file named after a built-in, e.g. bash.ts, OVERRIDES that built-in.)
+// For multiple tools per file, use named exports → tool name is `<file>_<export>`.
+import { tool } from "@opencode-ai/plugin"
+
+export default tool({
+  description: "Query the project database",
+  args: {
+    // tool.schema is a Zod re-export; or `import { z } from "zod"` and use z.
+    query: tool.schema.string().describe("SQL query to execute"),
+  },
+  // context = { agent, sessionID, messageID, directory, worktree }
+  async execute(args, context) {
+    // Shell out to any language via Bun.$ if needed:
+    // const out = await Bun.$`psql -c ${args.query}`.text()
+    return `Executed query against ${context.directory}: ${args.query}`
+  },
+})

--- a/skills/opencode-tools/assets/lsp.json
+++ b/skills/opencode-tools/assets/lsp.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "typescript": { "disabled": true },
+    "rust": {
+      "command": ["rust-analyzer"],
+      "env": { "RUST_LOG": "debug" }
+    },
+    "custom-lsp": {
+      "command": ["custom-lsp-server", "--stdio"],
+      "extensions": [".custom"]
+    }
+  }
+}

--- a/skills/opencode-tools/assets/mcp.json
+++ b/skills/opencode-tools/assets/mcp.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "local-srv": {
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-everything"],
+      "enabled": true,
+      "environment": { "MY_ENV_VAR": "value" }
+    },
+    "remote-srv": {
+      "type": "remote",
+      "url": "https://my-mcp-server.com/mcp",
+      "enabled": true,
+      "headers": { "Authorization": "Bearer {env:MY_API_KEY}" }
+    }
+  },
+  "tools": {
+    "local-srv*": false
+  },
+  "agent": {
+    "my-agent": {
+      "tools": { "local-srv*": true }
+    }
+  }
+}

--- a/skills/opencode-tools/references/custom-tools.rst
+++ b/skills/opencode-tools/references/custom-tools.rst
@@ -1,0 +1,154 @@
+<!-- Source: https://opencode.ai/docs/custom-tools/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# Custom Tools - OpenCode Technical Documentation
+
+## Overview
+Custom tools are functions that LLMs can invoke during conversations in OpenCode. They operate alongside built-in tools like `read`, `write`, and `bash`.
+
+## Creating a Tool
+
+### Location
+Tools can be defined in two locations:
+- **Locally**: `.opencode/tools/` directory in your project
+- **Globally**: `~/.config/opencode/tools/`
+
+### Structure
+Tools are defined as TypeScript or JavaScript files using the `tool()` helper:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Query the project database",
+  args: {
+    query: tool.schema.string().describe("SQL query to execute"),
+  },
+  async execute(args) {
+    // Your database logic here
+    return `Executed query: ${args.query}`
+  },
+})
+```
+
+The filename becomes the tool name (e.g., `database.ts` creates a `database` tool).
+
+### Multiple Tools Per File
+Export multiple tools with naming convention `<filename>_<exportname>`:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export const add = tool({
+  description: "Add two numbers",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args) {
+    return (args.a + args.b).toString()
+  },
+})
+
+export const multiply = tool({
+  description: "Multiply two numbers",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args) {
+    return (args.a * args.b).toString()
+  },
+})
+```
+
+This creates `math_add` and `math_multiply` tools.
+
+### Name Collisions
+Custom tools override built-in tools with identical names. Example replacing `bash`:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Restricted bash wrapper",
+  args: {
+    command: tool.schema.string(),
+  },
+  async execute(args) {
+    return `blocked: ${args.command}`
+  },
+})
+```
+
+### Arguments
+Define arguments using `tool.schema` (Zod-based):
+
+```typescript
+args: {
+  query: tool.schema.string().describe("SQL query to execute")
+}
+```
+
+Or import Zod directly:
+
+```typescript
+import { z } from "zod"
+export default {
+  description: "Tool description",
+  args: {
+    param: z.string().describe("Parameter description"),
+  },
+  async execute(args, context) {
+    return "result"
+  },
+}
+```
+
+### Context
+Tools receive session context:
+
+```typescript
+import { tool } from "@opencode-ai/plugin"
+export default tool({
+  description: "Get project information",
+  args: {},
+  async execute(args, context) {
+    const { agent, sessionID, messageID, directory, worktree } = context
+    return `Agent: ${agent}, Session: ${sessionID}, Message: ${messageID}, Directory: ${directory}, Worktree: ${worktree}`
+  },
+})
+```
+
+Key properties:
+- `context.directory` - session working directory
+- `context.worktree` - git worktree root
+
+## Examples
+
+### Write a Tool in Python
+
+Python script (`.opencode/tools/add.py`):
+```python
+import sys
+a = int(sys.argv[1])
+b = int(sys.argv[2])
+print(a + b)
+```
+
+Tool definition (`.opencode/tools/python-add.ts`):
+```typescript
+import { tool } from "@opencode-ai/plugin"
+import path from "path"
+
+export default tool({
+  description: "Add two numbers using Python",
+  args: {
+    a: tool.schema.number().describe("First number"),
+    b: tool.schema.number().describe("Second number"),
+  },
+  async execute(args, context) {
+    const script = path.join(context.worktree, ".opencode/tools/add.py")
+    const result = await Bun.$`python3 ${script} ${args.a} ${args.b}`.text()
+    return result.trim()
+  },
+})
+```
+
+Uses Bun's `$` shell utility for script execution.

--- a/skills/opencode-tools/references/lsp.rst
+++ b/skills/opencode-tools/references/lsp.rst
@@ -1,0 +1,108 @@
+<!-- Source: https://opencode.ai/docs/lsp/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# LSP Servers Configuration Guide
+
+## Overview
+OpenCode integrates with Language Server Protocol servers to provide diagnostics feedback for agents. The feature is disabled by default.
+
+## Built-in LSP Servers
+
+OpenCode includes 30+ pre-configured LSP servers for languages including:
+
+- **JavaScript/TypeScript**: typescript, eslint, deno
+- **Python**: pyright
+- **Rust**: rust-analyzer
+- **Go**: gopls
+- **Java**: jdtls
+- **C/C++**: clangd
+- **PHP**: intelephense
+- **Ruby**: ruby-lsp
+- **And many others** (Astro, Bash, C#, Clojure, Dart, Elixir, F#, Gleam, Haskell, Kotlin, Lua, Nix, OCaml, Prisma, Razor, Svelte, Vue, YAML, Zig)
+
+Each server has specific file extensions and requirements listed in the documentation table.
+(Note: the fetch summarized the per-language extension/requirement table; re-check the
+live page for the full table when wiring a built-in server.)
+
+## Configuration
+
+### Enable All Built-in Servers
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": true
+}
+```
+
+### Custom Configuration
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {}
+}
+```
+
+### Server Entry Properties
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `disabled` | boolean | Disable specific server |
+| `command` | string[] | Command to start server |
+| `extensions` | string[] | File extensions handled |
+| `env` | object | Environment variables |
+| `initialization` | object | LSP initialization options |
+
+### Environment Variables Example
+```json
+{
+  "lsp": {
+    "rust": {
+      "command": ["rust-analyzer"],
+      "env": {
+        "RUST_LOG": "debug"
+      }
+    }
+  }
+}
+```
+
+### Custom LSP Server
+```json
+{
+  "lsp": {
+    "custom-lsp": {
+      "command": ["custom-lsp-server", "--stdio"],
+      "extensions": [".custom"]
+    }
+  }
+}
+```
+
+### Disable Servers
+```json
+{
+  "lsp": false
+}
+```
+
+Or disable specific server:
+```json
+{
+  "lsp": {
+    "typescript": {
+      "disabled": true
+    }
+  }
+}
+```
+
+## PHP Intelephense License
+
+Place license key in text file at:
+- **macOS/Linux**: `$HOME/intelephense/license.txt`
+- **Windows**: `%USERPROFILE%/intelephense/license.txt`
+
+File should contain only the license key.
+
+## Auto-download
+
+Suppress LSP server auto-download with `OPENCODE_DISABLE_LSP_DOWNLOAD=true`.

--- a/skills/opencode-tools/references/mcp-servers.rst
+++ b/skills/opencode-tools/references/mcp-servers.rst
@@ -1,0 +1,252 @@
+<!-- Source: https://opencode.ai/docs/mcp-servers/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# MCP Servers Technical Documentation
+
+## Overview
+OpenCode supports integrating external tools via the Model Context Protocol (MCP), offering both local and remote server configurations. "MCP tools are automatically available to the LLM alongside built-in tools" once added.
+
+## Enable Configuration
+
+Basic MCP configuration structure in `opencode.jsonc`:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "name-of-mcp-server": {
+      "enabled": true
+    }
+  }
+}
+```
+
+### Remote Defaults Override
+Organizations can provide default MCP servers via `.well-known/opencode` endpoints. Local config values override remote defaults through config precedence.
+
+## Local MCP Servers
+
+Configuration type: `"local"`
+
+```jsonc
+{
+  "mcp": {
+    "my-local-mcp-server": {
+      "type": "local",
+      "command": ["npx", "-y", "my-mcp-command"],
+      "enabled": true,
+      "environment": {
+        "MY_ENV_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+### Local Server Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `type` | String | Y | Must be `"local"` |
+| `command` | Array | Y | Command and arguments to run |
+| `cwd` | String | N | Working directory for process |
+| `environment` | Object | N | Environment variables |
+| `enabled` | Boolean | N | Enable/disable on startup |
+| `timeout` | Number | N | Tool fetch timeout in ms (default: 5000) |
+
+## Remote MCP Servers
+
+Configuration type: `"remote"`
+
+```json
+{
+  "mcp": {
+    "my-remote-mcp": {
+      "type": "remote",
+      "url": "https://my-mcp-server.com",
+      "enabled": true,
+      "headers": {
+        "Authorization": "Bearer MY_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Remote Server Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `type` | String | Y | Must be `"remote"` |
+| `url` | String | Y | Remote server URL |
+| `enabled` | Boolean | N | Enable/disable on startup |
+| `headers` | Object | N | Request headers |
+| `oauth` | Object | N | OAuth configuration |
+| `timeout` | Number | N | Tool fetch timeout in ms (default: 5000) |
+
+## OAuth Authentication
+
+### Automatic OAuth
+No special configuration needed for most OAuth-enabled servers. OpenCode detects 401 responses and initiates Dynamic Client Registration (RFC 7591).
+
+### Pre-registered Credentials
+
+```json
+{
+  "mcp": {
+    "my-oauth-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": {
+        "clientId": "{env:MY_MCP_CLIENT_ID}",
+        "clientSecret": "{env:MY_MCP_CLIENT_SECRET}",
+        "scope": "tools:read tools:execute"
+      }
+    }
+  }
+}
+```
+
+### OAuth CLI Commands
+
+```bash
+# Authenticate with server
+opencode mcp auth my-oauth-server
+
+# List all servers and auth status
+opencode mcp list
+
+# Remove stored credentials
+opencode mcp logout my-oauth-server
+
+# Debug OAuth flow
+opencode mcp debug my-oauth-server
+```
+
+### Disable OAuth
+
+```json
+{
+  "mcp": {
+    "my-api-key-server": {
+      "type": "remote",
+      "url": "https://mcp.example.com/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:MY_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### OAuth Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `oauth` | Object \| false | OAuth config or `false` to disable |
+| `clientId` | String | OAuth client ID |
+| `clientSecret` | String | OAuth client secret |
+| `scope` | String | OAuth scopes to request |
+
+## Tool Management
+
+### Global Disable
+
+```json
+{
+  "mcp": {
+    "my-mcp-foo": { "type": "local", "command": [...] },
+    "my-mcp-bar": { "type": "local", "command": [...] }
+  },
+  "tools": {
+    "my-mcp-foo": false
+  }
+}
+```
+
+### Glob Pattern Disable
+
+```json
+{
+  "tools": {
+    "my-mcp*": false
+  }
+}
+```
+
+### Per-Agent Configuration
+
+```json
+{
+  "mcp": {
+    "my-mcp": {
+      "type": "local",
+      "command": ["bun", "x", "my-mcp-command"],
+      "enabled": true
+    }
+  },
+  "tools": {
+    "my-mcp*": false
+  },
+  "agent": {
+    "my-agent": {
+      "tools": {
+        "my-mcp*": true
+      }
+    }
+  }
+}
+```
+
+### Glob Pattern Syntax
+- `*` matches zero or more characters
+- `?` matches exactly one character
+- All other characters match literally
+
+## Common MCP Server Examples
+
+### Sentry
+```json
+{
+  "mcp": {
+    "sentry": {
+      "type": "remote",
+      "url": "https://mcp.sentry.dev/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+Authenticate: `opencode mcp auth sentry`
+
+### Context7
+```json
+{
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+### Grep by Vercel
+```json
+{
+  "mcp": {
+    "gh_grep": {
+      "type": "remote",
+      "url": "https://mcp.grep.app"
+    }
+  }
+}
+```
+
+## Important Caveat
+
+"MCP servers add to your context, so you want to be careful with which ones you enable." Certain servers like GitHub MCP can rapidly exceed context limits through token accumulation.

--- a/skills/opencode-tools/references/tools.rst
+++ b/skills/opencode-tools/references/tools.rst
@@ -1,0 +1,49 @@
+<!-- Source: https://opencode.ai/docs/tools/ — fetched 2026-06-29. Canonical truth; verify here (and re-check the live page for drift) before authoring OpenCode tools code. -->
+
+# Tools Documentation - OpenCode
+
+## Overview
+
+"Tools allow the LLM to perform actions in your codebase." OpenCode includes built-in tools and supports extensions through custom tools or MCP servers. By default, all tools are enabled without requiring permission.
+
+## Permission Configuration
+
+Control tool behavior using the `permission` field in `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny",
+    "bash": "ask",
+    "webfetch": "allow"
+  }
+}
+```
+
+Wildcards support multiple tools: `"mymcp_*": "ask"`
+
+## Built-in Tools
+
+| Tool | Function |
+|------|----------|
+| **bash** | Execute shell commands in project environment |
+| **edit** | Modify existing files using exact string replacements |
+| **write** | Create new files or overwrite existing ones (controlled by `edit` permission) |
+| **read** | Read file contents from codebase |
+| **grep** | Search file contents using regular expressions |
+| **glob** | Find files by pattern matching |
+| **lsp** | Code intelligence features (experimental; requires `OPENCODE_EXPERIMENTAL_LSP_TOOL=true`) |
+| **apply_patch** | Apply patch files to codebase (controlled by `edit` permission) |
+| **skill** | Load SKILL.md file content into conversation |
+| **todowrite** | Manage todo lists during coding sessions |
+| **webfetch** | Fetch and read web pages |
+| **websearch** | Search web using Exa AI (requires `OPENCODE_ENABLE_EXA=1` or OpenCode provider) |
+| **question** | Ask users questions during execution |
+
+## Key Technical Details
+
+- **apply_patch** uses `output.args.patchText` with relative paths embedded in marker lines
+- **ripgrep** powers `grep` and `glob`, respecting `.gitignore` by default
+- Create `.ignore` file to explicitly allow ignored paths: `!node_modules/`
+- "todowrite is disabled for subagents by default"


### PR DESCRIPTION
## What

Adds the **`opencode-dev`** subject plugin — seven skills for developing
**OpenCode** (opencode.ai, SST's open-source coding agent — *not* OpenAI Codex)
solutions, plus a doc-verification hook.

| Facet | Invokes | Scope |
|---|---|---|
| `plugin` | `/opencode-dev:plugin` | Plugins & hooks (the `Hooks` interface) |
| `sdk` | `/opencode-dev:sdk` | `@opencode-ai/sdk`, `opencode-sdk-go`, `opencode serve` |
| `agent` | `/opencode-dev:agent` | Agents, custom commands, `AGENTS.md` rules |
| `tools` | `/opencode-dev:tools` | Custom tools, MCP servers, LSP servers |
| `skill` | `/opencode-dev:skill` | OpenCode Agent Skills + references |
| `policies` | `/opencode-dev:policies` | `experimental.policies` + permissions |
| `delegate` | `/opencode-dev:delegate` | Drive OpenCode from a CC plugin (ACP/serve/run) |

Plus **`opencode-doc-review`** — a `UserPromptSubmit` hook that steers
canonical-doc verification when OpenCode work is detected (gated on OpenCode
markers; silent on "OpenAI Codex").

## How it was built

Skills authored by a multi-agent workflow (author → `skill:skill-auditor` →
revise), then content-reviewed against the verbatim `references/*.rst` they cite.
Each skill encodes the *non-inferable deltas* (e.g. handler-keys-vs-bus-events,
`experimental.policies` inverted precedence, MCP `environment:` vs LSP `env:`).

## Verification

All registry/manifest/consistency/grouping gates green, `asctl repo-check` green,
137 pipeline unit tests pass, `claude plugin validate` ✓. Doc links curl-verified
(27 live URLs); **lychee runs in CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)