### PR TITLE
Add dedicated Zensical Docs dev container for macOS

### DIFF
--- a/.changes/unreleased/Added-20260714-061746.yaml
+++ b/.changes/unreleased/Added-20260714-061746.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add a dedicated Zensical Docs dev container (`.devcontainer/docs/`) so macOS contributors preview docs via `pixi run zensical serve`; pinned to linux/amd64 to match the linux-64-only docs env
+time: '2026-07-14T06:17:46.280783+00:00'

--- a/.devcontainer/docs/Dockerfile
+++ b/.devcontainer/docs/Dockerfile
@@ -2,14 +2,17 @@
 #
 # The repo's `docs` pixi environment solves only for `linux-64` — Zensical has
 # no macOS or aarch64 conda build (see pixi.lock: only conda-forge/linux-64).
-# The build/run platform is therefore pinned to linux/amd64 in devcontainer.json
-# so the pinned `docs` env resolves; on an Apple Silicon host this runs under
-# Docker's amd64 emulation, which is fine for a preview server.
+# The platform is therefore pinned to linux/amd64 so the `docs` env resolves; on
+# an Apple Silicon host this runs under Docker's amd64 emulation, which is fine
+# for a preview server. The pin is enforced in three layers so it can't be
+# silently dropped: this FROM flag (build-time, honored regardless of how the
+# Dev Containers CLI invokes docker build), `build.options` (the documented
+# devcontainer.json way to pass docker-build flags), and `runArgs` (docker run).
 #
 # This is intentionally lightweight: no iptables firewall (unlike the
 # marketplace sandbox in ../Dockerfile) — a docs preview box needs open
 # outbound to fetch conda/PyPI packages, not the locked-down sandbox.
-FROM node:20-slim
+FROM --platform=linux/amd64 node:20-slim
 
 ARG TZ=America/Los_Angeles
 ENV TZ="$TZ"

--- a/.devcontainer/docs/Dockerfile
+++ b/.devcontainer/docs/Dockerfile
@@ -1,0 +1,48 @@
+# Docs preview container for the Zensical documentation site.
+#
+# The repo's `docs` pixi environment solves only for `linux-64` — Zensical has
+# no macOS or aarch64 conda build (see pixi.lock: only conda-forge/linux-64).
+# The build/run platform is therefore pinned to linux/amd64 in devcontainer.json
+# so the pinned `docs` env resolves; on an Apple Silicon host this runs under
+# Docker's amd64 emulation, which is fine for a preview server.
+#
+# This is intentionally lightweight: no iptables firewall (unlike the
+# marketplace sandbox in ../Dockerfile) — a docs preview box needs open
+# outbound to fetch conda/PyPI packages, not the locked-down sandbox.
+FROM node:20-slim
+
+ARG TZ=America/Los_Angeles
+ENV TZ="$TZ"
+
+# Minimal tooling: git for the workspace, curl + ca-certificates for the pixi
+# installer and HTTPS package fetches. node:20-slim ships neither curl nor CA
+# certs by default.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  curl \
+  git \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set `DEVCONTAINER` to help with orientation, matching the sandbox container.
+ENV DEVCONTAINER=true
+
+# Let the default `node` user own the global npm prefix (for the claude-code
+# install below) and its Claude config dir (target of a persisted volume).
+RUN mkdir -p /usr/local/share/npm-global /home/node/.claude \
+  && chown -R node:node /usr/local/share/npm-global /home/node/.claude
+
+USER node
+# Docker's USER does not set HOME; set it so the pixi installer and npm land in
+# /home/node (not /root) during the build.
+ENV HOME=/home/node
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=/usr/local/share/npm-global/bin:$PATH
+
+# Claude Code, so docs can be authored with Claude inside this container.
+ARG CLAUDE_CODE_VERSION=latest
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# pixi provides the `docs` environment (Zensical). Same official installer the
+# marketplace sandbox uses.
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+ENV PATH=/home/node/.pixi/bin:$PATH

