### PR TITLE
Rename marketplace `rdl` → `rdl-agent-extensions`

### DIFF
--- a/.changes/unreleased/Changed-20260703-013145.yaml
+++ b/.changes/unreleased/Changed-20260703-013145.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: "Rename the marketplace `rdl` → `rdl-agent-extensions` (breaking) — install plugins as `<plugin>@rdl-agent-extensions`, e.g. `gh@rdl-agent-extensions` / `rdl@rdl-agent-extensions`"
+time: 2026-07-03T01:31:45+00:00

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "rdl",
+  "name": "rdl-agent-extensions",
   "owner": {
     "name": "nq-rdl",
     "email": "tsv-datalab@health.qld.gov.au"

--- a/.claude/scripts/remind-review-agents.sh
+++ b/.claude/scripts/remind-review-agents.sh
@@ -79,7 +79,7 @@ if [ -n "$sid" ]; then
 fi
 
 cat <<'JSON'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"This path is under .claude/ — contributor tooling for developing the rdl marketplace (project settings, hooks, helper scripts, the curated external-plugin set), not part of the published catalog. AGENTS.md at the repo root is the authoritative guide for .claude/ changes: CONTRIBUTING.md covers the development requirements and docs/ holds the project documentation (docs/external-marketplaces.md documents the curated plugin set). Reviewing AGENTS.md in full before changing .claude/ keeps the project settings and docs in sync."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"This path is under .claude/ — contributor tooling for developing the rdl-agent-extensions marketplace (project settings, hooks, helper scripts, the curated external-plugin set), not part of the published catalog. AGENTS.md at the repo root is the authoritative guide for .claude/ changes: CONTRIBUTING.md covers the development requirements and docs/ holds the project documentation (docs/external-marketplaces.md documents the curated plugin set). Reviewing AGENTS.md in full before changing .claude/ keeps the project settings and docs in sync."}}
 JSON
 
 exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ docs/superpowers/
 
 # Local/personal Claude Code overrides — never committed. Holds machine-local
 # settings, including the optional rdl-self-shadow fix for contributors whose
-# user-scope config enables rdl@rdl: {"enabledPlugins": {"rdl@rdl": false}}
+# user-scope config enables rdl@rdl: {"enabledPlugins": {"rdl@rdl-agent-extensions": false}}
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ docs/superpowers/
 
 # Local/personal Claude Code overrides — never committed. Holds machine-local
 # settings, including the optional rdl-self-shadow fix for contributors whose
-# user-scope config enables rdl@rdl: {"enabledPlugins": {"rdl@rdl-agent-extensions": false}}
+# user-scope config enables rdl@rdl-agent-extensions: {"enabledPlugins": {"rdl@rdl-agent-extensions": false}}
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Agent guidance for this repository. Use this alongside the README for project co
 
 Two things, kept deliberately separate:
 
-1. **A Claude Code marketplace** — the published product. This repo *is* the `rdl`
+1. **A Claude Code marketplace** — the published product. This repo *is* the `rdl-agent-extensions`
    marketplace: it authors reusable skills and agents (canonical content under
    `skills/` and `agents/`) and publishes them as self-contained plugins through the
    repo-root marketplace manifest (`.claude-plugin/marketplace.json`). This is what
@@ -204,11 +204,11 @@ claude --plugin-dir ./plugins/go
 
 # Persistent install (workspace must stay mounted at /workspace)
 claude plugin marketplace add /workspace
-claude plugin install go@rdl
+claude plugin install go@rdl-agent-extensions
 
 # One command installs every subject via the rdl meta-plugin (it declares each
 # subject as a dependency). Requires Claude Code ≥ 2.1.110; prune needs ≥ 2.1.121.
-claude plugin install rdl@rdl
+claude plugin install rdl@rdl-agent-extensions
 claude plugin uninstall rdl --prune   # remove the set + orphaned dependencies
 ```
 
@@ -242,7 +242,7 @@ targets:
   claude:
     enabled: true
     pluginName: go
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions
 ```
 
 The bundle's `description` + `keywords` (plus `registry/marketplace.yaml` and `VERSION`) **generate** `plugins/<bundle>/.claude-plugin/plugin.json` and the bundle's `marketplace.json` entry — do not hand-edit those (CI `generate_manifests.py --check` enforces it). After editing a bundle's `description`/`keywords`, run `pixi run python3 scripts/generate_manifests.py .`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ for the mechanical add-and-sync steps.
 `plugin.json` and the `marketplace.json` entry for a subject are **generated from
 `registry/bundles/<subject>.yaml`** — do **not** hand-edit them. When you add a **new subject**,
 it is also registered as a dependency of the **`rdl` meta-plugin**, so `claude plugin install
-rdl@rdl` keeps installing the full set. CI consistency checks fail if registry, generated
+rdl@rdl-agent-extensions` keeps installing the full set. CI consistency checks fail if registry, generated
 manifests, and the meta-plugin dependency list disagree.
 
 ## Skill directory structure
@@ -251,7 +251,7 @@ These two engine scripts have one **canonical source**, `skills/cc-web-setup/ass
 
 There is **no Setup-script field to set and no manual per-environment step** — declaring the plugins is sufficient.
 
