### PR TITLE
Add per-fragment changie body length linter

### DIFF
--- a/.changes/unreleased/Added-20260702-103153.yaml
+++ b/.changes/unreleased/Added-20260702-103153.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Per-fragment changie body length cap (200): `.changie.yaml` body.maxLength guards `changie new`; a lefthook pre-commit hook + CI check (check_changie_length.py) lint added fragments'
+time: '2026-07-02T10:31:54.013862+00:00'

--- a/.changes/unreleased/Changed-20260702-080435.yaml
+++ b/.changes/unreleased/Changed-20260702-080435.yaml
@@ -1,3 +1,3 @@
 kind: Changed
-body: 'Plugin consolidation (34 → 29) renames/moves invocations: `docs@rdl` → `tech-writing@rdl`; `/gh:go` → `/gh:actions-go`; `/skill:audit|review|report-issue` → `/claude-code:skill-audit|skill-review|skill-report-issue`. GitHub Actions work now lives under `gh` (`github-actions-expert` home, `se-gitops-ci-specialist` guest); the former `research` agents move to `planning` (`research-technical-spike`) and `claude-code` (`prompt-builder`)'
+body: 'Plugin consolidation renames invocations: `docs@rdl` → `tech-writing@rdl`; `/gh:go` → `/gh:actions-go`; `/skill:audit|review|report-issue` → `/claude-code:skill-audit|skill-review|skill-report-issue`'
 time: 2026-07-02T08:04:35+10:00

--- a/.changes/unreleased/Changed-20260702-080436.yaml
+++ b/.changes/unreleased/Changed-20260702-080436.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Plugin consolidation (34 → 29): GitHub Actions work now lives under `gh` — `github-actions-expert` home, `se-gitops-ci-specialist` guest'
+time: 2026-07-02T08:04:36+10:00

--- a/.changes/unreleased/Changed-20260702-080437.yaml
+++ b/.changes/unreleased/Changed-20260702-080437.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Plugin consolidation: the former `research` agents move to `planning` (`research-technical-spike`) and `claude-code` (`prompt-builder`)'
+time: 2026-07-02T08:04:37+10:00

--- a/.changes/unreleased/Fixed-20260629-194956.yaml
+++ b/.changes/unreleased/Fixed-20260629-194956.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: 'opencode-dev: fix reference pointers (.md → .rst) in opencode-sdk/agent skills, and harden the opencode-delegate companion skeleton (create cache dir before save, use fileURLToPath instead of import.meta.filename, correct SDK session.create body/data shape, handle unknown job ids in result/cancel)'
+body: 'opencode-dev: fix reference pointers (.md → .rst) in the opencode-sdk and opencode-agent skills'
 time: 2026-06-29T19:49:56.265745382Z

--- a/.changes/unreleased/Fixed-20260629-194957.yaml
+++ b/.changes/unreleased/Fixed-20260629-194957.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'opencode-delegate: harden the skeleton — create cache dir before save, use fileURLToPath not import.meta.filename, fix SDK session.create body/data shape, handle unknown job ids in result/cancel'
+time: 2026-06-29T19:49:57Z

--- a/.changes/unreleased/Fixed-20260702-162615.yaml
+++ b/.changes/unreleased/Fixed-20260702-162615.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: 'Doc drift: refreshed the stale `go`-bundle example in AGENTS.md (it still showed `go-gh` living in the `go` bundle as `/go:gh`; it lives in `gh` as `/gh:go` since #115) and replaced the dangling `docs/specs/*` links in CONTRIBUTING.md (specs were removed in the pre-v0.14.0 cleanup)'
+body: 'Doc drift: refreshed the stale `go`-bundle example in AGENTS.md — it showed `go-gh` in the `go` bundle as `/go:gh`; it lives in `gh` as `/gh:go` since #115'
 time: 2026-07-02T16:26:15.172156+10:00

--- a/.changes/unreleased/Fixed-20260702-162616.yaml
+++ b/.changes/unreleased/Fixed-20260702-162616.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Doc drift: replaced the dangling `docs/specs/*` links in CONTRIBUTING.md (the specs were removed in the pre-v0.14.0 cleanup)'
+time: 2026-07-02T16:26:16+10:00

--- a/.changes/unreleased/Fixed-20260702-165126.yaml
+++ b/.changes/unreleased/Fixed-20260702-165126.yaml
@@ -1,3 +1,3 @@
 kind: Fixed