--- a/.devcontainer/docs/README.md
+++ b/.devcontainer/docs/README.md
@@ -1,0 +1,62 @@
+# Zensical docs dev container
+
+A dedicated dev container for previewing and editing the [Zensical](https://zensical.org)
+documentation site — built for contributors on **macOS**, where
+`pixi run zensical` can't run natively.
+
+## Why this exists
+
+The repo's `docs` pixi environment is pinned to `linux-64` because Zensical
+ships **no macOS (or aarch64) conda build** — only `conda-forge/linux-64`. So
+`pixi run zensical serve` / `build` work only on Linux. This container gives
+macOS (and any) contributors a Linux environment where those commands work,
+without touching the shared pixi config or the marketplace sandbox next door.
+
+It is deliberately separate from the sibling **RDL Plugin Sandbox**
+(`../devcontainer.json`): that one is a locked-down box (outbound firewall,
+`claude-code`, full toolchain) for developing the marketplace itself. This one
+is a lightweight docs-preview box — `pixi` + `claude-code`, open outbound, port
+8000 forwarded, no firewall.
+
+## Requirements
+
+- Docker (Docker Desktop on macOS) and the VS Code **Dev Containers** extension.
+- On **Apple Silicon**: the container is pinned to `linux/amd64` (to match the
+  `linux-64`-only `docs` env) and runs under Docker's emulation. The first build
+  is slower as a result; the preview server itself is plenty fast.
+
+## Usage
+
+1. In VS Code: **Dev Containers: Reopen in Container** → pick **Zensical Docs**
+   (the picker appears because the repo now has more than one `.devcontainer`
+   config).
+2. On first create, the container runs `pixi install -e docs` to provision the
+   docs environment. Then, in the integrated terminal:
+
+   ```bash
+   pixi run zensical serve
+   ```
+
+   VS Code auto-forwards port **8000** and opens your browser to the
+   live-reloading preview. Edit files under `docs/` and the site refreshes.
+3. To produce a static build instead:
+
+   ```bash
+   pixi run zensical build   # outputs ./site
+   ```
+
+### Accessing the server outside VS Code
+
+VS Code forwards the loopback-bound dev server automatically. If you run the
+container with plain `docker` (no VS Code port forwarding), bind to all
+interfaces so the published port is reachable from the host:
+
+```bash
+pixi run zensical serve -a 0.0.0.0:8000
+```
+
+## See also
+
+- `docs/ARCHITECTURE.md` — the pixi environment layout and the docs feature.
+- `zensical.toml` — the Zensical site configuration.
+- `../devcontainer.json` — the marketplace-dev sandbox container.

--- a/.devcontainer/docs/devcontainer.json
+++ b/.devcontainer/docs/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "Zensical Docs",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Pin build to linux/amd64: the `docs` pixi env solves only for linux-64
+    // (Zensical has no macOS/aarch64 conda build). See the Dockerfile header.
+    "options": [
+      "--platform=linux/amd64"
+    ],
+    "args": {
+      "TZ": "${localEnv:TZ:America/Los_Angeles}",
+      "CLAUDE_CODE_VERSION": "latest"
+    }
+  },
+  // Run under amd64 too (emulated on Apple Silicon) so it matches the image.
+  "runArgs": [
+    "--platform=linux/amd64"
+  ],
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "remoteUser": "node",
+  // Sync the container `node` user to the host uid/gid so bind-mount writes
+  // work regardless of the host uid.
+  "updateRemoteUserUID": true,
+  // Zensical's dev server listens on 8000; forward it and pop the browser.
+  "forwardPorts": [
+    8000
+  ],
+  "portsAttributes": {
+    "8000": {
+      "label": "Zensical docs preview",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude"
+  },
+  // Persist Claude Code login across rebuilds.
+  "mounts": [
+    "source=zensical-docs-claude-config-${devcontainerId},target=/home/node/.claude,type=volume"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "yzhang.markdown-all-in-one",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  },
+  // Provision the docs env once on create so `pixi run zensical serve` is
+  // ready immediately when you open a terminal.
+  "postCreateCommand": "pixi install -e docs"
+}

