### PR TITLE
Add `zensical` pixi task for local docs review

### DIFF
--- a/.changes/unreleased/Added-20260714-044026.yaml
+++ b/.changes/unreleased/Added-20260714-044026.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add a `zensical` pixi task (docs env) so contributors review docs locally with `pixi run zensical serve` / `pixi run zensical build`, no `-e docs` flag needed
+time: '2026-07-14T04:40:26.978061+00:00'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # generated output
 dist/
 
+# Zensical local build output (`pixi run zensical build`)
+site/
+
 # lychee link-checker cache (config sets cache = true; local runs / lefthook write it)
 .lycheecache
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,16 @@ recovers a tag-pushed-but-release-missing partial failure).
 
 ## Docs
 
-The docs site uses Zensical (configured in `zensical.toml`), provided by the pixi `docs` environment (linux-64 only — `pixi run -e docs …`). Source is `docs/`. Architecture decisions live in `docs/ARCHITECTURE.md`.
+The docs site uses Zensical (configured in `zensical.toml`), provided by the pixi `docs` environment (linux-64 only). Source is `docs/`. Architecture decisions live in `docs/ARCHITECTURE.md`.
+
+Review the docs locally with the `zensical` pixi task — it runs Zensical from the `docs` environment and provisions it on first run, so no `-e docs` flag is needed:
+
+```bash
+pixi run zensical serve   # live-reload preview at http://localhost:8000
+pixi run zensical build   # build the static site into ./site
+```
+
+The task forwards any subcommand and flags to Zensical (`pixi run zensical <cmd> …`). The `docs` environment is linux-64 only; on macOS install Zensical separately (`uv tool install zensical` or `pip install zensical`) and run `zensical` directly.
 
 ## Platform Notes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ MCP servers in `mcp/*-go/` follow a Makefile with a `cross-compile` target that 
 
 ### Python / pixi
 
-`pixi` provides the repo's reproducible Python environments — the default (`python` + `pyyaml`) for the registry/pipeline scripts, and `docs` (`zensical`, linux-64 only) for building the docs site via the `zensical` pixi task (`pixi run zensical serve` / `pixi run zensical build`). It stays optional, though: the `pixi.lock` is linux-64 only, macOS contributors use `uv`, and Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
+`pixi` provides the repo's reproducible Python environments — the default (`python` + `pyyaml`, solved for `linux-64`/`osx-64`/`osx-arm64`) runs the registry/pipeline scripts, and `docs` (`zensical`) builds the docs site via the `zensical` pixi task (`pixi run zensical serve` / `pixi run zensical build`). It stays optional, though: the `docs` environment is `linux-64` only, so macOS contributors build docs with `uv`/`pip` instead, and Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
 
 ## CI and release design
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ MCP servers in `mcp/*-go/` follow a Makefile with a `cross-compile` target that 
 
 ### Python / pixi
 
-`pixi` is optional — its only role here is a reproducible docs environment (`zensical`) on linux-64. The `pixi.lock` is linux-64 only; macOS contributors use `uv`. Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
+`pixi` provides the repo's reproducible Python environments — the default (`python` + `pyyaml`) for the registry/pipeline scripts, and `docs` (`zensical`, linux-64 only) for building the docs site via the `zensical` pixi task (`pixi run zensical serve` / `pixi run zensical build`). It stays optional, though: the `pixi.lock` is linux-64 only, macOS contributors use `uv`, and Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
 
 ## CI and release design
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,14 @@ platforms = ["linux-64"]
 [tool.pixi.feature.docs.dependencies]
 zensical = ">=0.0.31,<0.0.32"
 
+# Drive Zensical for local docs review. Zensical lives only in the linux-64
+# `docs` environment, so a plain `pixi install` (default env) does not carry
+# it. These tasks are defined on the `docs` feature, so `pixi run zensical …`
+# auto-selects the docs environment (and provisions it on first run) — no
+# `-e docs` needed. Extra args are forwarded, so `pixi run zensical serve`,
+# `pixi run zensical build`, etc. all work.
+[tool.pixi.feature.docs.tasks]
+zensical = "zensical"
+
 [tool.pixi.environments]
 docs = ["docs"]


### PR DESCRIPTION
## Summary

Simplifies the local docs development workflow by adding a `zensical` pixi task that auto-selects the `docs` environment, eliminating the need for contributors to manually specify `-e docs` when building or previewing the documentation site.

## Changes

- **pyproject.toml**: Added `zensical` task under `[tool.pixi.feature.docs.tasks]` that forwards all arguments to the Zensical CLI
- **AGENTS.md**: Updated docs section with clear instructions for using `pixi run zensical serve` and `pixi run zensical build`, plus guidance for macOS users who need to install Zensical separately
- **docs/ARCHITECTURE.md**: Clarified pixi's role in providing reproducible Python environments (default + docs) and documented the new `zensical` task workflow
- **.gitignore**: Added `site/` directory (Zensical's local build output)
- **.changes/unreleased/**: Added changelog entry documenting the new feature

## Implementation Details

The task is defined on the `docs` feature, so `pixi run zensical …` automatically selects and provisions the `docs` environment on first run. This works because pixi's task resolution auto-selects feature environments when a task is defined there. The task simply forwards all subcommands and flags to Zensical, enabling both `pixi run zensical serve` (live-reload preview) and `pixi run zensical build` (static site generation) without additional flags.

Since the `docs` environment is linux-64 only, macOS contributors are directed to install Zensical separately via `uv tool install zensical` or `pip install zensical` and run `zensical` directly.

https://claude.ai/code/session_01VKdHkSM8pZAdnAnisorYKC