### PR TITLE
Add new-service-request skill for RDL Service Desk

### DIFF
--- a/.changes/unreleased/Added-20260713-195752.yaml
+++ b/.changes/unreleased/Added-20260713-195752.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New service request skill for creating GitHub issues with RDL Service Desk templates
+time: 2026-07-13T19:57:52.709500726-04:00

--- a/plugins/lychee/skills/check/lychee.toml
+++ b/plugins/lychee/skills/check/lychee.toml
@@ -41,6 +41,8 @@ exclude = [
   # Team spec-kit catalog (may be private) — referenced by speckit-dev skills/hook
   "^https://github\\.com/nq-rdl/spec-kit-extensions",
   "^https://raw\\.githubusercontent\\.com/nq-rdl/spec-kit-extensions",
+  # RDL Service Desk (access-controlled) — referenced by the new-service-request skill
+  "^https://github\\.com/rdl-service-desk/service-desk",
   # Exclude conventional commits due to rate limiting / connection reset in CI
   "^https://www\\.conventionalcommits\\.org/",
   "^https?://icons\\.getbootstrap\\.com",

--- a/skills/lychee/lychee.toml
+++ b/skills/lychee/lychee.toml
@@ -41,6 +41,8 @@ exclude = [
   # Team spec-kit catalog (may be private) — referenced by speckit-dev skills/hook
   "^https://github\\.com/nq-rdl/spec-kit-extensions",
   "^https://raw\\.githubusercontent\\.com/nq-rdl/spec-kit-extensions",
+  # RDL Service Desk (access-controlled) — referenced by the new-service-request skill
+  "^https://github\\.com/rdl-service-desk/service-desk",
   # Exclude conventional commits due to rate limiting / connection reset in CI
   "^https://www\\.conventionalcommits\\.org/",
   "^https?://icons\\.getbootstrap\\.com",

--- a/skills/new-service-request/SKILL.md
+++ b/skills/new-service-request/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: new-service-request
+license: CC-BY-4.0
+description: >-
+  Create a new service desk issue from available templates. Use when creating
+  GitHub issues for the RDL Service Desk repository with data request, enquiry,
+  or ICT request templates.
+compatibility: >-
+  Requires access to the rdl-service-desk/service-desk GitHub repository.
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# New Service Request Skill
+
+Creates a new GitHub issue for the RDL Service Desk repository using one of the available templates.
+
+**Repository:** https://github.com/rdl-service-desk/service-desk
+
+## Available Templates
+
+1. **data-request** - Data Request Template
+   - Fields: Project title, Approval ID, Workflow Checklist
+
+2. **enquiry** - Enquiry Request Template
+   - Fields: Overview, Priority (low/medium/high)
+
+3. **ict** - ICT Request Template
+   - Fields: Overview, Priority (low/medium/high)
+
+## Usage
+
+Run `new_service_request` in your terminal and you'll be guided through:
+1. Selecting which template to use (1, 2, or 3)
+2. Entering the issue number you provide (you must supply this)
+3. Filling in the required fields for that template
+4. Creating the issue automatically and assigning it to you
+
+Example: You provide issue number `1181`, and it creates `THHSRDLENQ-1181`
+
+## Template Details
+
+### Data Request
+- **Project title**: e.g., "Emergency Examination Authority Presentations in the Emergency Department"
+- **Approval ID**: e.g., THHSAQUIRE-1234 or SSAQTHS-123456
+- **Workflow items**: Mark checklist items as complete (repo bootstrapped, released)
+
+### Enquiry Request
+- **Overview**: Brief description (e.g., "Data management review")
+- **Priority**: low, medium, or high
+
+### ICT Request
+- **Overview**: Brief description (e.g., "New user account setup")
+- **Priority**: low, medium, or high


### PR DESCRIPTION
## Summary
- Adds a new skill for creating GitHub issues in the RDL Service Desk repository
- Supports three templates: data request, enquiry, and ICT request
- Properly formatted with required frontmatter and metadata

## Validation
- ✅ Skill structure follows repository standards
- ✅ Plugin validation passed
- ✅ Changelog entry created

🤖 Generated with Claude Code