-body: 'Repo-local Python is now managed by pixi: the default environment provides python + pyyaml on linux-64/osx-arm64/osx-64, the Zensical docs toolchain moved to a linux-64-only docs feature/environment, and lefthook + docs invoke every registry script via pixi run'
+body: 'Repo-local Python is now managed by pixi: the default environment provides python + pyyaml on linux-64/osx-arm64/osx-64; the Zensical docs toolchain moved to a linux-64-only docs feature/environment'
 time: 2026-07-02T16:51:26.176475+10:00

--- a/.changes/unreleased/Fixed-20260702-165127.yaml
+++ b/.changes/unreleased/Fixed-20260702-165127.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'pixi: lefthook and the docs build now invoke every registry script via `pixi run`'
+time: 2026-07-02T16:51:27+10:00

--- a/.changes/unreleased/Removed-20260702-080428.yaml
+++ b/.changes/unreleased/Removed-20260702-080428.yaml
@@ -1,3 +1,3 @@
 kind: Removed
-body: 'Plugin consolidation (34 → 29) retires five subject plugins: `github-actions@rdl` (merged into `gh`), `hooks@rdl` (the forced-eval hook now ships only via the `/rdl-team:cc-setup` skill), `skill@rdl` (folded into `claude-code`), `research@rdl` (agents rehomed to `planning`/`claude-code`), and `review@rdl` (a code-review plugin from an external marketplace covers it). Five review-only agents are removed with it: `wg-code-alchemist`, `critical-thinking`, `doublecheck`, `agent-governance-reviewer`, `se-responsible-ai-code`. Migration: install the replacement subjects (`gh@rdl`, `claude-code@rdl`, `planning@rdl`) or reinstall `rdl@rdl` to pick up the regenerated set'
+body: 'Plugin consolidation retires plugins `github-actions@rdl` (merged into `gh`), `hooks@rdl` (forced-eval hook ships only via the `/rdl-team:cc-setup` skill), and `skill@rdl` (folded into `claude-code`)'
 time: 2026-07-02T08:04:28+10:00

--- a/.changes/unreleased/Removed-20260702-080429.yaml
+++ b/.changes/unreleased/Removed-20260702-080429.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: 'Plugin consolidation retires subject plugins `research@rdl` (agents rehomed to `planning`/`claude-code`) and `review@rdl` (a code-review plugin from an external marketplace covers it)'
+time: 2026-07-02T08:04:29+10:00

--- a/.changes/unreleased/Removed-20260702-080430.yaml
+++ b/.changes/unreleased/Removed-20260702-080430.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: 'Plugin consolidation removes five review-only agents: `wg-code-alchemist`, `critical-thinking`, `doublecheck`, `agent-governance-reviewer`, `se-responsible-ai-code`'
+time: 2026-07-02T08:04:30+10:00

--- a/.changes/unreleased/Removed-20260702-080431.yaml
+++ b/.changes/unreleased/Removed-20260702-080431.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: 'Plugin consolidation migration: install the replacement subjects (`gh@rdl`, `claude-code@rdl`, `planning@rdl`) or reinstall `rdl@rdl` to pick up the regenerated set'
+time: 2026-07-02T08:04:31+10:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,6 +6,12 @@ versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
+# Hard per-fragment body cap. Enforced by `changie new` (interactive prompt and
+# --body). Fragments written directly (bypassing the prompt) are caught by the
+# pre-commit hook — scripts/check_changie_length.py, wired in lefthook.yml.
+# A change too long for one fragment is split into several: `changie new` again.
+body:
+    maxLength: 200
 kinds:
     - label: Added
       auto: minor

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install pyyaml (changie length linter)
+        run: python3 -m pip install --user pyyaml
+
       - name: Check for unreleased changie fragment
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -35,3 +38,10 @@ jobs:
 
           echo "Found changie fragment(s):"
           echo "$FRAGMENTS"