-To add a dev-helper plugin: set it `true` in `enabledPlugins` and register its marketplace under `extraKnownMarketplaces`. Keep the set small and **external** — do not enable the `rdl` marketplace or the `rdl@rdl` meta-plugin here (it is self-referential in this repo's own dev env: per the docs it must reach its marketplace source, and a self-cloning meta batch breaks that install).
+To add a dev-helper plugin: set it `true` in `enabledPlugins` and register its marketplace under `extraKnownMarketplaces`. Keep the set small and **external** — do not enable the `rdl-agent-extensions` marketplace or the `rdl@rdl-agent-extensions` meta-plugin here (it is self-referential in this repo's own dev env: per the docs it must reach its marketplace source, and a self-cloning meta batch breaks that install).
 
 **Further reading.** [`docs/claude-code-web.md`](docs/claude-code-web.md) is the reader-facing overview (the first-session invariant, the vendoring route, the constraints); the authoritative platform facts, the git-proxy 403, and the hard-won anti-patterns live in [`skills/cc-web-setup/references/web-setup.rst`](skills/cc-web-setup/references/web-setup.rst). The `/claude-code:web-setup` skill provisions all of this for any repo.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Claude Code is the only publication target.
 /plugin marketplace add nq-rdl/agent-extensions
 
 # Install every subject in one command via the rdl meta-plugin
-/plugin install rdl@rdl
+/plugin install rdl@rdl-agent-extensions
 
 # …or install a single subject
-/plugin install go@rdl
+/plugin install go@rdl-agent-extensions
 ```
 
 See [`docs/bundles.md`](docs/bundles.md) for the full subject list and [`docs/local-testing.md`](docs/local-testing.md) for local/devcontainer install.

--- a/agents/marketplace-scout/agent.md
+++ b/agents/marketplace-scout/agent.md
@@ -7,7 +7,7 @@ description: >-
   decide which ones THIS repo should enable. It locates the team's tracked
   marketplace list, enumerates each marketplace's plugin catalog (live), inspects
   the repo's languages and tooling, and returns a ranked suggestion set: the
-  always-useful baseline (pr-review-toolkit, gh@rdl, worktrunk, the applicable LSP)
+  always-useful baseline (pr-review-toolkit, gh@rdl-agent-extensions, worktrunk, the applicable LSP)
   plus language/stack-matched picks, each with id, marketplace, and a one-line reason.
   It only researches and recommends — it does not install or edit settings.
 license: MIT
@@ -61,14 +61,14 @@ Parse its keys:
 
 | Marketplace key | GitHub repo |
 |---|---|
-| `rdl` | `nq-rdl/agent-extensions` |
+| `rdl-agent-extensions` | `nq-rdl/agent-extensions` |
 | `claude-plugins-official` | `anthropics/claude-plugins-official` |
 | `worktrunk` | `max-sixty/worktrunk` |
 | `openai-codex` | `openai/codex-plugin-cc` |
 | `goland-claude-marketplace` | `JetBrains/go-modern-guidelines` |
 | `astral-sh` | `astral-sh/claude-code-plugins` |
 
-Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl`,
+Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl-agent-extensions`,
 `worktrunk@worktrunk`; plus the applicable LSP (`gopls-lsp@claude-plugins-official` for Go).
 
 ## Step 2 — Enumerate each marketplace's plugin catalog (live)
@@ -117,10 +117,10 @@ Survey the target repo to know what to match against. Look for:
   `DESCRIPTION`/`*.R` (R), `package.json` (TS/JS), `*.tf` (Terraform), `Chart.yaml`/`k8s` manifests, `*.qmd` (Quarto), etc.
 - **Tooling / workflow signals:** `.github/workflows/` (CI), `.pre-commit-config.yaml`/`lefthook.yml`/`.husky` (hooks),
   `CHANGELOG.md`/`.changes/` (changie), `Dockerfile`/`docker-compose` (containers), `.sops.yaml` (secrets), docs sites.
-- **Repo shape:** is the target repo **itself the `rdl` marketplace** — i.e. does
-  `.claude-plugin/marketplace.json` exist with `name: rdl`? If so, **every** `@rdl` plugin
-  (not just `rdl@rdl` — also `gh@rdl`, `go@rdl`, …) is already provided by the working tree,
-  and installing the published copy would shadow local edits. Drop **all** `@rdl` ids from the
+- **Repo shape:** is the target repo **itself the `rdl-agent-extensions` marketplace** — i.e. does
+  `.claude-plugin/marketplace.json` exist with `name: rdl-agent-extensions`? If so, **every** `@rdl-agent-extensions` plugin
+  (not just `rdl@rdl-agent-extensions` — also `gh@rdl-agent-extensions`, `go@rdl-agent-extensions`, …) is already provided by the working tree,
+  and installing the published copy would shadow local edits. Drop **all** `@rdl-agent-extensions` ids from the
   install recommendation for that repo (the web path's `strip-self` enforces this; the local
   path has no such guard, so the recommendation itself must exclude them) and say why in the
   report's Notes.
@@ -131,15 +131,15 @@ Use `Glob`/`Grep` for fast detection; don't read whole files.
 
 Build the recommendation in three tiers:
 
-1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl,
+1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl-agent-extensions,
    worktrunk. These are useful in essentially every repo.
 2. **Applicable LSP.** From `baseline.lsp` plus any `*-lsp` plugins you found in the official
    catalog, include the one matching each detected language (gopls-lsp for Go, a python LSP
    for Python, etc.). Skip languages the repo doesn't use.
 3. **Stack-matched.** From the RDL catalog and `teamExternals`, the plugins whose subject
-   matches a detected language/tool: e.g. `go@rdl` + `gopls-lsp` + `modern-go-guidelines` for
-   a Go repo; `terraform@rdl` for `*.tf`; `kubernetes@rdl`/`argo-cd@rdl` for k8s; `astral@astral-sh`
-   for Python; `tech-writing@rdl`/`quarto@rdl` for docs-heavy repos. Match on keywords/description, and
+   matches a detected language/tool: e.g. `go@rdl-agent-extensions` + `gopls-lsp` + `modern-go-guidelines` for
+   a Go repo; `terraform@rdl-agent-extensions` for `*.tf`; `kubernetes@rdl-agent-extensions`/`argo-cd@rdl-agent-extensions` for k8s; `astral@astral-sh`
+   for Python; `tech-writing@rdl-agent-extensions`/`quarto@rdl-agent-extensions` for docs-heavy repos. Match on keywords/description, and
    keep it tight — only plugins with a real signal in the repo.
 
 Drop anything already enabled in the repo's `.claude/settings.json` (read `enabledPlugins`),
@@ -156,15 +156,15 @@ Return (do not install) a concise, scannable report the calling skill can presen
 
 ### Baseline (recommended for every repo)
 - pr-review-toolkit@claude-plugins-official — specialized PR-review subagents
-- gh@rdl — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
+- gh@rdl-agent-extensions — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
 - worktrunk@worktrunk — git worktree management via the wt CLI
 
 ### Language / LSP (detected: <languages>)
 - gopls-lsp@claude-plugins-official — gopls language server (go.mod found)
-- go@rdl — idiomatic Go naming and secure error handling
+- go@rdl-agent-extensions — idiomatic Go naming and secure error handling
 
 ### Stack-matched
-- terraform@rdl — *.tf detected; compliant HCL + IaC review
+- terraform@rdl-agent-extensions — *.tf detected; compliant HCL + IaC review
   …
 
 ### Notes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ targets:
   claude:
     enabled: true
     pluginName: go
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions
 ```
 
 Required behavior:
@@ -233,9 +233,9 @@ partial failure where the tag was created but the release publish step did not c
 
 ```bash
 /plugin marketplace add nq-rdl/agent-extensions
-/plugin install rdl@rdl                 # the meta-plugin installs every subject
+/plugin install rdl@rdl-agent-extensions                 # the meta-plugin installs every subject
 # …or install a single subject:
-/plugin install go@rdl --scope project
+/plugin install go@rdl-agent-extensions --scope project
 ```
 
 Publication target: this repository, with `.claude-plugin/marketplace.json` at the root and plugins under `plugins/`.

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -51,13 +51,13 @@ Install the whole set in one command via the `rdl` meta-plugin:
 
 ```bash
 /plugin marketplace add nq-rdl/agent-extensions
-/plugin install rdl@rdl    # installs every subject below
+/plugin install rdl@rdl-agent-extensions    # installs every subject below
 ```
 
 Or install a single subject:
 
 ```bash
-/plugin install <subject>@rdl
+/plugin install <subject>@rdl-agent-extensions
 ```
 
 ---

--- a/docs/external-marketplaces.md
+++ b/docs/external-marketplaces.md
@@ -1,15 +1,15 @@
 # External marketplaces
 
-This repo's `rdl` marketplace ships **only the plugins the team authors here**
+This repo's `rdl-agent-extensions` marketplace ships **only the plugins the team authors here**
 (under `skills/` and `agents/`). Plugins maintained by *other people* —
-Anthropic, vendors, OSS projects — are **not** re-hosted in `rdl`. Instead the
+Anthropic, vendors, OSS projects — are **not** re-hosted in `rdl-agent-extensions`. Instead the
 team consumes them straight from their **upstream marketplaces**, which Claude
 Code registers via the `extraKnownMarketplaces` setting.
 
-## Why not re-host them in `rdl`?
+## Why not re-host them in `rdl-agent-extensions`?
 
 A Claude Code marketplace catalogs *plugins*, not other marketplaces — you
-cannot nest one inside another. Re-publishing someone else's plugin into `rdl`
+cannot nest one inside another. Re-publishing someone else's plugin into `rdl-agent-extensions`
 (the old `external:` passthrough, now removed) meant **we** owned its source and
 version pin, and had to bump it to deliver upstream updates. Registering the
 upstream marketplace instead hands versioning and auto-update back to the people

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -24,16 +24,16 @@ Inside the devcontainer the repo is mounted at `/workspace` and `CLAUDE_CONFIG_D
 # Validate manifests first — catch schema errors before install
 claude plugin validate /workspace
 
-# Register the local repo as a marketplace named "rdl"
+# Register the local repo as a marketplace named "rdl-agent-extensions"
 claude plugin marketplace add /workspace
 
 # Confirm it registered
 claude plugin marketplace list
 
 # Install every subject in one command via the meta-plugin…
-claude plugin install rdl@rdl
+claude plugin install rdl@rdl-agent-extensions
 # …or install a single subject
-claude plugin install go@rdl
+claude plugin install go@rdl-agent-extensions
 ```
 
 Then launch `claude` and type `/` — confirm the expected skills appear (e.g. `/go:secure`, `/gh:changie`, `/claude-code:hook`).
@@ -53,7 +53,7 @@ After mapping a new skill (e.g. `go-secure` → `/go:secure`) into a subject bun
    `- {source: go-secure, leaf: secure}` mapping to rename the facet.
 2. Ensure the real-file copy exists: `test -d plugins/go/skills/secure && echo ok`
    (run `bash scripts/sync-plugins.sh go` if it does not).
-3. Re-run install: `claude plugin install go@rdl`.
+3. Re-run install: `claude plugin install go@rdl-agent-extensions`.
 4. In the Claude REPL, type `/go:secure` — it should autocomplete.
 
 ## Self-Contained Plugin Trees
@@ -78,7 +78,7 @@ claude --plugin-dir ./plugins/go
 Remove the marketplace registration and all installed plugins from it:
 
 ```bash
-claude plugin marketplace remove rdl
+claude plugin marketplace remove rdl-agent-extensions
 ```
 
 ## Why Not Copy Into `.claude/`?

--- a/plugins/claude-code/agents/marketplace-scout.md
+++ b/plugins/claude-code/agents/marketplace-scout.md
@@ -7,7 +7,7 @@ description: >-
   decide which ones THIS repo should enable. It locates the team's tracked
   marketplace list, enumerates each marketplace's plugin catalog (live), inspects
   the repo's languages and tooling, and returns a ranked suggestion set: the
-  always-useful baseline (pr-review-toolkit, gh@rdl, worktrunk, the applicable LSP)
+  always-useful baseline (pr-review-toolkit, gh@rdl-agent-extensions, worktrunk, the applicable LSP)
   plus language/stack-matched picks, each with id, marketplace, and a one-line reason.
   It only researches and recommends — it does not install or edit settings.
 license: MIT
@@ -61,14 +61,14 @@ Parse its keys:
 
 | Marketplace key | GitHub repo |
 |---|---|
-| `rdl` | `nq-rdl/agent-extensions` |
+| `rdl-agent-extensions` | `nq-rdl/agent-extensions` |
 | `claude-plugins-official` | `anthropics/claude-plugins-official` |
 | `worktrunk` | `max-sixty/worktrunk` |
 | `openai-codex` | `openai/codex-plugin-cc` |
 | `goland-claude-marketplace` | `JetBrains/go-modern-guidelines` |
 | `astral-sh` | `astral-sh/claude-code-plugins` |
 
-Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl`,
+Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl-agent-extensions`,
 `worktrunk@worktrunk`; plus the applicable LSP (`gopls-lsp@claude-plugins-official` for Go).
 
 ## Step 2 — Enumerate each marketplace's plugin catalog (live)
@@ -117,10 +117,10 @@ Survey the target repo to know what to match against. Look for:
   `DESCRIPTION`/`*.R` (R), `package.json` (TS/JS), `*.tf` (Terraform), `Chart.yaml`/`k8s` manifests, `*.qmd` (Quarto), etc.
 - **Tooling / workflow signals:** `.github/workflows/` (CI), `.pre-commit-config.yaml`/`lefthook.yml`/`.husky` (hooks),
   `CHANGELOG.md`/`.changes/` (changie), `Dockerfile`/`docker-compose` (containers), `.sops.yaml` (secrets), docs sites.
-- **Repo shape:** is the target repo **itself the `rdl` marketplace** — i.e. does
-  `.claude-plugin/marketplace.json` exist with `name: rdl`? If so, **every** `@rdl` plugin
-  (not just `rdl@rdl` — also `gh@rdl`, `go@rdl`, …) is already provided by the working tree,
-  and installing the published copy would shadow local edits. Drop **all** `@rdl` ids from the
+- **Repo shape:** is the target repo **itself the `rdl-agent-extensions` marketplace** — i.e. does
+  `.claude-plugin/marketplace.json` exist with `name: rdl-agent-extensions`? If so, **every** `@rdl-agent-extensions` plugin
+  (not just `rdl@rdl-agent-extensions` — also `gh@rdl-agent-extensions`, `go@rdl-agent-extensions`, …) is already provided by the working tree,
+  and installing the published copy would shadow local edits. Drop **all** `@rdl-agent-extensions` ids from the
   install recommendation for that repo (the web path's `strip-self` enforces this; the local
   path has no such guard, so the recommendation itself must exclude them) and say why in the
   report's Notes.
@@ -131,15 +131,15 @@ Use `Glob`/`Grep` for fast detection; don't read whole files.
 
 Build the recommendation in three tiers:
 
-1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl,
+1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl-agent-extensions,
    worktrunk. These are useful in essentially every repo.
 2. **Applicable LSP.** From `baseline.lsp` plus any `*-lsp` plugins you found in the official
    catalog, include the one matching each detected language (gopls-lsp for Go, a python LSP
    for Python, etc.). Skip languages the repo doesn't use.
 3. **Stack-matched.** From the RDL catalog and `teamExternals`, the plugins whose subject
-   matches a detected language/tool: e.g. `go@rdl` + `gopls-lsp` + `modern-go-guidelines` for
-   a Go repo; `terraform@rdl` for `*.tf`; `kubernetes@rdl`/`argo-cd@rdl` for k8s; `astral@astral-sh`
-   for Python; `tech-writing@rdl`/`quarto@rdl` for docs-heavy repos. Match on keywords/description, and
+   matches a detected language/tool: e.g. `go@rdl-agent-extensions` + `gopls-lsp` + `modern-go-guidelines` for
+   a Go repo; `terraform@rdl-agent-extensions` for `*.tf`; `kubernetes@rdl-agent-extensions`/`argo-cd@rdl-agent-extensions` for k8s; `astral@astral-sh`
+   for Python; `tech-writing@rdl-agent-extensions`/`quarto@rdl-agent-extensions` for docs-heavy repos. Match on keywords/description, and
    keep it tight — only plugins with a real signal in the repo.
 
 Drop anything already enabled in the repo's `.claude/settings.json` (read `enabledPlugins`),
@@ -156,15 +156,15 @@ Return (do not install) a concise, scannable report the calling skill can presen
 
 ### Baseline (recommended for every repo)
 - pr-review-toolkit@claude-plugins-official — specialized PR-review subagents
-- gh@rdl — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
+- gh@rdl-agent-extensions — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
 - worktrunk@worktrunk — git worktree management via the wt CLI
 
 ### Language / LSP (detected: <languages>)
 - gopls-lsp@claude-plugins-official — gopls language server (go.mod found)
-- go@rdl — idiomatic Go naming and secure error handling
+- go@rdl-agent-extensions — idiomatic Go naming and secure error handling
 
 ### Stack-matched
-- terraform@rdl — *.tf detected; compliant HCL + IaC review
+- terraform@rdl-agent-extensions — *.tf detected; compliant HCL + IaC review
   …
 
 ### Notes

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -200,7 +200,7 @@ exactly what you want. `cover` is a read-only assertion (no redirect needed).
 | Base | File | Use for |
 |---|---|---|
 | **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl-agent-extensions`) |
-| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
+| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no RDL catalog** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
 
 Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
 `alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).

--- a/plugins/claude-code/skills/web-setup/SKILL.md
+++ b/plugins/claude-code/skills/web-setup/SKILL.md
@@ -94,7 +94,7 @@ marketplace source"* undersells a hard constraint that is why layers 1–2 exist
 > work — **not** the git protocol.
 
 Practical consequence: a marketplace whose source repo **is** the session repo (e.g.
-`rdl@rdl` inside `nq-rdl/agent-extensions`) git-clones fine; **every external marketplace**
+`rdl@rdl-agent-extensions` inside `nq-rdl/agent-extensions`) git-clones fine; **every external marketplace**
 (`claude-plugins-official`, `worktrunk`, `astral-sh`, …) 403s over git. The route that
 survives this (see [`references/web-setup.rst`](references/web-setup.rst) → "Failure mode #4 —
 git-proxy repo-scoping" and Phase 3 below):
@@ -150,7 +150,7 @@ surfaced, never masked. (It flags **"install unverified"** when the CLI can't be
 - Check whether `.claude/settings.json` and `.claude/scripts/` already exist — this decides
   create-fresh vs. merge for each.
 - **Self-marketplace check.** If the target repo has a `.claude-plugin/marketplace.json`, it
-  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl`
+  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl-agent-extensions`
   inside `nq-rdl/agent-extensions`) installs `main`'s *published* copy into the plugin cache,
   silently **shadowing the working-tree edits** under development. Pick the **externals** base
   (not rdl) in Phase 2; the bundled `web-settings.sh strip-self` enforces this
@@ -199,14 +199,14 @@ exactly what you want. `cover` is a read-only assertion (no redirect needed).
 
 | Base | File | Use for |
 |---|---|---|
-| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
+| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl-agent-extensions`) |
 | **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
 
 Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
 `alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
 
 1. **Pick the base** per the table. For *rdl + externals* (a consumer wanting both), start
-   from the externals base and add `"rdl@rdl": true` to `enabledPlugins`.
+   from the externals base and add `"rdl@rdl-agent-extensions": true` to `enabledPlugins`.
 2. **Discover and tailor the plugin set.** Delegate the "what does this repo need?" work to
    the **`marketplace-scout`** agent (Task tool): it locates `assets/marketplaces.json`,
    enumerates the *live* catalog of every tracked marketplace (the RDL marketplace **and**
@@ -215,16 +215,16 @@ Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`
    recommends — **you** present its menu and let the user confirm; never silently decide.
    The scout's report is organized as:
    - **Baseline (always-useful)** — from `marketplaces.json` → `baseline`: `pr-review-toolkit@claude-plugins-official`,
-     `gh@rdl`, `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official`
+     `gh@rdl-agent-extensions`, `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official`
      for Go; the official marketplace ships more `*-lsp` plugins the scout enumerates per language).
    - **Language/LSP + stack-matched** — RDL subject plugins and `teamExternals` whose subject
-     matches a detected language/tool (e.g. `go@rdl` + `modern-go-guidelines` + `gopls-lsp` for Go,
-     `terraform@rdl` for `*.tf`, `astral@astral-sh` for Python).
+     matches a detected language/tool (e.g. `go@rdl-agent-extensions` + `modern-go-guidelines` + `gopls-lsp` for Go,
+     `terraform@rdl-agent-extensions` for `*.tf`, `astral@astral-sh` for Python).
 
    If you cannot or do not delegate, tailor by hand from `assets/marketplaces.json`: always
    offer the `baseline.always` set and the `agnostic`-tagged `teamExternals`; add the
    `go`/`python`/`workflow`-tagged entries and the matching `baseline.lsp` entry by language.
-   Remember `gh@rdl` (and any other `@rdl` baseline pick) is stripped automatically inside this
+   Remember `gh@rdl-agent-extensions` (and any other `@rdl-agent-extensions` baseline pick) is stripped automatically inside this
    repo by `strip-self` (Phase 0) — it is a suggestion for *consumer* repos.
 
    **Then classify each confirmed pick** — this single selection drives all three layers, and
@@ -279,7 +279,7 @@ writing**):
 - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never override a
   deliberate user choice.
 
-> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl` inside
+> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl-agent-extensions` inside
 > `nq-rdl/agent-extensions` installs `main`'s published catalog into the plugin cache,
 > shadowing your working-tree edits, and the self-cloning batch can break the whole
 > session-start install so **nothing** surfaces. `strip-self` removes it deterministically;

--- a/plugins/claude-code/skills/web-setup/assets/marketplaces.json
+++ b/plugins/claude-code/skills/web-setup/assets/marketplaces.json
@@ -20,7 +20,7 @@
       "source": { "source": "github", "repo": "max-sixty/worktrunk" },
       "autoUpdate": true
     },
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
       "autoUpdate": true
     }
@@ -70,7 +70,7 @@
     }
   ],
   "baseline": {
-    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl` marketplace (a .claude-plugin/marketplace.json named `rdl`, e.g. agent-extensions), the gh@rdl suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
+    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl-agent-extensions` marketplace (a .claude-plugin/marketplace.json named `rdl-agent-extensions`, e.g. agent-extensions), the gh@rdl-agent-extensions suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
     "always": [
       {
         "id": "pr-review-toolkit@claude-plugins-official",
@@ -78,8 +78,8 @@
         "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.) — the team's default review toolkit"
       },
       {
-        "id": "gh@rdl",
-        "marketplace": "rdl",
+        "id": "gh@rdl-agent-extensions",
+        "marketplace": "rdl-agent-extensions",
         "purpose": "GitHub workflow — git hooks, changelogs, conventional commits, pull requests, releases, and CI/CD (the RDL gh plugin)"
       },
       {

--- a/plugins/claude-code/skills/web-setup/assets/settings.json.tmpl
+++ b/plugins/claude-code/skills/web-setup/assets/settings.json.tmpl
@@ -23,10 +23,10 @@
     ]
   },
   "enabledPlugins": {
-    "rdl@rdl": true
+    "rdl@rdl-agent-extensions": true
   },
   "extraKnownMarketplaces": {
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": {
         "source": "github",
         "repo": "nq-rdl/agent-extensions"

--- a/plugins/claude-code/skills/web-setup/references/web-setup.rst
+++ b/plugins/claude-code/skills/web-setup/references/web-setup.rst
@@ -71,7 +71,7 @@ best-effort layer on top.
    session — even "session 2+" inheritance is unproven. Treat it as necessary config for
    plugin-behavior picks, **not** a delivery route, until a clean-cloud lifecycle test
    (install → restart → reuse) proves activation. This skill ships two bases —
-   ``assets/settings.json.tmpl`` (rdl) and ``assets/settings.externals.json.tmpl`` — and
+   ``assets/settings.json.tmpl`` (rdl-agent-extensions) and ``assets/settings.externals.json.tmpl`` — and
    ``assets/marketplaces.json`` as the source of truth for sources + the team-externals set.
 
 For the rare skill a team cannot commit, see "Escape hatch — fetch without committing" below;
@@ -317,7 +317,7 @@ Anti-patterns — do not repeat these
 
 These each cost a PR (or several) to learn:
 
-- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl``
+- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl-agent-extensions``
   inside ``nq-rdl/agent-extensions`` re-clones the repo and fans out to dozens of
   dependency plugins; that oversized self-cloning batch broke the whole session-start
   install so **nothing** surfaced. A catalog-dev env enables *external* dev-helper

--- a/plugins/rdl-team/agents/marketplace-scout.md
+++ b/plugins/rdl-team/agents/marketplace-scout.md
@@ -7,7 +7,7 @@ description: >-
   decide which ones THIS repo should enable. It locates the team's tracked
   marketplace list, enumerates each marketplace's plugin catalog (live), inspects
   the repo's languages and tooling, and returns a ranked suggestion set: the
-  always-useful baseline (pr-review-toolkit, gh@rdl, worktrunk, the applicable LSP)
+  always-useful baseline (pr-review-toolkit, gh@rdl-agent-extensions, worktrunk, the applicable LSP)
   plus language/stack-matched picks, each with id, marketplace, and a one-line reason.
   It only researches and recommends — it does not install or edit settings.
 license: MIT
@@ -61,14 +61,14 @@ Parse its keys:
 
 | Marketplace key | GitHub repo |
 |---|---|
-| `rdl` | `nq-rdl/agent-extensions` |
+| `rdl-agent-extensions` | `nq-rdl/agent-extensions` |
 | `claude-plugins-official` | `anthropics/claude-plugins-official` |
 | `worktrunk` | `max-sixty/worktrunk` |
 | `openai-codex` | `openai/codex-plugin-cc` |
 | `goland-claude-marketplace` | `JetBrains/go-modern-guidelines` |
 | `astral-sh` | `astral-sh/claude-code-plugins` |
 
-Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl`,
+Baseline (always suggest): `pr-review-toolkit@claude-plugins-official`, `gh@rdl-agent-extensions`,
 `worktrunk@worktrunk`; plus the applicable LSP (`gopls-lsp@claude-plugins-official` for Go).
 
 ## Step 2 — Enumerate each marketplace's plugin catalog (live)
@@ -117,10 +117,10 @@ Survey the target repo to know what to match against. Look for:
   `DESCRIPTION`/`*.R` (R), `package.json` (TS/JS), `*.tf` (Terraform), `Chart.yaml`/`k8s` manifests, `*.qmd` (Quarto), etc.
 - **Tooling / workflow signals:** `.github/workflows/` (CI), `.pre-commit-config.yaml`/`lefthook.yml`/`.husky` (hooks),
   `CHANGELOG.md`/`.changes/` (changie), `Dockerfile`/`docker-compose` (containers), `.sops.yaml` (secrets), docs sites.
-- **Repo shape:** is the target repo **itself the `rdl` marketplace** — i.e. does
-  `.claude-plugin/marketplace.json` exist with `name: rdl`? If so, **every** `@rdl` plugin
-  (not just `rdl@rdl` — also `gh@rdl`, `go@rdl`, …) is already provided by the working tree,
-  and installing the published copy would shadow local edits. Drop **all** `@rdl` ids from the
+- **Repo shape:** is the target repo **itself the `rdl-agent-extensions` marketplace** — i.e. does
+  `.claude-plugin/marketplace.json` exist with `name: rdl-agent-extensions`? If so, **every** `@rdl-agent-extensions` plugin
+  (not just `rdl@rdl-agent-extensions` — also `gh@rdl-agent-extensions`, `go@rdl-agent-extensions`, …) is already provided by the working tree,
+  and installing the published copy would shadow local edits. Drop **all** `@rdl-agent-extensions` ids from the
   install recommendation for that repo (the web path's `strip-self` enforces this; the local
   path has no such guard, so the recommendation itself must exclude them) and say why in the
   report's Notes.
@@ -131,15 +131,15 @@ Use `Glob`/`Grep` for fast detection; don't read whole files.
 
 Build the recommendation in three tiers:
 
-1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl,
+1. **Baseline (always).** The `baseline.always` set verbatim — pr-review-toolkit, gh@rdl-agent-extensions,
    worktrunk. These are useful in essentially every repo.
 2. **Applicable LSP.** From `baseline.lsp` plus any `*-lsp` plugins you found in the official
    catalog, include the one matching each detected language (gopls-lsp for Go, a python LSP
    for Python, etc.). Skip languages the repo doesn't use.
 3. **Stack-matched.** From the RDL catalog and `teamExternals`, the plugins whose subject
-   matches a detected language/tool: e.g. `go@rdl` + `gopls-lsp` + `modern-go-guidelines` for
-   a Go repo; `terraform@rdl` for `*.tf`; `kubernetes@rdl`/`argo-cd@rdl` for k8s; `astral@astral-sh`
-   for Python; `tech-writing@rdl`/`quarto@rdl` for docs-heavy repos. Match on keywords/description, and
+   matches a detected language/tool: e.g. `go@rdl-agent-extensions` + `gopls-lsp` + `modern-go-guidelines` for
+   a Go repo; `terraform@rdl-agent-extensions` for `*.tf`; `kubernetes@rdl-agent-extensions`/`argo-cd@rdl-agent-extensions` for k8s; `astral@astral-sh`
+   for Python; `tech-writing@rdl-agent-extensions`/`quarto@rdl-agent-extensions` for docs-heavy repos. Match on keywords/description, and
    keep it tight — only plugins with a real signal in the repo.
 
 Drop anything already enabled in the repo's `.claude/settings.json` (read `enabledPlugins`),
@@ -156,15 +156,15 @@ Return (do not install) a concise, scannable report the calling skill can presen
 
 ### Baseline (recommended for every repo)
 - pr-review-toolkit@claude-plugins-official — specialized PR-review subagents
-- gh@rdl — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
+- gh@rdl-agent-extensions — GitHub workflow: hooks, changelog, conventional commits, PRs, releases
 - worktrunk@worktrunk — git worktree management via the wt CLI
 
 ### Language / LSP (detected: <languages>)
 - gopls-lsp@claude-plugins-official — gopls language server (go.mod found)
-- go@rdl — idiomatic Go naming and secure error handling
+- go@rdl-agent-extensions — idiomatic Go naming and secure error handling
 
 ### Stack-matched
-- terraform@rdl — *.tf detected; compliant HCL + IaC review
+- terraform@rdl-agent-extensions — *.tf detected; compliant HCL + IaC review
   …
 
 ### Notes

--- a/plugins/rdl-team/skills/cc-setup/SKILL.md
+++ b/plugins/rdl-team/skills/cc-setup/SKILL.md
@@ -166,11 +166,11 @@ team's tracked-marketplace list (`marketplaces.json` — shipped in this skill's
 also in the `cc-web-setup` plugin), enumerates the *live* plugin catalog of every tracked
 marketplace, inspects this repo's languages/tooling, and returns a ranked suggestion list:
 
-- **Baseline (always-useful)** — `pr-review-toolkit@claude-plugins-official`, `gh@rdl`,
+- **Baseline (always-useful)** — `pr-review-toolkit@claude-plugins-official`, `gh@rdl-agent-extensions`,
   `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official` for Go;
   the official marketplace ships more `*-lsp` plugins the scout matches by language).
 - **Language/stack-matched** — RDL subject plugins and team externals whose subject matches a
