### PR TITLE
Fix lychee config: use string mode for include_fragments

### DIFF
--- a/.changes/unreleased/Fixed-20260714-005435.yaml
+++ b/.changes/unreleased/Fixed-20260714-005435.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'lychee link-check: include_fragments was a bare bool, invalid for lychee v0.24''s string-enum schema; set to a valid string so config parsing succeeds again'
+time: 2026-07-14T00:54:41.0000000+00:00

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # generated output
 dist/
 
+# lychee link-checker cache (config sets cache = true; local runs / lefthook write it)
+.lycheecache
+
 # Node.js dependencies
 node_modules/
 

--- a/plugins/lychee/skills/check/lychee.toml
+++ b/plugins/lychee/skills/check/lychee.toml
@@ -6,8 +6,8 @@
 # Cache results to .lycheecache to avoid re-checking on repeated runs
 cache = true
 
-# Include fragment checking (e.g., #section-name anchors)
-include_fragments = true
+# Check intra-document anchor fragments (#section-name); v0.24 needs a string mode, not a boolean
+include_fragments = "anchor-only"
 
 # Max concurrent requests — throttle to avoid rate limiting
 max_concurrency = 32

--- a/skills/lychee/lychee.toml
+++ b/skills/lychee/lychee.toml
@@ -6,8 +6,8 @@
 # Cache results to .lycheecache to avoid re-checking on repeated runs
 cache = true
 
-# Include fragment checking (e.g., #section-name anchors)
-include_fragments = true
+# Check intra-document anchor fragments (#section-name); v0.24 needs a string mode, not a boolean
+include_fragments = "anchor-only"
 
 # Max concurrent requests — throttle to avoid rate limiting
 max_concurrency = 32


### PR DESCRIPTION
## Summary
Updates lychee configuration to use the correct string-enum format for the `include_fragments` setting, required by lychee v0.24+. The setting was previously a bare boolean, which is invalid for the current schema.

## Changes
- **lychee.toml files**: Changed `include_fragments = true` to `include_fragments = "anchor-only"` in both `plugins/lychee/skills/check/lychee.toml` and `skills/lychee/lychee.toml`
  - Updated comment to clarify that v0.24 requires a string mode, not a boolean
  - `"anchor-only"` mode checks intra-document anchor fragments (e.g., `#section-name`)
- **.gitignore**: Added `.lycheecache` to ignore the lychee link-checker cache file generated during local runs and CI
- **Changelog**: Added a Fixed entry documenting the config schema fix

## Implementation Details
The lychee v0.24 release changed `include_fragments` from a boolean to a string-enum field. The `"anchor-only"` mode preserves the original intent of checking fragment anchors while conforming to the new schema. This fix allows the lychee link-check configuration to parse successfully again.

https://claude.ai/code/session_012u14zuyxeEJ62ZqKtjP9HF