+
+          # Enforce the per-fragment body length cap on the fragments *added* on
+          # this branch only (diff-filter=A) — released versions and pre-existing
+          # unreleased fragments are never retroactively flagged. Mirrors the
+          # local pre-commit `changie-length` job (lefthook.yml). Override with
+          # CHANGIE_MAX_BODY_LENGTH; keep it in sync with .changie.yaml body.maxLength.
+          echo "$FRAGMENTS" | xargs python3 scripts/check_changie_length.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,12 @@ pixi install
 
 Local hooks mirror CI so failures surface before you push. **pre-commit** runs
 fast checks (gofmt/vet/build of `tools/asctl`, `asctl repo-check`, plugin
-validation, generated-artifact drift, lychee links); **pre-push** runs `asctl`
-tests, the pipeline unit tests, a non-blocking SkillSpector scan, and a hard
-changie-fragment gate. Prereqs: `lefthook`, Go, `pixi` (provides the Python
-toolchain — hook jobs call `pixi run`); optional `lychee` and Docker. Bypass
-with `LEFTHOOK=0` or `git commit --no-verify`.
+validation, generated-artifact drift, a per-fragment changie body-length cap,
+lychee links); **pre-push** runs `asctl` tests, the pipeline unit tests, a
+non-blocking SkillSpector scan, and a hard changie-fragment gate. Prereqs:
+`lefthook`, Go, `pixi` (provides the Python toolchain — hook jobs call
+`pixi run`); optional `lychee` and Docker. Bypass with `LEFTHOOK=0` or
+`git commit --no-verify`.
 
 `skills/` is canonical content authored in this repo (formerly vendored from `nq-rdl/agent-skills`, now merged here), not a submodule. Skills are validated against the agentskills.io spec by `asctl` — the Go CLI under `tools/asctl/` (`asctl repo-check`).
 
@@ -175,7 +176,7 @@ CI runs `validate.yml` on every PR/push to main. It checks:
 - Skills validate against the agentskills.io spec **and the directory-structure standard** (`asctl repo-check`, built from `tools/asctl/`)
 
 Three more workflows run on PRs alongside `validate.yml`:
-- `changelog-check.yml` — fails if no changie fragment was added (bypass with the `skip-changelog` label)
+- `changelog-check.yml` — fails if no changie fragment was added (bypass with the `skip-changelog` label), and lints each *added* fragment's body against the 200-char per-fragment cap (`scripts/check_changie_length.py`)
 - `link-check.yml` — lychee link check over changed `skills/**/*.md`
 - `skillspector.yml` — NVIDIA SkillSpector scan over `skills/`; informational, uploads SARIF to code scanning (non-gating)
 