-  detected language/tool (`go@rdl`, `terraform@rdl`, `astral@astral-sh`, …).
+  detected language/tool (`go@rdl-agent-extensions`, `terraform@rdl-agent-extensions`, `astral@astral-sh`, …).
 
 The marketplace list lives in `assets/marketplaces.json` beside this skill (resolve it the
 same way as the hook script in Phase 1: prefer the installed plugin-cache copy, fall back to
@@ -182,16 +182,16 @@ register it and install **only the confirmed plugins** — locally this skill *c
 
 ```bash
 # Register each marketplace the chosen plugins need (idempotent), then install.
-claude plugin marketplace add <owner>/<repo>      # e.g. nq-rdl/agent-extensions for @rdl
+claude plugin marketplace add <owner>/<repo>      # e.g. nq-rdl/agent-extensions for @rdl-agent-extensions
 claude plugin install <plugin>@<marketplace>      # only the ones the user confirmed
 ```
 
 Never install without confirmation. **Self-marketplace guard:** if the target repo is
-itself the `rdl` marketplace (a `.claude-plugin/marketplace.json` with `name: rdl` — e.g.
-`agent-extensions` itself), skip **every** `@rdl` plugin, not just `rdl@rdl`. Installing the
-published copy of *any* `@rdl` id (including the baseline's `gh@rdl`) shadows the working
+itself the `rdl-agent-extensions` marketplace (a `.claude-plugin/marketplace.json` with `name: rdl-agent-extensions` — e.g.
+`agent-extensions` itself), skip **every** `@rdl-agent-extensions` plugin, not just `rdl@rdl-agent-extensions`. Installing the
+published copy of *any* `@rdl-agent-extensions` id (including the baseline's `gh@rdl-agent-extensions`) shadows the working
 tree's own copy. Unlike the web path, this local install has no automatic `strip-self`, so
-you must exclude `@rdl` ids yourself there — the working tree already provides those skills.
+you must exclude `@rdl-agent-extensions` ids yourself there — the working tree already provides those skills.
 
 ## Phase 5 — Summarize
 

--- a/plugins/rdl-team/skills/cc-setup/assets/marketplaces.json
+++ b/plugins/rdl-team/skills/cc-setup/assets/marketplaces.json
@@ -20,7 +20,7 @@
       "source": { "source": "github", "repo": "max-sixty/worktrunk" },
       "autoUpdate": true
     },
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
       "autoUpdate": true
     }
@@ -70,7 +70,7 @@
     }
   ],
   "baseline": {
-    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl` marketplace (a .claude-plugin/marketplace.json named `rdl`, e.g. agent-extensions), the gh@rdl suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
+    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl-agent-extensions` marketplace (a .claude-plugin/marketplace.json named `rdl-agent-extensions`, e.g. agent-extensions), the gh@rdl-agent-extensions suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
     "always": [
       {
         "id": "pr-review-toolkit@claude-plugins-official",
@@ -78,8 +78,8 @@
         "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.) — the team's default review toolkit"
       },
       {
-        "id": "gh@rdl",
-        "marketplace": "rdl",
+        "id": "gh@rdl-agent-extensions",
+        "marketplace": "rdl-agent-extensions",
         "purpose": "GitHub workflow — git hooks, changelogs, conventional commits, pull requests, releases, and CI/CD (the RDL gh plugin)"
       },
       {

--- a/registry/bundles/ansible.yaml
+++ b/registry/bundles/ansible.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: ansible
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/arch-linux.yaml
+++ b/registry/bundles/arch-linux.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: arch-linux
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/argo-cd.yaml
+++ b/registry/bundles/argo-cd.yaml
@@ -18,4 +18,4 @@ targets:
   claude:
     enabled: true
     pluginName: argo-cd
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/bitwarden.yaml
+++ b/registry/bundles/bitwarden.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: bitwarden
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/charm-tui.yaml
+++ b/registry/bundles/charm-tui.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: charm-tui
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/claude-code.yaml
+++ b/registry/bundles/claude-code.yaml
@@ -25,4 +25,4 @@ targets:
   claude:
     enabled: true
     pluginName: claude-code
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/debug.yaml
+++ b/registry/bundles/debug.yaml
@@ -18,4 +18,4 @@ targets:
   claude:
     enabled: true
     pluginName: debug
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/defuddle.yaml
+++ b/registry/bundles/defuddle.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: defuddle
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/gh.yaml
+++ b/registry/bundles/gh.yaml
@@ -28,4 +28,4 @@ targets:
   claude:
     enabled: true
     pluginName: gh
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/go.yaml
+++ b/registry/bundles/go.yaml
@@ -21,4 +21,4 @@ targets:
   claude:
     enabled: true
     pluginName: go
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/kubernetes.yaml
+++ b/registry/bundles/kubernetes.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: kubernetes
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/lucid.yaml
+++ b/registry/bundles/lucid.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: lucid
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/lychee.yaml
+++ b/registry/bundles/lychee.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: lychee
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/mongodb.yaml
+++ b/registry/bundles/mongodb.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: mongodb
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/obsidian.yaml
+++ b/registry/bundles/obsidian.yaml
@@ -19,4 +19,4 @@ targets:
   claude:
     enabled: true
     pluginName: obsidian
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/opencode-dev.yaml
+++ b/registry/bundles/opencode-dev.yaml
@@ -23,4 +23,4 @@ targets:
   claude:
     enabled: true
     pluginName: opencode-dev
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/pixi.yaml
+++ b/registry/bundles/pixi.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: pixi
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/planning.yaml
+++ b/registry/bundles/planning.yaml
@@ -21,4 +21,4 @@ targets:
   claude:
     enabled: true
     pluginName: planning
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/playwright.yaml
+++ b/registry/bundles/playwright.yaml
@@ -18,4 +18,4 @@ targets:
   claude:
     enabled: true
     pluginName: playwright
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/postgres.yaml
+++ b/registry/bundles/postgres.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: postgres
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/quarto.yaml
+++ b/registry/bundles/quarto.yaml
@@ -18,4 +18,4 @@ targets:
   claude:
     enabled: true
     pluginName: quarto
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/r.yaml
+++ b/registry/bundles/r.yaml
@@ -24,4 +24,4 @@ targets:
   claude:
     enabled: true
     pluginName: r
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/rdl-team.yaml
+++ b/registry/bundles/rdl-team.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: rdl-team
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/rust.yaml
+++ b/registry/bundles/rust.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: rust
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/shiny.yaml
+++ b/registry/bundles/shiny.yaml
@@ -18,4 +18,4 @@ targets:
   claude:
     enabled: true
     pluginName: shiny
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/sops.yaml
+++ b/registry/bundles/sops.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: sops
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/starrocks.yaml
+++ b/registry/bundles/starrocks.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: starrocks
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/tech-writing.yaml
+++ b/registry/bundles/tech-writing.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: tech-writing
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/terraform.yaml
+++ b/registry/bundles/terraform.yaml
@@ -19,4 +19,4 @@ targets:
   claude:
     enabled: true
     pluginName: terraform
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/bundles/writerside.yaml
+++ b/registry/bundles/writerside.yaml
@@ -17,4 +17,4 @@ targets:
   claude:
     enabled: true
     pluginName: writerside
-    marketplaceName: rdl
+    marketplaceName: rdl-agent-extensions

--- a/registry/marketplace.yaml
+++ b/registry/marketplace.yaml
@@ -4,7 +4,7 @@
 # registry/bundles/*.yaml and VERSION by scripts/generate_manifests.py.
 # Do NOT hand-edit the generated manifests — CI (generate_manifests.py --check)
 # fails if they drift. This is the structural fix for #100's metadata rot.
-name: rdl
+name: rdl-agent-extensions
 owner:
   name: nq-rdl
   email: tsv-datalab@health.qld.gov.au
@@ -57,7 +57,7 @@ order:
 # via `extraKnownMarketplaces`. See docs/external-marketplaces.md.
 
 # D-1 meta-plugin: a content-less plugin that declares every local subject plugin
-# as a dependency, so `claude plugin install rdl@rdl` installs the whole set and
+# as a dependency, so `claude plugin install rdl@rdl-agent-extensions` installs the whole set and
 # `claude plugin uninstall rdl --prune` cleans up. The dependency list is
 # generated from the enabled bundles. Emitted only when enabled.
 meta:

--- a/scripts/generate_bundles_doc.py
+++ b/scripts/generate_bundles_doc.py
@@ -105,14 +105,14 @@ def generate(repo) -> str:
         "/plugin marketplace add nq-rdl/agent-extensions",
     ]
     if meta.get("enabled"):
-        lines += [f"/plugin install {meta['name']}@rdl    # installs every subject below"]
+        lines += [f"/plugin install {meta['name']}@{mkt['name']}    # installs every subject below"]
     lines += [
         "```",
         "",
         "Or install a single subject:",
         "",
         "```bash",
-        "/plugin install <subject>@rdl",
+        f"/plugin install <subject>@{mkt['name']}",
         "```",
         "",
     ]

--- a/skills/cc-setup/SKILL.md
+++ b/skills/cc-setup/SKILL.md
@@ -167,11 +167,11 @@ team's tracked-marketplace list (`marketplaces.json` — shipped in this skill's
 also in the `cc-web-setup` plugin), enumerates the *live* plugin catalog of every tracked
 marketplace, inspects this repo's languages/tooling, and returns a ranked suggestion list:
 
-- **Baseline (always-useful)** — `pr-review-toolkit@claude-plugins-official`, `gh@rdl`,
+- **Baseline (always-useful)** — `pr-review-toolkit@claude-plugins-official`, `gh@rdl-agent-extensions`,
   `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official` for Go;
   the official marketplace ships more `*-lsp` plugins the scout matches by language).
 - **Language/stack-matched** — RDL subject plugins and team externals whose subject matches a