--- a/.devcontainer/docs/devcontainer.json
+++ b/.devcontainer/docs/devcontainer.json
@@ -3,7 +3,9 @@
   "build": {
     "dockerfile": "Dockerfile",
     // Pin build to linux/amd64: the `docs` pixi env solves only for linux-64
-    // (Zensical has no macOS/aarch64 conda build). See the Dockerfile header.
+    // (Zensical has no macOS/aarch64 conda build). `build.options` is the
+    // documented devcontainer.json way to pass flags to `docker build`; the
+    // Dockerfile's `FROM --platform` backs this up so the pin can't be dropped.
     "options": [
       "--platform=linux/amd64"
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ pixi run zensical serve   # live-reload preview at http://localhost:8000
 pixi run zensical build   # build the static site into ./site
 ```
 
-The task forwards any subcommand and flags to Zensical (`pixi run zensical <cmd> …`). The `docs` environment is linux-64 only; on macOS install Zensical separately (`uv tool install zensical` or `pip install zensical`) and run `zensical` directly.
+The task forwards any subcommand and flags to Zensical (`pixi run zensical <cmd> …`). The `docs` environment is linux-64 only; on macOS either use the dedicated **Zensical Docs** dev container (`.devcontainer/docs/` — pinned to `linux/amd64`, forwards port 8000; see its `README.md`) or install Zensical separately (`uv tool install zensical` or `pip install zensical`) and run `zensical` directly.
 
 ## Platform Notes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,7 +192,7 @@ MCP servers in `mcp/*-go/` follow a Makefile with a `cross-compile` target that 
 
 ### Python / pixi
 
-`pixi` provides the repo's reproducible Python environments — the default (`python` + `pyyaml`, solved for `linux-64`/`osx-64`/`osx-arm64`) runs the registry/pipeline scripts, and `docs` (`zensical`) builds the docs site via the `zensical` pixi task (`pixi run zensical serve` / `pixi run zensical build`). It stays optional, though: the `docs` environment is `linux-64` only, so macOS contributors build docs with `uv`/`pip` instead, and Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
+`pixi` provides the repo's reproducible Python environments — the default (`python` + `pyyaml`, solved for `linux-64`/`osx-64`/`osx-arm64`) runs the registry/pipeline scripts, and `docs` (`zensical`) builds the docs site via the `zensical` pixi task (`pixi run zensical serve` / `pixi run zensical build`). It stays optional, though: the `docs` environment is `linux-64` only, so macOS contributors build docs either in the dedicated **Zensical Docs** dev container (`.devcontainer/docs/`, pinned to `linux/amd64` so the `linux-64` env resolves) or with `uv`/`pip` directly, and Python skill `ensure-deps.sh` scripts walk `pixi > uv > mamba > conda > pip`, so they work without pixi.
 
 ## CI and release design
 


### PR DESCRIPTION
## Summary

Adds a dedicated dev container (`.devcontainer/docs/`) to enable macOS contributors to preview and edit the Zensical documentation site locally. The `docs` pixi environment is pinned to `linux-64` only (Zensical has no macOS/aarch64 conda build), so this container provides a Linux environment where `pixi run zensical serve` and `pixi run zensical build` work natively.

## Key Changes

- **`.devcontainer/docs/Dockerfile`**: Lightweight docs-preview container based on `node:20-slim`, pinned to `linux/amd64` to match the `linux-64`-only docs environment. Installs pixi, Claude Code, and minimal tooling (git, curl, ca-certificates) for fetching conda/PyPI packages. Deliberately separate from the marketplace sandbox container — no firewall, open outbound, port 8000 forwarded.

- **`.devcontainer/docs/devcontainer.json`**: Configuration for the docs container with:
  - Platform pinning to `linux/amd64` (emulated on Apple Silicon)
  - Port 8000 forwarding with auto-browser-open for the live-reload preview server
  - Persistent Claude Code login via volume mount
  - VS Code extensions: Claude Code, Markdown, TOML
  - Post-create provisioning: `pixi install -e docs` so `pixi run zensical serve` is ready immediately

- **`.devcontainer/docs/README.md`**: User-facing documentation explaining why the container exists, requirements, and usage instructions for both VS Code and plain Docker.

- **`AGENTS.md`**: Updated guidance to mention the new dev container as an alternative to manual Zensical installation on macOS.

- **`docs/ARCHITECTURE.md`**: Updated to reference the new dev container option for macOS contributors.

- **`.changes/unreleased/Added-20260714-061746.yaml`**: Changelog entry documenting the addition.

## Implementation Details

- The container is intentionally lightweight and separate from the marketplace sandbox (`.devcontainer/devcontainer.json`) — it's a docs-preview box, not a locked-down development environment.
- On Apple Silicon hosts, the container runs under Docker's amd64 emulation to match the `linux-64`-only pixi environment; the preview server performance is unaffected.
- The `node` user owns the global npm prefix and Claude config directory, with `updateRemoteUserUID` enabled so bind-mount writes work regardless of host uid.
- VS Code auto-forwards port 8000 and opens the browser; plain Docker users can bind to `0.0.0.0:8000` for external access.

https://claude.ai/code/session_01KK9n2KXi3RnYDfoGSvz3ds