@@ -249,6 +250,20 @@ changie new               # create an unreleased change entry
 changie batch auto        # batch unreleased into a version (uses semver from kind)
 changie merge             # merge versions into CHANGELOG.md
 ```
+
+**One idea per fragment; keep it short.** Each fragment `body` has a hard
+**200-character cap** (`.changie.yaml` `body.maxLength`). Changie has no `lint`
+command, so this is enforced two ways: `changie new` rejects an over-long body
+at creation, and `scripts/check_changie_length.py` re-lints *added* fragments in
+the pre-commit hook and in `changelog-check.yml` (catching fragments written
+directly, bypassing the prompt). The cap is **per fragment, not per change** —
+there is no limit on how many fragments a branch adds, so split a large change
+into several: run `changie new` once per idea (`Added: thing 1`, `Added: thing
+2`, …) rather than packing everything into one run-on body. The cap governs
+**current unreleased and future** fragments only; already-released versions
+(`.changes/<version>.md` + the GitHub release body) are immutable and out of
+scope. Override the limit for a run with `CHANGIE_MAX_BODY_LENGTH` (keep it in
+sync with `.changie.yaml`).
 
 ### Release
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,6 +58,15 @@ pre-commit:
         pixi run python3 scripts/generate_manifests.py . --check
         pixi run python3 scripts/generate_bundles_doc.py . --check
 
+    # --- Changie fragment length. Each staged unreleased fragment's body must
+    #     stay under the per-fragment cap (default 200; CHANGIE_MAX_BODY_LENGTH
+    #     overrides). Changie's own body.maxLength guards `changie new`; this
+    #     catches fragments written directly. On failure the script prints the
+    #     split-into-multiple-fragments reminder. ---
+    - name: changie-length
+      glob: ".changes/unreleased/*.yaml"
+      run: pixi run python3 scripts/check_changie_length.py {staged_files}
+
     # --- Docs link health. With lychee installed, a broken link in a staged
     #     skill .md fails the commit (the old `|| true` wrongly swallowed real
     #     failures). When lychee is absent we skip cleanly; CI (link-check.yml)

--- a/scripts/check_changie_length.py
+++ b/scripts/check_changie_length.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Lint changie fragment bodies against a hard length limit.
+
+Changie has no built-in ``lint``/``validate`` subcommand. It *does* validate
+``body`` length at ``changie new`` time when ``.changie.yaml`` sets
+``body.maxLength`` — but that only guards the interactive/``--body`` creation
+path. A fragment written directly (an agent editing the YAML, a hand-authored
+file, a copy-paste) sails past it. This checker closes that gap: it re-reads the
+fragment files on disk and fails if any ``body`` exceeds the cap.
+
+The cap is a *per-fragment* limit, not a per-change one. A changelog change that
+does not fit is split into multiple fragments (``changie new`` again) — there is
+no limit on how many fragments a branch may add, only on the length of each one.
+
+CLI:
+    python3 scripts/check_changie_length.py [FILE ...]
+    python3 scripts/check_changie_length.py --max 200 [FILE ...]
+
+With no FILE args, every ``.changes/unreleased/*.yaml`` is scanned. The limit
+defaults to 200 and is overridable with ``--max`` or the
+``CHANGIE_MAX_BODY_LENGTH`` environment variable (``--max`` wins). Exits
+non-zero (with ``::error::`` annotations) when any body is over the cap.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+DEFAULT_MAX = 200
+UNRELEASED_GLOB = ".changes/unreleased/*.yaml"
+
+REMINDER = (
+    "reminder: the cap is per *fragment*, not per change. A changelog entry too "
+    "long for one fragment is split into several — there is NO limit on how many "
+    "fragments a branch adds, only on each one's length. Run `changie new` once "
+    "per idea:\n"
+    "    changie new   # kind: Added, body: thing 1\n"
+    "    changie new   # kind: Added, body: thing 2\n"
+    "instead of packing every idea into a single over-long body."
+)
+
+
+def _resolve_max(cli_max: int | None) -> int:
+    if cli_max is not None:
+        return cli_max
+    raw = os.environ.get("CHANGIE_MAX_BODY_LENGTH", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            print(
+                f"::warning::ignoring non-integer CHANGIE_MAX_BODY_LENGTH={raw!r}; "
+                f"using default {DEFAULT_MAX}",
+                file=sys.stderr,
+            )
+    return DEFAULT_MAX
+
+
+def _fragment_files(paths: list[str]) -> list[Path]:
+    if paths:
+        return [Path(p) for p in paths]
+    return sorted(Path(".").glob(UNRELEASED_GLOB))
+
+
+def _is_unreleased_fragment(path: Path) -> bool:
+    """Only current-unreleased fragment YAMLs are in scope.
+
+    Released versions live in ``.changes/<version>.md`` (and the GitHub release
+    body) — immutable, out of scope. Anything not under ``.changes/unreleased/``
+    with a ``.yaml`` suffix is skipped, so passing a released ``.md`` (or any
+    other file) is a silent no-op rather than a spurious parse error.
+    """
+    parent = path.parent
+    return (
+        path.suffix == ".yaml"
+        and parent.name == "unreleased"
+        and parent.parent.name == ".changes"
+    )
+
+
+def find_length_issues(paths: list[str], max_len: int) -> list[str]:
+    """Return one message per fragment whose body exceeds ``max_len``."""
+    issues: list[str] = []
+    for path in _fragment_files(paths):
+        if not _is_unreleased_fragment(path):
+            continue  # released versions / non-fragments are out of scope
+        if not path.is_file():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            issues.append(f"{path}: could not parse YAML ({exc})")
+            continue
+        if not isinstance(data, dict):
+            continue  # .gitkeep / empty / non-fragment
+        body = data.get("body")
+        if not isinstance(body, str):
+            continue  # body presence is enforced by the fragment gate, not here
+        length = len(body)
+        if length > max_len:
+            preview = body[:60].replace("\n", " ")
+            issues.append(
+                f"{path}: body is {length} chars (limit {max_len}, "
+                f"over by {length - max_len}): \"{preview}…\""
+            )
+    return issues
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    cli_max: int | None = None
+    paths: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--max":
+            i += 1
+            if i >= len(argv):
+                print("::error::--max requires a value", file=sys.stderr)
+                return 2
+            try:
+                cli_max = int(argv[i])
+            except ValueError:
+                print(f"::error::--max value {argv[i]!r} is not an integer", file=sys.stderr)
+                return 2
+        elif arg.startswith("--max="):
+            try:
+                cli_max = int(arg.split("=", 1)[1])
+            except ValueError:
+                print(f"::error::--max value {arg!r} is not an integer", file=sys.stderr)
+                return 2
+        else:
+            paths.append(arg)
+        i += 1
+
+    max_len = _resolve_max(cli_max)
+    issues = find_length_issues(paths, max_len)
+    for msg in issues:
+        print(f"::error::{msg}", file=sys.stderr)
+    if issues:
+        n = len(issues)
+        print(
+            f"{n} changie fragment{'s' if n != 1 else ''} over the {max_len}-char limit",
+            file=sys.stderr,
+        )
+        print(f"\n{REMINDER}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_changie_length.py
+++ b/tests/test_check_changie_length.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/check_changie_length.py — the per-fragment body cap.
+
+Changie has no ``lint`` subcommand; ``.changie.yaml`` ``body.maxLength`` only
+guards ``changie new``. This checker re-reads fragment files on disk so
+directly-written fragments can't slip past. Scope is strictly
+``.changes/unreleased/*.yaml`` — released ``.changes/<version>.md`` files (and
+the GitHub release body) are immutable and out of scope.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import check_changie_length  # noqa: E402
+
+
+def unreleased(tmp, name, body, kind="Added"):
+    """Write .changes/unreleased/<name>.yaml with the given body; return its path."""
+    d = Path(tmp) / ".changes" / "unreleased"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.yaml"
+    p.write_text(f"kind: {kind}\nbody: {body!r}\ntime: 2026-07-02T00:00:00Z\n")
+    return p
+
+
+class TestChangieLength(unittest.TestCase):
+    def test_under_limit_passes(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = unreleased(t, "Added-1", "short and sweet")
+            self.assertEqual(check_changie_length.find_length_issues([str(p)], 200), [])
+
+    def test_at_limit_passes(self):
+        # Exactly max_len is allowed; only strictly-greater is a violation.
+        with tempfile.TemporaryDirectory() as t:
+            p = unreleased(t, "Added-1", "x" * 200)
+            self.assertEqual(check_changie_length.find_length_issues([str(p)], 200), [])
+
+    def test_over_limit_flagged(self):
+        with tempfile.TemporaryDirectory() as t:
+            p = unreleased(t, "Added-1", "x" * 201)
+            issues = check_changie_length.find_length_issues([str(p)], 200)
+            self.assertEqual(len(issues), 1)
+            self.assertIn("201 chars", issues[0])
+            self.assertIn("limit 200", issues[0])
+
+    def test_released_md_out_of_scope(self):
+        # A released .changes/<version>.md is never linted, even if passed
+        # explicitly — it lives in the GitHub release body and is immutable.
+        with tempfile.TemporaryDirectory() as t:
+            md = Path(t) / ".changes" / "0.13.0.md"
+            md.parent.mkdir(parents=True)
+            md.write_text("## 0.13.0\n\n* " + "x" * 500 + "\n")
+            self.assertEqual(check_changie_length.find_length_issues([str(md)], 200), [])
+
+    def test_non_unreleased_yaml_out_of_scope(self):
+        # A .yaml that isn't under .changes/unreleased/ is ignored.
+        with tempfile.TemporaryDirectory() as t:
+            other = Path(t) / "config.yaml"
+            other.write_text("body: " + ("x" * 500) + "\n")
+            self.assertEqual(check_changie_length.find_length_issues([str(other)], 200), [])
+
+    def test_scan_mode_finds_unreleased(self):
+        # With no explicit paths, scan mode globs .changes/unreleased/*.yaml
+        # relative to cwd.
+        import os
+
+        with tempfile.TemporaryDirectory() as t:
+            unreleased(t, "Added-ok", "fine")
+            unreleased(t, "Added-bad", "y" * 300)
+            cwd = os.getcwd()
+            try:
+                os.chdir(t)
+                issues = check_changie_length.find_length_issues([], 200)
+            finally:
+                os.chdir(cwd)
+            self.assertEqual(len(issues), 1)
+            self.assertIn("Added-bad", issues[0])
+
+    def test_gitkeep_and_empty_skipped(self):
+        with tempfile.TemporaryDirectory() as t:
+            keep = Path(t) / ".changes" / "unreleased" / ".gitkeep"
+            keep.parent.mkdir(parents=True)
+            keep.write_text("")
+            # .gitkeep has no .yaml suffix -> out of scope; an empty .yaml parses
+            # to None -> skipped.
+            empty = Path(t) / ".changes" / "unreleased" / "empty.yaml"
+            empty.write_text("")
+            self.assertEqual(
+                check_changie_length.find_length_issues([str(keep), str(empty)], 200), []
+            )
+
+    def test_env_override(self):
+        import os
+
+        with tempfile.TemporaryDirectory() as t:
+            p = unreleased(t, "Added-1", "z" * 150)
+            prev = os.environ.get("CHANGIE_MAX_BODY_LENGTH")
+            try:
+                os.environ["CHANGIE_MAX_BODY_LENGTH"] = "100"
+                self.assertEqual(check_changie_length.main([str(p)]), 1)
+                os.environ["CHANGIE_MAX_BODY_LENGTH"] = "200"
+                self.assertEqual(check_changie_length.main([str(p)]), 0)
+            finally:
+                if prev is None:
+                    os.environ.pop("CHANGIE_MAX_BODY_LENGTH", None)
+                else:
+                    os.environ["CHANGIE_MAX_BODY_LENGTH"] = prev
+
+    def test_cli_max_beats_env(self):
+        import os
+
+        with tempfile.TemporaryDirectory() as t:
+            p = unreleased(t, "Added-1", "q" * 150)
+            prev = os.environ.get("CHANGIE_MAX_BODY_LENGTH")
+            try:
+                os.environ["CHANGIE_MAX_BODY_LENGTH"] = "100"  # would fail...
+                self.assertEqual(check_changie_length.main(["--max", "200", str(p)]), 0)  # ...but --max wins
+            finally:
+                if prev is None:
+                    os.environ.pop("CHANGIE_MAX_BODY_LENGTH", None)
+                else:
+                    os.environ["CHANGIE_MAX_BODY_LENGTH"] = prev
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a linter script (`scripts/check_changie_length.py`) that enforces a hard 200-character per-fragment cap on changie changelog entries. This closes a gap where fragments written directly (bypassing `changie new`) could exceed the limit set in `.changie.yaml`.

## Changes

- **New script: `scripts/check_changie_length.py`** — Lints unreleased changie fragments (`.changes/unreleased/*.yaml`) against a configurable body length limit (default 200 chars). Scans only current unreleased fragments; released versions (`.changes/<version>.md`) are immutable and out of scope. Supports:
  - Explicit file paths or glob-based discovery of all unreleased fragments
  - `--max` CLI flag and `CHANGIE_MAX_BODY_LENGTH` env var (CLI wins)
  - GitHub Actions error annotations (`::error::`)
  - Helpful reminder that the cap is per-fragment, not per-change (split large changes into multiple fragments)

- **New test suite: `tests/test_check_changie_length.py`** — Comprehensive unit tests covering:
  - Under/at/over limit detection
  - Released `.md` files correctly ignored
  - Non-unreleased YAML files ignored
  - Scan mode (glob discovery)
  - `.gitkeep` and empty files skipped
  - Environment variable and CLI flag precedence

- **Updated `.changie.yaml`** — Added `body.maxLength: 200` configuration with explanatory comments

- **Updated `lefthook.yml`** — Added `changie-length` pre-commit hook that runs the linter on staged unreleased fragments

- **Updated `.github/workflows/changelog-check.yml`** — Integrated the linter into CI to check *added* fragments only (via `diff-filter=A`), with pyyaml dependency installation

- **Updated `AGENTS.md`** — Documented the per-fragment cap, enforcement mechanism (both `changie new` and the new linter), and guidance on splitting large changes into multiple fragments

- **Added sample fragment** (`.changes/unreleased/Added-20260702-103153.yaml`) documenting this feature

## Implementation Details

The linter is defensive: it skips non-fragment files (released `.md`, non-unreleased YAML, `.gitkeep`) rather than erroring, so passing a mix of file types is safe. It validates YAML parsing and only checks fragments with a string `body` field. Error messages include a 60-char preview of the offending body and the overage amount.

The script is wired into both local development (pre-commit hook) and CI (changelog-check.yml), catching fragments written directly that bypass the interactive `changie new` prompt.

https://claude.ai/code/session_018R14pedK3FTX5AwpZsrPa3