-  detected language/tool (`go@rdl`, `terraform@rdl`, `astral@astral-sh`, …).
+  detected language/tool (`go@rdl-agent-extensions`, `terraform@rdl-agent-extensions`, `astral@astral-sh`, …).
 
 The marketplace list lives in `assets/marketplaces.json` beside this skill (resolve it the
 same way as the hook script in Phase 1: prefer the installed plugin-cache copy, fall back to
@@ -183,16 +183,16 @@ register it and install **only the confirmed plugins** — locally this skill *c
 
 ```bash
 # Register each marketplace the chosen plugins need (idempotent), then install.
-claude plugin marketplace add <owner>/<repo>      # e.g. nq-rdl/agent-extensions for @rdl
+claude plugin marketplace add <owner>/<repo>      # e.g. nq-rdl/agent-extensions for @rdl-agent-extensions
 claude plugin install <plugin>@<marketplace>      # only the ones the user confirmed
 ```
 
 Never install without confirmation. **Self-marketplace guard:** if the target repo is
-itself the `rdl` marketplace (a `.claude-plugin/marketplace.json` with `name: rdl` — e.g.
-`agent-extensions` itself), skip **every** `@rdl` plugin, not just `rdl@rdl`. Installing the
-published copy of *any* `@rdl` id (including the baseline's `gh@rdl`) shadows the working
+itself the `rdl-agent-extensions` marketplace (a `.claude-plugin/marketplace.json` with `name: rdl-agent-extensions` — e.g.
+`agent-extensions` itself), skip **every** `@rdl-agent-extensions` plugin, not just `rdl@rdl-agent-extensions`. Installing the
+published copy of *any* `@rdl-agent-extensions` id (including the baseline's `gh@rdl-agent-extensions`) shadows the working
 tree's own copy. Unlike the web path, this local install has no automatic `strip-self`, so
-you must exclude `@rdl` ids yourself there — the working tree already provides those skills.
+you must exclude `@rdl-agent-extensions` ids yourself there — the working tree already provides those skills.
 
 ## Phase 5 — Summarize
 

--- a/skills/cc-setup/assets/marketplaces.json
+++ b/skills/cc-setup/assets/marketplaces.json
@@ -20,7 +20,7 @@
       "source": { "source": "github", "repo": "max-sixty/worktrunk" },
       "autoUpdate": true
     },
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
       "autoUpdate": true
     }
@@ -70,7 +70,7 @@
     }
   ],
   "baseline": {
-    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl` marketplace (a .claude-plugin/marketplace.json named `rdl`, e.g. agent-extensions), the gh@rdl suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
+    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl-agent-extensions` marketplace (a .claude-plugin/marketplace.json named `rdl-agent-extensions`, e.g. agent-extensions), the gh@rdl-agent-extensions suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
     "always": [
       {
         "id": "pr-review-toolkit@claude-plugins-official",
@@ -78,8 +78,8 @@
         "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.) — the team's default review toolkit"
       },
       {
-        "id": "gh@rdl",
-        "marketplace": "rdl",
+        "id": "gh@rdl-agent-extensions",
+        "marketplace": "rdl-agent-extensions",
         "purpose": "GitHub workflow — git hooks, changelogs, conventional commits, pull requests, releases, and CI/CD (the RDL gh plugin)"
       },
       {

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -95,7 +95,7 @@ marketplace source"* undersells a hard constraint that is why layers 1–2 exist
 > work — **not** the git protocol.
 
 Practical consequence: a marketplace whose source repo **is** the session repo (e.g.
-`rdl@rdl` inside `nq-rdl/agent-extensions`) git-clones fine; **every external marketplace**
+`rdl@rdl-agent-extensions` inside `nq-rdl/agent-extensions`) git-clones fine; **every external marketplace**
 (`claude-plugins-official`, `worktrunk`, `astral-sh`, …) 403s over git. The route that
 survives this (see [`references/web-setup.rst`](references/web-setup.rst) → "Failure mode #4 —
 git-proxy repo-scoping" and Phase 3 below):
@@ -151,7 +151,7 @@ surfaced, never masked. (It flags **"install unverified"** when the CLI can't be
 - Check whether `.claude/settings.json` and `.claude/scripts/` already exist — this decides
   create-fresh vs. merge for each.
 - **Self-marketplace check.** If the target repo has a `.claude-plugin/marketplace.json`, it
-  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl`
+  **is itself a Claude Code marketplace** — enabling a plugin it publishes (e.g. `rdl@rdl-agent-extensions`
   inside `nq-rdl/agent-extensions`) installs `main`'s *published* copy into the plugin cache,
   silently **shadowing the working-tree edits** under development. Pick the **externals** base
   (not rdl) in Phase 2; the bundled `web-settings.sh strip-self` enforces this
@@ -200,14 +200,14 @@ exactly what you want. `cover` is a read-only assertion (no redirect needed).
 
 | Base | File | Use for |
 |---|---|---|
-| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl`) |
+| **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl-agent-extensions`) |
 | **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
 
 Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
 `alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).
 
 1. **Pick the base** per the table. For *rdl + externals* (a consumer wanting both), start
-   from the externals base and add `"rdl@rdl": true` to `enabledPlugins`.
+   from the externals base and add `"rdl@rdl-agent-extensions": true` to `enabledPlugins`.
 2. **Discover and tailor the plugin set.** Delegate the "what does this repo need?" work to
    the **`marketplace-scout`** agent (Task tool): it locates `assets/marketplaces.json`,
    enumerates the *live* catalog of every tracked marketplace (the RDL marketplace **and**
@@ -216,16 +216,16 @@ Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`
    recommends — **you** present its menu and let the user confirm; never silently decide.
    The scout's report is organized as:
    - **Baseline (always-useful)** — from `marketplaces.json` → `baseline`: `pr-review-toolkit@claude-plugins-official`,
-     `gh@rdl`, `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official`
+     `gh@rdl-agent-extensions`, `worktrunk@worktrunk`, plus the applicable LSP (`gopls-lsp@claude-plugins-official`
      for Go; the official marketplace ships more `*-lsp` plugins the scout enumerates per language).
    - **Language/LSP + stack-matched** — RDL subject plugins and `teamExternals` whose subject
-     matches a detected language/tool (e.g. `go@rdl` + `modern-go-guidelines` + `gopls-lsp` for Go,
-     `terraform@rdl` for `*.tf`, `astral@astral-sh` for Python).
+     matches a detected language/tool (e.g. `go@rdl-agent-extensions` + `modern-go-guidelines` + `gopls-lsp` for Go,
+     `terraform@rdl-agent-extensions` for `*.tf`, `astral@astral-sh` for Python).
 
    If you cannot or do not delegate, tailor by hand from `assets/marketplaces.json`: always
    offer the `baseline.always` set and the `agnostic`-tagged `teamExternals`; add the
    `go`/`python`/`workflow`-tagged entries and the matching `baseline.lsp` entry by language.
-   Remember `gh@rdl` (and any other `@rdl` baseline pick) is stripped automatically inside this
+   Remember `gh@rdl-agent-extensions` (and any other `@rdl-agent-extensions` baseline pick) is stripped automatically inside this
    repo by `strip-self` (Phase 0) — it is a suggestion for *consumer* repos.
 
    **Then classify each confirmed pick** — this single selection drives all three layers, and
@@ -280,7 +280,7 @@ writing**):
 - `model` / `alwaysThinkingEnabled` / `effortLevel`: set **only if absent** — never override a
   deliberate user choice.
 
-> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl` inside
+> **Why externals-not-rdl for a marketplace repo.** Enabling `rdl@rdl-agent-extensions` inside
 > `nq-rdl/agent-extensions` installs `main`'s published catalog into the plugin cache,
 > shadowing your working-tree edits, and the self-cloning batch can break the whole
 > session-start install so **nothing** surfaces. `strip-self` removes it deterministically;

--- a/skills/cc-web-setup/SKILL.md
+++ b/skills/cc-web-setup/SKILL.md
@@ -201,7 +201,7 @@ exactly what you want. `cover` is a read-only assertion (no redirect needed).
 | Base | File | Use for |
 |---|---|---|
 | **rdl** | `assets/settings.json.tmpl` | a *consumer* repo that wants the RDL catalog (`rdl@rdl-agent-extensions`) |
-| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no rdl** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
+| **externals** | `assets/settings.externals.json.tmpl` | the team's external dev-helper plugins, **no RDL catalog** — and the **only** correct base when Phase 0 found a `.claude-plugin/marketplace.json` |
 
 Both wire the two SessionStart hooks and the opinionated defaults (`model: opus`,
 `alwaysThinkingEnabled`, `effortLevel: xhigh`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`).

--- a/skills/cc-web-setup/assets/marketplaces.json
+++ b/skills/cc-web-setup/assets/marketplaces.json
@@ -20,7 +20,7 @@
       "source": { "source": "github", "repo": "max-sixty/worktrunk" },
       "autoUpdate": true
     },
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": { "source": "github", "repo": "nq-rdl/agent-extensions" },
       "autoUpdate": true
     }
@@ -70,7 +70,7 @@
     }
   ],
   "baseline": {
-    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl` marketplace (a .claude-plugin/marketplace.json named `rdl`, e.g. agent-extensions), the gh@rdl suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
+    "description": "Always-useful plugins to suggest on every setup (cc-setup / cc-web-setup), regardless of the repo's stack. The `always` set is language-agnostic; the `lsp` set is language-applicable — offer the entry whose `language` matches a detected language. Every id's @marketplace must be declared in `marketplaces` above. Caveat for marketplace repos: when the repo being set up is itself the `rdl-agent-extensions` marketplace (a .claude-plugin/marketplace.json named `rdl-agent-extensions`, e.g. agent-extensions), the gh@rdl-agent-extensions suggestion is removed — automatically by web-settings.sh strip-self on the web path, and manually by the cc-setup self-marketplace guard on the local path.",
     "always": [
       {
         "id": "pr-review-toolkit@claude-plugins-official",
@@ -78,8 +78,8 @@
         "purpose": "specialized PR-review subagents (silent-failure-hunter, type-design, etc.) — the team's default review toolkit"
       },
       {
-        "id": "gh@rdl",
-        "marketplace": "rdl",
+        "id": "gh@rdl-agent-extensions",
+        "marketplace": "rdl-agent-extensions",
         "purpose": "GitHub workflow — git hooks, changelogs, conventional commits, pull requests, releases, and CI/CD (the RDL gh plugin)"
       },
       {

--- a/skills/cc-web-setup/assets/settings.json.tmpl
+++ b/skills/cc-web-setup/assets/settings.json.tmpl
@@ -23,10 +23,10 @@
     ]
   },
   "enabledPlugins": {
-    "rdl@rdl": true
+    "rdl@rdl-agent-extensions": true
   },
   "extraKnownMarketplaces": {
-    "rdl": {
+    "rdl-agent-extensions": {
       "source": {
         "source": "github",
         "repo": "nq-rdl/agent-extensions"

--- a/skills/cc-web-setup/references/web-setup.rst
+++ b/skills/cc-web-setup/references/web-setup.rst
@@ -71,7 +71,7 @@ best-effort layer on top.
    session — even "session 2+" inheritance is unproven. Treat it as necessary config for
    plugin-behavior picks, **not** a delivery route, until a clean-cloud lifecycle test
    (install → restart → reuse) proves activation. This skill ships two bases —
-   ``assets/settings.json.tmpl`` (rdl) and ``assets/settings.externals.json.tmpl`` — and
+   ``assets/settings.json.tmpl`` (rdl-agent-extensions) and ``assets/settings.externals.json.tmpl`` — and
    ``assets/marketplaces.json`` as the source of truth for sources + the team-externals set.
 
 For the rare skill a team cannot commit, see "Escape hatch — fetch without committing" below;
@@ -317,7 +317,7 @@ Anti-patterns — do not repeat these
 
 These each cost a PR (or several) to learn:
 
-- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl``
+- **Self-referential / meta marketplace in its own dev env.** Enabling ``rdl@rdl-agent-extensions``
   inside ``nq-rdl/agent-extensions`` re-clones the repo and fans out to dozens of
   dependency plugins; that oversized self-cloning batch broke the whole session-start
   install so **nothing** surfaced. A catalog-dev env enables *external* dev-helper

--- a/tests/e2e/marketplace-smoke.sh
+++ b/tests/e2e/marketplace-smoke.sh
@@ -64,7 +64,7 @@ if [ "${1:-}" = "--live" ]; then
     else
       bad "live: marketplace add failed"; tail -3 "$tmp/add.out"
     fi
-    if claude plugin install rdl@rdl >"$tmp/install.out" 2>&1; then pass "live: install rdl@rdl"; else bad "live: install rdl@rdl failed"; tail -3 "$tmp/install.out"; fi
+    if claude plugin install rdl@rdl-agent-extensions >"$tmp/install.out" 2>&1; then pass "live: install rdl@rdl-agent-extensions"; else bad "live: install rdl@rdl-agent-extensions failed"; tail -3 "$tmp/install.out"; fi
     # Verify `plugin list` itself succeeded before drawing conclusions from its
     # output — otherwise an errored listing has no "zod" line and false-PASSes the
     # removal assertion below.

--- a/tests/test_web_setup_templates.py
+++ b/tests/test_web_setup_templates.py
@@ -99,8 +99,8 @@ class TestMarketplacesJson(unittest.TestCase):
         # a curated team external, or strip-self's self-marketplace target would reappear.
         for ext in self.externals:
             with self.subTest(plugin=ext["id"]):
-                self.assertNotEqual(ext["marketplace"], "rdl")
-                self.assertNotEqual(ext["id"], "rdl@rdl")
+                self.assertNotEqual(ext["marketplace"], "rdl-agent-extensions")
+                self.assertNotEqual(ext["id"], "rdl@rdl-agent-extensions")
 
     def test_baseline_ids_reference_known_marketplaces(self):
         # The always-useful set the setup skills + marketplace-scout suggest. Every id must
@@ -124,7 +124,7 @@ class TestMarketplacesJson(unittest.TestCase):
             always,
             {
                 "pr-review-toolkit@claude-plugins-official",
-                "gh@rdl",
+                "gh@rdl-agent-extensions",
                 "worktrunk@worktrunk",
             },
         )
@@ -203,13 +203,13 @@ class TestTemplates(unittest.TestCase):
 
 class TestTemplateExactSets(unittest.TestCase):
     def test_rdl_template_enables_exactly_rdl(self):
-        self.assertEqual(load(RDL_TMPL)["enabledPlugins"], {"rdl@rdl": True})
+        self.assertEqual(load(RDL_TMPL)["enabledPlugins"], {"rdl@rdl-agent-extensions": True})
 
     def test_externals_template_matches_team_externals_and_excludes_rdl(self):
         external_ids = {e["id"] for e in load(MARKETPLACES)["teamExternals"]}
         enabled = load(EXT_TMPL)["enabledPlugins"]
         self.assertEqual(set(enabled), external_ids)
-        self.assertNotIn("rdl@rdl", enabled)
+        self.assertNotIn("rdl@rdl-agent-extensions", enabled)
 
 
 class TestEngineByteIdentity(unittest.TestCase):
@@ -254,9 +254,9 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.externals = load(EXT_TMPL)
 
     def _externals_plus_rdl(self):
-        """The 'rdl + externals' composition: the 7 externals + rdl@rdl enabled."""
+        """The 'rdl + externals' composition: the 7 externals + rdl@rdl-agent-extensions enabled."""
         both = dict(self.externals)
-        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl": True})
+        both["enabledPlugins"] = dict(both["enabledPlugins"], **{"rdl@rdl-agent-extensions": True})
         return both
 
     # --- cover ---
@@ -282,7 +282,7 @@ class TestWebSettingsHelper(unittest.TestCase):
             set(out["extraKnownMarketplaces"]),
             {
                 "claude-plugins-official", "openai-codex", "goland-claude-marketplace",
-                "astral-sh", "worktrunk", "rdl",
+                "astral-sh", "worktrunk", "rdl-agent-extensions",
             },
         )
 
@@ -320,7 +320,7 @@ class TestWebSettingsHelper(unittest.TestCase):
 
     def test_composed_rdl_plus_externals(self):
         # The 'rdl + externals' outcome: externals template + the single rdl line,
-        # reconciled by ensure. No duplicate hooks, exactly one rdl@rdl, all 8
+        # reconciled by ensure. No duplicate hooks, exactly one rdl@rdl-agent-extensions, all 8
         # plugins, 6 marketplaces, and top-level keys preserved.
         both = self._externals_plus_rdl()
         path = self._write(both)
@@ -329,8 +329,8 @@ class TestWebSettingsHelper(unittest.TestCase):
         out = json.loads(res.stdout)
         self.assertEqual(session_start_commands(out), HOOK_CMDS)
         self.assertEqual(set(out["enabledPlugins"]), set(both["enabledPlugins"]))
-        self.assertIs(out["enabledPlugins"]["rdl@rdl"], True)
-        self.assertIn("rdl", out["extraKnownMarketplaces"])
+        self.assertIs(out["enabledPlugins"]["rdl@rdl-agent-extensions"], True)
+        self.assertIn("rdl-agent-extensions", out["extraKnownMarketplaces"])
         self.assertEqual(len(out["extraKnownMarketplaces"]), 6)
         # ensure must only touch extraKnownMarketplaces — model/env/effortLevel survive.
         for key in ("model", "env", "effortLevel"):
@@ -453,7 +453,7 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.assertEqual(set(l for l in lines if l), {"ghost1@acme", "ghost2@acme"})
 
     # --- strip-self ---
-    def _marketplace_repo(self, name="rdl"):
+    def _marketplace_repo(self, name="rdl-agent-extensions"):
         root = tempfile.mkdtemp(dir=self.tmp)
         plugin_dir = Path(root) / ".claude-plugin"
         plugin_dir.mkdir()
@@ -466,15 +466,15 @@ class TestWebSettingsHelper(unittest.TestCase):
         both = self._externals_plus_rdl()
         both["extraKnownMarketplaces"] = dict(
             both["extraKnownMarketplaces"],
-            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+            **{"rdl-agent-extensions": {"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True}},
         )
         path = self._write(both)
-        root = self._marketplace_repo("rdl")
+        root = self._marketplace_repo("rdl-agent-extensions")
         res = run_helper(HELPER, "strip-self", root, path)
         self.assertEqual(res.returncode, 0, res.stderr)
         out = json.loads(res.stdout)
-        self.assertNotIn("rdl@rdl", out["enabledPlugins"])
-        self.assertNotIn("rdl", out["extraKnownMarketplaces"])
+        self.assertNotIn("rdl@rdl-agent-extensions", out["enabledPlugins"])
+        self.assertNotIn("rdl-agent-extensions", out["extraKnownMarketplaces"])
         self.assertEqual(set(out["enabledPlugins"]), set(self.externals["enabledPlugins"]))
 
     def test_strip_self_keeps_a_differently_named_marketplace(self):
@@ -568,10 +568,10 @@ class TestWebSettingsHelper(unittest.TestCase):
         both = self._externals_plus_rdl()
         both["extraKnownMarketplaces"] = dict(
             both["extraKnownMarketplaces"],
-            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+            **{"rdl-agent-extensions": {"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True}},
         )
         path = self._write(both)
-        root = self._marketplace_repo("rdl")
+        root = self._marketplace_repo("rdl-agent-extensions")
         stripped = run_helper(HELPER, "strip-self", root, path)
         self.assertEqual(stripped.returncode, 0, stripped.stderr)
         p2 = self._write(json.loads(stripped.stdout))
@@ -583,8 +583,8 @@ class TestWebSettingsHelper(unittest.TestCase):
         self.assertEqual(covered.stdout.strip(), "")
         # No rdl left anywhere after the pipeline.
         final = json.loads(ensured.stdout)
-        self.assertNotIn("rdl@rdl", final["enabledPlugins"])
-        self.assertNotIn("rdl", final["extraKnownMarketplaces"])
+        self.assertNotIn("rdl@rdl-agent-extensions", final["enabledPlugins"])
+        self.assertNotIn("rdl-agent-extensions", final["extraKnownMarketplaces"])
 
     def test_ensure_is_idempotent(self):
         # ensure∘ensure is a fixed point: a second pass over ensure's own output is a no-op.
@@ -601,9 +601,9 @@ class TestWebSettingsHelper(unittest.TestCase):
         both = self._externals_plus_rdl()
         both["extraKnownMarketplaces"] = dict(
             both["extraKnownMarketplaces"],
-            rdl={"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True},
+            **{"rdl-agent-extensions": {"source": {"source": "github", "repo": "nq-rdl/agent-extensions"}, "autoUpdate": True}},
         )
-        root = self._marketplace_repo("rdl")
+        root = self._marketplace_repo("rdl-agent-extensions")
         first = run_helper(HELPER, "strip-self", root, self._write(both))
         self.assertEqual(first.returncode, 0, first.stderr)
         out = json.loads(first.stdout)


### PR DESCRIPTION
## Summary

Rename the marketplace identifier from `rdl` to `rdl-agent-extensions` throughout the codebase. This is a breaking change that affects how plugins are installed and referenced.

## Key Changes

- **Marketplace identifier**: Updated all references from `rdl` to `rdl-agent-extensions` in:
  - `.claude-plugin/marketplace.json` (root marketplace manifest)
  - `registry/marketplace.yaml` (marketplace metadata)
  - All `registry/bundles/*.yaml` files (plugin target declarations)
  - All `assets/marketplaces.json` files across skills (marketplace configuration)
  - All `assets/settings.json.tmpl` files (plugin enablement templates)

- **Plugin IDs**: Updated all plugin references from `<plugin>@rdl` to `<plugin>@rdl-agent-extensions`:
  - `rdl@rdl` → `rdl@rdl-agent-extensions` (meta-plugin)
  - `gh@rdl` → `gh@rdl-agent-extensions` (baseline plugin)
  - All other subject plugins in documentation and examples

- **Documentation**: Updated all references across:
  - Agent documentation (`agents/marketplace-scout/agent.md`)
  - Skill documentation (SKILL.md files in multiple skills)
  - Architecture and setup guides (`docs/ARCHITECTURE.md`, `docs/local-testing.md`)
  - README and contributing guides
  - Inline code comments and examples

- **Tests**: Updated test assertions in `tests/test_web_setup_templates.py` to expect the new marketplace name and plugin IDs

- **Changelog**: Added unreleased changelog entry documenting this breaking change

## Installation Impact

Users will need to update their installation commands from:
```bash
/plugin install rdl@rdl
/plugin install go@rdl
```

To:
```bash
/plugin install rdl@rdl-agent-extensions
/plugin install go@rdl-agent-extensions
```

The marketplace registration command remains the same (`/plugin marketplace add nq-rdl/agent-extensions`), but the marketplace key in configuration files changes from `rdl` to `rdl-agent-extensions`.

https://claude.ai/code/session_01KuCujGVRCwbcoCG6T2NV78