### PR TITLE
Limit push workflow to main branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, 'release/*']
   push:
-    branches: [main, 'release/*']
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Restrict the push trigger for the validate workflow to only the `main` branch, removing `release/*` branches from the push trigger while keeping them in the pull request trigger.

## Changes
- Modified `.github/workflows/validate.yml` to trigger on push only for the `main` branch
- Pull request validation continues to run on both `main` and `release/*` branches

## Rationale
This change prevents validation workflows from running on every push to release branches, likely reducing CI overhead while maintaining validation coverage for pull requests to those branches. The pull request trigger ensures code quality checks still occur before merging into release branches.

https://claude.ai/code/session_01M5fjAGnZ361SE1MchjkHR4