### PR TITLE
Add reverse-reference check for canonical content exposure

### DIFF
--- a/.changes/unreleased/Added-20260715-005007.yaml
+++ b/.changes/unreleased/Added-20260715-005007.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add scripts/check_exposure.py — a reverse-reference check that every canonical skill/agent/hook/mcp is exposed by at least one bundle
+time: '2026-07-15T00:50:07+00:00'

--- a/.changes/unreleased/Added-20260715-005008.yaml
+++ b/.changes/unreleased/Added-20260715-005008.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Wire the new exposure check as a strict CI gate in validate.yml and a non-blocking pre-commit reminder in lefthook.yml
+time: '2026-07-15T00:50:08+00:00'

--- a/.changes/unreleased/Added-20260715-041015.yaml
+++ b/.changes/unreleased/Added-20260715-041015.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add codex-content-review CI workflow — an informational GPT-5.6 Terra reviewer flagging skill/agent/hook/plugin instructions that reference commands or files the repo does not ship
+time: '2026-07-15T03:05:00+00:00'

--- a/.changes/unreleased/Fixed-20260715-005009.yaml
+++ b/.changes/unreleased/Fixed-20260715-005009.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Expose the new-service-request skill through the rdl-team bundle — it was authored under skills/ but never wired into any plugin
+time: '2026-07-15T00:50:09+00:00'

--- a/.changes/unreleased/Fixed-20260715-143000.yaml
+++ b/.changes/unreleased/Fixed-20260715-143000.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Rewrite the new-service-request skill to create the issue with gh — it told users to run a `new_service_request` command that does not exist
+time: '2026-07-15T14:30:00+00:00'

--- a/.changes/unreleased/Fixed-20260715-154500.yaml
+++ b/.changes/unreleased/Fixed-20260715-154500.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: "check_exposure.py no longer tracebacks on a malformed registry value (a scalar where a list or mapping belongs) — --warn stays non-blocking, strict fails closed."
+time: 2026-07-15T15:45:00.000000000+10:00

--- a/.github/workflows/codex-content-review.yml
+++ b/.github/workflows/codex-content-review.yml
@@ -81,8 +81,12 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ vars.CODEX_REVIEW_MODEL || 'gpt-5.6-terra' }}
           effort: high
-          permission-profile: ":read-only" # built-in profile — leading colon required
-          safety-strategy: read-only
+          permission-profile: ":read-only" # read-only enforced via the profile (leading colon = built-in)
+          # Keep the default drop-sudo, NOT safety-strategy: read-only — the
+          # read-only strategy forces the legacy sandbox, which per the action's
+          # README cannot be combined with a permission-profile (the codex step
+          # would error and, being continue-on-error, silently post nothing).
+          safety-strategy: drop-sudo
           prompt: |
             You are reviewing a pull request in a Claude Code plugin
             marketplace repo. Static validation already runs elsewhere in CI

--- a/.github/workflows/codex-content-review.yml
+++ b/.github/workflows/codex-content-review.yml
@@ -1,0 +1,154 @@
+# Codex Content Review
+#
+# WHAT THIS DOES: an LLM "plausibility" reviewer (openai/codex-action running
+# GPT) that catches semantic errors static validation can't. Static checks
+# (asctl repo-check, check_bundle_refs.py, check_grouping.py,
+# check_consistency.py, validate-plugins.sh, generate_manifests.py --check,
+# ...) verify structure and that cross-references resolve, but none of them
+# can tell that a skill's prose instructs running a `new_service_request`
+# command/binary/file that ships nowhere in the repo. This workflow asks
+# Codex to read the skills/, agents/, hooks/, mcp/, and — MOST IMPORTANTLY —
+# plugins/<bundle>/ files changed in a PR and flag claims that are impossible
+# or inconsistent with what the repo actually ships, weighting the installed
+# plugins/<bundle>/ trees highest since that's what users install and run.
+# It posts its findings as a single PR comment.
+#
+# INFORMATIONAL / NON-GATING: like skillspector.yml, this check is advisory
+# only — it never fails the job (see the continue-on-error / no-op steps
+# below) and MUST stay OUT of the branch-protection required-checks list on
+# `main` (see CLAUDE.md's "Required status checks on main" note). Its purpose
+# is to give reviewers a second opinion, not to block merges.
+#
+# PREREQUISITES (both optional — the workflow no-ops cleanly, staying green,
+# until they're configured):
+#   - Repo secret `OPENAI_API_KEY`: an OpenAI API key with access to the
+#     configured model. Not yet configured as of writing; until it is, the
+#     "Check for OPENAI_API_KEY" step below detects its absence and every
+#     downstream step is skipped as a deliberate no-op.
+#   - Repo variable `CODEX_REVIEW_MODEL` (optional): overrides the default
+#     model (`gpt-5.6-terra`) without editing this file.
+
+name: Codex Content Review
+
+on:
+  pull_request:
+    paths:
+      - skills/**
+      - agents/**
+      - hooks/**
+      - mcp/**
+      - plugins/**
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: codex-content-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Codex plausibility review
+    runs-on: ubuntu-latest
+    # Fork PRs can't read repo secrets (the GITHUB_TOKEN they get is
+    # read-only and OPENAI_API_KEY isn't shared with fork runs at all), so
+    # skip them outright rather than let the codex step fail there.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Check out PR (full history, for base-ref diffing)
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      # Secret-gated no-op: OPENAI_API_KEY is not yet configured in this
+      # repo, and this workflow must land (and stay green) before it is.
+      # Never print the secret itself — only whether it's present.
+      - name: Check for OPENAI_API_KEY
+        id: key
+        run: echo "present=${{ secrets.OPENAI_API_KEY != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip (no-op)
+        if: steps.key.outputs.present != 'true'
+        run: echo "OPENAI_API_KEY not set; skipping (no-op)"
+
+      - name: Run Codex plausibility review
+        id: codex
+        if: steps.key.outputs.present == 'true'
+        continue-on-error: true # informational — a Codex/API failure must not gate the PR
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: ${{ vars.CODEX_REVIEW_MODEL || 'gpt-5.6-terra' }}
+          effort: high
+          permission-profile: ":read-only" # built-in profile — leading colon required
+          safety-strategy: read-only
+          prompt: |
+            You are reviewing a pull request in a Claude Code plugin
+            marketplace repo. Static validation already runs elsewhere in CI
+            (schema/reference checks, generated-manifest drift, plugin-tree
+            byte-for-byte sync with canonical skills/ and agents/). Your job
+            is different: catch semantic "plausibility" errors that static
+            checks cannot, e.g. a skill whose prose instructs running a
+            `new_service_request` command/binary/file that ships nowhere in
+            the repo.
+
+            Step 1 — scope. Determine the files changed in this PR with:
+              git diff --name-only origin/${{ github.base_ref }}...HEAD
+            From that list, keep only paths under skills/, agents/, hooks/,
+            mcp/, and plugins/. Review ONLY those changed files. Ignore any
+            other changed files and anything unchanged.
+
+            Step 2 — check each changed file for claims that are IMPOSSIBLE
+            OR INCONSISTENT WITH THE REPO:
+              (a) Instructions to run a command, binary, script, or file
+                  that exists nowhere in the repo (e.g. a tool name like
+                  `new_service_request` invented by the prose but never
+                  shipped anywhere in the tree).
+              (b) Instructions that contradict the files actually shipped
+                  under plugins/<bundle>/ — weight the plugin trees
+                  HIGHEST, since that is exactly what users install and
+                  run. If a changed skill or agent claims a script,
+                  template, or asset ships alongside it, verify that file
+                  is actually present in the corresponding
+                  plugins/<bundle>/... copy, not only in the canonical
+                  skills/ or agents/ source.
+              (c) A hook or MCP config/manifest referencing a path, tool,
+                  or asset it does not itself ship (e.g. a hooks/*.sh
+                  script invoking a binary not present in the repo, or an
+                  .mcp.json wiring a command/URL that doesn't exist).
+
+            Step 3 — report. For each finding, give:
+              - file:line
+              - the exact impossible or inconsistent claim (quote it)
+              - why it is impossible or inconsistent (what you checked and
+                did not find)
+
+            If you find no such issues, output EXACTLY the following line
+            and nothing else:
+            No plausibility issues found.
+
+            This is a report-only review: make no file changes, run no
+            destructive commands, and do not attempt to fix anything you
+            find.
+
+      - name: Post review as PR comment
+        if: steps.key.outputs.present == 'true'
+        continue-on-error: true # informational — a comment-post failure must not gate the PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          REVIEW_BODY: ${{ steps.codex.outputs.final-message }}
+        with:
+          script: |
+            const raw = (process.env.REVIEW_BODY || '').trim();
+            const body = raw.length > 0
+              ? raw
+              : '_Codex produced no output for this run._';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body:
+                '### Codex content review (informational — non-gating)\n\n' +
+                body,
+            });

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Check bundle references resolve
         run: python3 scripts/check_bundle_refs.py .
 
+      - name: Check every canonical artifact is exposed in a bundle
+        run: python3 scripts/check_exposure.py .
+
       - name: Check skill grouping contract
         run: python3 scripts/check_grouping.py .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ pixi run python3 scripts/generate_bundles_doc.py . --check  # CI gate: fail on d
 
 # Bundle reference + grouping + three-way consistency checks (also run by validate.yml)
 pixi run python3 scripts/check_bundle_refs.py .   # registry refs resolve to skills/ & agents/
+pixi run python3 scripts/check_exposure.py .      # every canonical skill/agent/hook/mcp is exposed by >=1 bundle (strict); add --warn for a non-blocking reminder
 pixi run python3 scripts/check_grouping.py .      # grouping contract: valid member shape, unique leaf + pluginName
 pixi run python3 scripts/check_consistency.py .   # bundle <-> marketplace.json <-> plugins/ agree
 
@@ -164,6 +165,7 @@ CI runs `validate.yml` on every PR/push to main. It checks:
 - Generated `plugin.json` + `marketplace.json` match the registry (`scripts/generate_manifests.py --check`)
 - Generated `docs/bundles.md` matches the registry (`scripts/generate_bundles_doc.py --check`)
 - Registry bundles, `marketplace.json`, and `plugins/` dirs stay in lockstep (`scripts/check_consistency.py`)
+- Every canonical skill/agent/hook/mcp is exposed by >=1 bundle (`scripts/check_exposure.py`); intentional exclusions live in `registry/unbundled.yaml`
 - Plugin manifests, hooks, skills, and `.mcp.json` wiring are valid (`scripts/validate-plugins.sh`)
 - Any symlink under `plugins/` resolves (`validate-symlinks` — plugin trees are real-file copies, so this guards against accidental links)
 - Every `agents/<name>/agent.md` has frontmatter `name` + `description`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,9 @@ References: Biggs, *You're Probably Using Agent Skills Wrong*; SkillsBench (arXi
 
 A new skill authored under `skills/<name>/` is **not installable until you map it into a bundle**
 — authoring the `SKILL.md` only adds it to the flat library; the registry decides which plugin
-(subject) it belongs to. Here is the full loop, using a hypothetical `sql-review-analyse` skill
+(subject) it belongs to. CI enforces this: `scripts/check_exposure.py` fails if a canonical
+skill/agent/hook isn't referenced by any `registry/bundles/*.yaml` (or explicitly allowlisted in
+`registry/unbundled.yaml`). Here is the full loop, using a hypothetical `sql-review-analyse` skill
 that should become `sql-review:analyse`:
 
 1. **Pick the subject and facet** (the rules above). Subject → the plugin (`sql-review`); facet →
@@ -213,6 +215,7 @@ that should become `sql-review:analyse`:
 6. **Validate** exactly what CI will:
    ```bash
    pixi run python3 scripts/check_bundle_refs.py .   && \
+   pixi run python3 scripts/check_exposure.py .      && \
    pixi run python3 scripts/check_grouping.py .      && \
    pixi run python3 scripts/generate_manifests.py . --check && \
    pixi run python3 scripts/generate_bundles_doc.py . --check && \

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -386,6 +386,7 @@ RDL team workflows — Claude Code onboarding, setup, and config management.
 **Skills**
 
 - `/rdl-team:cc-setup`
+- `/rdl-team:new-service-request`
 
 **Agents**
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -63,7 +63,7 @@ pre-commit:
     #     exits 0 (non-blocking); CI's strict `check_exposure.py .` is the hard
     #     gate (validate.yml).
     - name: exposure-reminder
-      glob: "{skills/**,agents/**,hooks/**,mcp/**,registry/bundles/**}"
+      glob: "{skills/**,agents/**,hooks/**,mcp/**,registry/bundles/**,registry/unbundled.yaml}"
       run: pixi run python3 scripts/check_exposure.py . --warn
 
     # --- Changie fragment length. Each staged unreleased fragment's body must

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,6 +58,14 @@ pre-commit:
         pixi run python3 scripts/generate_manifests.py . --check
         pixi run python3 scripts/generate_bundles_doc.py . --check
 
+    # --- Reverse-exposure reminder. Just a nudge: a new skill/agent/hook/mcp
+    #     that no bundle references yet is easy to miss locally. --warn always
+    #     exits 0 (non-blocking); CI's strict `check_exposure.py .` is the hard
+    #     gate (validate.yml).
+    - name: exposure-reminder
+      glob: "{skills/**,agents/**,hooks/**,mcp/**,registry/bundles/**}"
+      run: pixi run python3 scripts/check_exposure.py . --warn
+
     # --- Changie fragment length. Each staged unreleased fragment's body must
     #     stay under the per-fragment cap (default 200; CHANGIE_MAX_BODY_LENGTH
     #     overrides). Changie's own body.maxLength guards `changie new`; this

--- a/plugins/rdl-team/skills/new-service-request/SKILL.md
+++ b/plugins/rdl-team/skills/new-service-request/SKILL.md
@@ -12,42 +12,52 @@ metadata:
 
 # New Service Request Skill
 
-Creates a new GitHub issue for the RDL Service Desk repository using one of the available templates.
+Create a new GitHub issue in the RDL Service Desk repository from one of its
+issue templates.
 
-**Repository:** https://github.com/rdl-service-desk/service-desk
+**Repository:** `rdl-service-desk/service-desk`
+(<https://github.com/rdl-service-desk/service-desk>)
 
-## Available Templates
+## How to run it
 
-1. **data-request** - Data Request Template
-   - Fields: Project title, Approval ID, Workflow Checklist
+This is an agent skill, not a CLI — there is no `new_service_request` binary.
+When it is invoked (e.g. `/rdl-team:new-service-request`), **you** create the
+issue using whatever GitHub tooling is available in the session, preferring:
 
-2. **enquiry** - Enquiry Request Template
-   - Fields: Overview, Priority (low/medium/high)
+1. the **GitHub MCP server**'s create-issue tool, or
+2. the **`gh` CLI**:
+   `gh issue create --repo rdl-service-desk/service-desk --template <name> ...`.
 
-3. **ict** - ICT Request Template
-   - Fields: Overview, Priority (low/medium/high)
+First confirm you can reach `rdl-service-desk/service-desk` (see *Compatibility*
+above). If you cannot, tell the user what access is missing instead of
+guessing.
 
-## Usage
+## Workflow
 
-Run `new_service_request` in your terminal and you'll be guided through:
-1. Selecting which template to use (1, 2, or 3)
-2. Entering the issue number you provide (you must supply this)
-3. Filling in the required fields for that template
-4. Creating the issue automatically and assigning it to you
+1. **Ask which template** the request uses — `data-request`, `enquiry`, or
+   `ict` (1, 2, or 3).
+2. **Ask for the issue number** — the user must supply this; never invent one.
+3. **Collect the template's required fields** (see *Template details* below).
+4. **Create the issue** in `rdl-service-desk/service-desk` from that template,
+   and **assign it to the requesting user**.
+5. **Return the new issue's URL** so the user can confirm it.
 
-Example: You provide issue number `1181`, and it creates `THHSRDLENQ-1181`
+**Title convention:** match the prefix the service-desk repo already uses for
+the chosen template — e.g. an enquiry with issue number `1181` is titled
+`THHSRDLENQ-1181`. If you are unsure of the prefix for a template, check an
+existing issue of that type in the repo rather than assuming one.
 
-## Template Details
+## Template details
 
-### Data Request
-- **Project title**: e.g., "Emergency Examination Authority Presentations in the Emergency Department"
-- **Approval ID**: e.g., THHSAQUIRE-1234 or SSAQTHS-123456
-- **Workflow items**: Mark checklist items as complete (repo bootstrapped, released)
+### 1. Data Request (`data-request`)
+- **Project title** — e.g. "Emergency Examination Authority Presentations in the Emergency Department"
+- **Approval ID** — e.g. `THHSAQUIRE-1234` or `SSAQTHS-123456`
+- **Workflow checklist** — mark items complete (e.g. repo bootstrapped, released)
 
-### Enquiry Request
-- **Overview**: Brief description (e.g., "Data management review")
-- **Priority**: low, medium, or high
+### 2. Enquiry Request (`enquiry`)
+- **Overview** — brief description (e.g. "Data management review")
+- **Priority** — `low`, `medium`, or `high`
 
-### ICT Request
-- **Overview**: Brief description (e.g., "New user account setup")
-- **Priority**: low, medium, or high
+### 3. ICT Request (`ict`)
+- **Overview** — brief description (e.g. "New user account setup")
+- **Priority** — `low`, `medium`, or `high`

--- a/plugins/rdl-team/skills/new-service-request/SKILL.md
+++ b/plugins/rdl-team/skills/new-service-request/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   GitHub issues for the RDL Service Desk repository with data request, enquiry,
   or ICT request templates.
 compatibility: >-
-  Requires access to the rdl-service-desk/service-desk GitHub repository.
+  Requires write access to the private rdl-service-desk/service-desk repository,
+  via either the GitHub MCP server or an authenticated GitHub CLI (`gh`).
 metadata:
   repo: https://github.com/nq-rdl/agent-extensions
 ---
@@ -25,27 +26,58 @@ When it is invoked (e.g. `/rdl-team:new-service-request`), **you** create the
 issue using whatever GitHub tooling is available in the session, preferring:
 
 1. the **GitHub MCP server**'s create-issue tool, or
-2. the **`gh` CLI**:
-   `gh issue create --repo rdl-service-desk/service-desk --template <name> ...`.
+2. the **`gh` CLI** (worked command below).
 
 First confirm you can reach `rdl-service-desk/service-desk` (see *Compatibility*
 above). If you cannot, tell the user what access is missing instead of
 guessing.
+
+## Available templates
+
+| Template | Label | Source | Fields |
+|---|---|---|---|
+| data-request | `data-request` | `data_request_template.md` | Project title, Approval ID, Workflow Checklist |
+| enquiry | `enquiry` | `enquiry_template.md` | Overview, Priority |
+| ict | `ICT` | `ict_request_template.md` | Overview, Priority |
+
+Labels are case-sensitive: `ICT` is uppercase, the other two are not.
 
 ## Workflow
 
 1. **Ask which template** the request uses — `data-request`, `enquiry`, or
    `ict` (1, 2, or 3).
 2. **Ask for the issue number** — the user must supply this; never invent one.
+   It is allocated outside this repository, so it cannot be derived or guessed.
 3. **Collect the template's required fields** (see *Template details* below).
-4. **Create the issue** in `rdl-service-desk/service-desk` from that template,
-   and **assign it to the requesting user**.
+4. **Create the issue** in `rdl-service-desk/service-desk`, and **assign it to
+   the requesting user**.
 5. **Return the new issue's URL** so the user can confirm it.
 
-**Title convention:** match the prefix the service-desk repo already uses for
-the chosen template — e.g. an enquiry with issue number `1181` is titled
-`THHSRDLENQ-1181`. If you are unsure of the prefix for a template, check an
-existing issue of that type in the repo rather than assuming one.
+**Title convention:** the issue number prefixed with `THHSRDLENQ-`, uniform
+across all three templates — issue number `1181` becomes the title
+`THHSRDLENQ-1181`.
+
+```bash
+gh issue create \
+  --repo rdl-service-desk/service-desk \
+  --title "THHSRDLENQ-1181" \
+  --label enquiry \
+  --assignee @me \
+  --body "$(cat <<'EOF'
+## Overview
+
+Data management review
+
+## Priority
+
+medium
+EOF
+)"
+```
+
+The body must use the template's `##` headings verbatim — the repo's
+`.github/ISSUE_TEMPLATE/*.md` files are the source of truth, so read the
+relevant one first if you need to confirm the current headings.
 
 ## Template details
 

--- a/plugins/rdl-team/skills/new-service-request/SKILL.md
+++ b/plugins/rdl-team/skills/new-service-request/SKILL.md
@@ -1,0 +1,53 @@
+---
+license: CC-BY-4.0
+description: >-
+  Create a new service desk issue from available templates. Use when creating
+  GitHub issues for the RDL Service Desk repository with data request, enquiry,
+  or ICT request templates.
+compatibility: >-
+  Requires access to the rdl-service-desk/service-desk GitHub repository.
+metadata:
+  repo: https://github.com/nq-rdl/agent-extensions
+---
+
+# New Service Request Skill
+
+Creates a new GitHub issue for the RDL Service Desk repository using one of the available templates.
+
+**Repository:** https://github.com/rdl-service-desk/service-desk
+
+## Available Templates
+
+1. **data-request** - Data Request Template
+   - Fields: Project title, Approval ID, Workflow Checklist
+
+2. **enquiry** - Enquiry Request Template
+   - Fields: Overview, Priority (low/medium/high)
+
+3. **ict** - ICT Request Template
+   - Fields: Overview, Priority (low/medium/high)
+
+## Usage
+
+Run `new_service_request` in your terminal and you'll be guided through:
+1. Selecting which template to use (1, 2, or 3)
+2. Entering the issue number you provide (you must supply this)
+3. Filling in the required fields for that template
+4. Creating the issue automatically and assigning it to you
+
+Example: You provide issue number `1181`, and it creates `THHSRDLENQ-1181`
+
+## Template Details
+
+### Data Request
+- **Project title**: e.g., "Emergency Examination Authority Presentations in the Emergency Department"
+- **Approval ID**: e.g., THHSAQUIRE-1234 or SSAQTHS-123456
+- **Workflow items**: Mark checklist items as complete (repo bootstrapped, released)
+
+### Enquiry Request
+- **Overview**: Brief description (e.g., "Data management review")
+- **Priority**: low, medium, or high
+
+### ICT Request
+- **Overview**: Brief description (e.g., "New user account setup")
+- **Priority**: low, medium, or high

--- a/registry/bundles/rdl-team.yaml
+++ b/registry/bundles/rdl-team.yaml
@@ -9,6 +9,7 @@ channels:
   - stable
 skills:
   - {source: cc-setup, leaf: cc-setup}
+  - new-service-request
 agents: [marketplace-scout]  # guest — home: claude-code
 hooks: []
 prompts: []

--- a/registry/unbundled.yaml
+++ b/registry/unbundled.yaml
@@ -1,0 +1,18 @@
+# Allowlist for scripts/check_exposure.py — the reverse-reference check that
+# fails CI when a canonical skill/agent/hook/mcp is authored but no
+# registry/bundles/*.yaml exposes it to an install.
+#
+# An entry here suppresses that check for content that is intentionally NOT
+# shipped through any plugin. Every entry needs a `reason`: this is a
+# reviewable choice, not a place to silence the check because wiring it up is
+# inconvenient. A stale entry — one that no longer matches anything on disk,
+# or that a bundle now references anyway — is itself a check_exposure.py
+# failure, so this file cannot silently rot.
+schemaVersion: v1
+unbundled:
+  - kind: hook
+    name: changie-fragment-lint
+    reason: >-
+      Repo-internal PreToolUse dev hook that lints 'changie new' in THIS repo; its command is a
+      repo-relative path (bash hooks/changie-fragment-lint.sh), not a shipped ${CLAUDE_PLUGIN_ROOT} asset.
+      Not distributed through any plugin.

--- a/scripts/check_exposure.py
+++ b/scripts/check_exposure.py
@@ -38,6 +38,16 @@ from _registry import normalize_member
 
 KINDS = ("skill", "agent", "hook", "mcp", "prompt")
 
+# The bundle-YAML list key for each kind. Note `mcp` does NOT pluralise — the
+# bundle key is `mcp:`, not `mcps:` — so messages must not naively append "s".
+KIND_TO_BUNDLE_KEY = {
+    "skill": "skills",
+    "agent": "agents",
+    "hook": "hooks",
+    "mcp": "mcp",
+    "prompt": "prompts",
+}
+
 
 @dataclass(frozen=True)
 class Orphan:
@@ -64,6 +74,12 @@ def collect_bundle_refs(repo) -> dict[str, set[str]]:
     for bundle_file in bundle_files:
         with bundle_file.open() as fh:
             data = yaml.safe_load(fh) or {}
+        # A bundle whose Claude target is explicitly disabled ships nothing, so a
+        # reference from it does not make an artifact "exposed" (mirrors
+        # check_consistency.py, which reconciles only enabled Claude targets).
+        claude = (data.get("targets") or {}).get("claude") or {}
+        if claude.get("enabled") is False:
+            continue
         for member in data.get("skills") or []:
             try:
                 source, _leaf = normalize_member(member)
@@ -241,7 +257,7 @@ def main(argv=None) -> int:
             print(
                 f"hint: {o.name} ({o.kind}) is authored under {o.path} but no bundle "
                 "references it yet — add it to a registry/bundles/*.yaml "
-                f"{o.kind}s list, or to registry/unbundled.yaml with a reason.",
+                f"`{KIND_TO_BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml with a reason.",
                 file=sys.stderr,
             )
         for msg in allowlist_problems:
@@ -252,7 +268,7 @@ def main(argv=None) -> int:
         print(
             f"::error file={o.path}::{o.name} ({o.kind}) is authored under {o.path} "
             f"but no bundle references it — add it to a registry/bundles/*.yaml "
-            f"{o.kind}s list, or to registry/unbundled.yaml with a reason.",
+            f"`{KIND_TO_BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml with a reason.",
             file=sys.stderr,
         )
     for msg in allowlist_problems:

--- a/scripts/check_exposure.py
+++ b/scripts/check_exposure.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Find canonical content that no bundle exposes (the reverse of check_bundle_refs).
+
+``check_bundle_refs.py`` checks the FORWARD direction: every skill/agent named
+in ``registry/bundles/*.yaml`` must resolve to something on disk. This module
+checks the REVERSE direction: every skill authored under ``skills/<name>/``,
+every agent under ``agents/<name>/agent.md``, and every hook under
+``hooks/<name>.sh`` must be *referenced* by at least one bundle — otherwise it
+is authored but never shipped in any plugin, which is easy to miss because
+nothing else in the pipeline fails.
+
+An orphan can be deliberate (repo-internal tooling that is never meant to ship
+in a plugin, e.g. a dev-only hook). ``registry/unbundled.yaml`` is a reviewable
+allowlist for exactly those cases; an allowlist entry that no longer matches
+anything on disk, or that a bundle now references anyway, is itself flagged as
+stale so the allowlist cannot silently rot.
+
+``mcp`` and ``prompt`` kinds are collected for completeness (there is currently
+no canonical ``mcp/<name>/`` server tree and no ``prompts/`` directory in this
+repo), but with nothing on disk to enumerate they never produce orphans today.
+
+CLI:
+    python3 scripts/check_exposure.py [REPO_ROOT] [--warn]
+Without ``--warn`` this exits non-zero (with ``::error::`` annotations) if any
+canonical item is unreferenced or any allowlist entry is stale. With
+``--warn`` it prints friendly ``hint:`` lines instead and always exits 0 (a
+local, non-blocking reminder — CI runs the strict form).
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from _registry import normalize_member
+
+KINDS = ("skill", "agent", "hook", "mcp", "prompt")
+
+
+@dataclass(frozen=True)
+class Orphan:
+    kind: str  # one of KINDS
+    name: str
+    path: str = ""  # repo-relative canonical path, for CI annotations
+
+
+def collect_bundle_refs(repo) -> dict[str, set[str]]:
+    """Union, across every ``registry/bundles/*.yaml``, the names referenced per kind.
+
+    Skills are keyed by their SOURCE (the canonical ``skills/<source>/`` dir),
+    never the leaf — a member's leaf is plugin-local naming and does not
+    identify the canonical item.
+    """
+    repo = Path(repo)
+    refs: dict[str, set[str]] = {kind: set() for kind in KINDS}
+    bundles_dir = repo / "registry" / "bundles"
+    if not bundles_dir.is_dir():
+        return refs
+    bundle_files = sorted(
+        list(bundles_dir.glob("*.yaml")) + list(bundles_dir.glob("*.yml"))
+    )
+    for bundle_file in bundle_files:
+        with bundle_file.open() as fh:
+            data = yaml.safe_load(fh) or {}
+        for member in data.get("skills") or []:
+            try:
+                source, _leaf = normalize_member(member)
+            except ValueError:
+                continue
+            refs["skill"].add(source)
+        for name in data.get("agents") or []:
+            refs["agent"].add(name)
+        for name in data.get("hooks") or []:
+            refs["hook"].add(name)
+        for name in data.get("mcp") or []:
+            refs["mcp"].add(name)
+        for name in data.get("prompts") or []:
+            refs["prompt"].add(name)
+    return refs
+
+
+def collect_canonical(repo) -> dict[str, dict[str, str]]:
+    """Return, per kind, a ``{name: repo-relative path}`` map of on-disk identities."""
+    repo = Path(repo)
+    canonical: dict[str, dict[str, str]] = {kind: {} for kind in KINDS}
+
+    skills_dir = repo / "skills"
+    if skills_dir.is_dir():
+        for d in sorted(skills_dir.iterdir()):
+            if d.is_dir() and (d / "SKILL.md").is_file():
+                canonical["skill"][d.name] = f"skills/{d.name}/"
+
+    agents_dir = repo / "agents"
+    if agents_dir.is_dir():
+        for d in sorted(agents_dir.iterdir()):
+            if d.is_dir() and (d / "agent.md").is_file():
+                canonical["agent"][d.name] = f"agents/{d.name}/agent.md"
+
+    hooks_dir = repo / "hooks"
+    if hooks_dir.is_dir():
+        for f in sorted(hooks_dir.glob("*.sh")):
+            canonical["hook"][f.stem] = f"hooks/{f.name}"
+
+    mcp_dir = repo / "mcp"
+    if mcp_dir.is_dir():
+        for d in sorted(mcp_dir.iterdir()):
+            if d.is_dir():
+                canonical["mcp"][d.name] = f"mcp/{d.name}/"
+
+    prompts_dir = repo / "prompts"
+    if prompts_dir.is_dir():
+        for p in sorted(prompts_dir.iterdir()):
+            canonical["prompt"][p.name] = f"prompts/{p.name}"
+
+    return canonical
+
+
+def load_allowlist(repo) -> tuple[set[tuple[str, str]], list[dict]]:
+    """Parse ``registry/unbundled.yaml``. Returns (allowed set, raw entries).
+
+    A ``(kind, name)`` pair enters ``allowed`` (and therefore suppresses the
+    orphan) only when both are non-empty strings; the ``reason`` requirement is
+    validated separately by :func:`find_allowlist_problems`, which fails the
+    strict check on a missing reason so a malformed entry can never *silently*
+    suppress a genuine orphan. Missing file => empty allowlist.
+    """
+    repo = Path(repo)
+    path = repo / "registry" / "unbundled.yaml"
+    if not path.is_file():
+        return set(), []
+    with path.open() as fh:
+        data = yaml.safe_load(fh) or {}
+    entries = data.get("unbundled") or []
+    allowed = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        kind = entry.get("kind")
+        name = entry.get("name")
+        if isinstance(kind, str) and kind and isinstance(name, str) and name:
+            allowed.add((kind, name))
+    return allowed, entries
+
+
+def find_unexposed(repo) -> list[Orphan]:
+    """Return an Orphan for every canonical item referenced by no bundle and not allowlisted."""
+    repo = Path(repo)
+    refs = collect_bundle_refs(repo)
+    canonical = collect_canonical(repo)
+    allowed, _entries = load_allowlist(repo)
+    orphans: list[Orphan] = []
+    for kind in KINDS:
+        for name, path in canonical[kind].items():
+            if name in refs[kind]:
+                continue
+            if (kind, name) in allowed:
+                continue
+            orphans.append(Orphan(kind, name, path))
+    return orphans
+
+
+def find_stale_allowlist_entries(repo) -> list[str]:
+    """Return a message per allowlist entry that no longer needs to exist.
+
+    Stale means either: (a) the entry no longer matches anything canonical on
+    disk, or (b) a bundle now references it anyway, so the exemption is dead
+    weight.
+    """
+    repo = Path(repo)
+    refs = collect_bundle_refs(repo)
+    canonical = collect_canonical(repo)
+    allowed, _entries = load_allowlist(repo)
+    messages: list[str] = []
+    for kind, name in sorted(allowed):
+        if kind not in canonical:
+            messages.append(
+                f"registry/unbundled.yaml lists unknown kind '{kind}' for '{name}'"
+            )
+            continue
+        if name not in canonical[kind]:
+            messages.append(
+                f"registry/unbundled.yaml allowlists {kind} '{name}' but it no longer "
+                "exists on disk — remove the stale entry"
+            )
+        elif name in refs[kind]:
+            messages.append(
+                f"registry/unbundled.yaml allowlists {kind} '{name}' but a bundle now "
+                "references it — remove the stale entry"
+            )
+    return messages
+
+
+def find_allowlist_problems(repo) -> list[str]:
+    """Return a message per structurally-invalid ``registry/unbundled.yaml`` entry.
+
+    Every entry must be a mapping with a non-empty ``kind``, ``name``, and
+    ``reason``. The ``reason`` requirement is load-bearing: without it the
+    allowlist becomes a friction-free way to silence the exposure check
+    ("wiring it up is inconvenient") rather than a deliberate, reviewable
+    exemption. A malformed entry is reported here — and so fails the strict
+    check — instead of quietly suppressing a genuine orphan.
+    """
+    _allowed, entries = load_allowlist(repo)
+    messages: list[str] = []
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            messages.append(
+                f"registry/unbundled.yaml entry #{i + 1} must be a mapping with "
+                "'kind', 'name', and 'reason'"
+            )
+            continue
+        kind = entry.get("kind")
+        name = entry.get("name")
+        reason = entry.get("reason")
+        label = f"{kind or '?'} '{name or '?'}'"
+        if not (isinstance(kind, str) and kind.strip()):
+            messages.append(f"registry/unbundled.yaml entry {label} is missing a 'kind'")
+        if not (isinstance(name, str) and name.strip()):
+            messages.append(f"registry/unbundled.yaml entry {label} is missing a 'name'")
+        if not (isinstance(reason, str) and reason.strip()):
+            messages.append(
+                f"registry/unbundled.yaml entry {label} is missing a 'reason' — "
+                "every exemption must document why the item is not bundled"
+            )
+    return messages
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    warn = "--warn" in argv
+    positional = [a for a in argv if a != "--warn"]
+    repo = Path(positional[0]) if positional else Path(".")
+
+    orphans = find_unexposed(repo)
+    allowlist_problems = find_allowlist_problems(repo) + find_stale_allowlist_entries(repo)
+
+    if warn:
+        for o in orphans:
+            print(
+                f"hint: {o.name} ({o.kind}) is authored under {o.path} but no bundle "
+                "references it yet — add it to a registry/bundles/*.yaml "
+                f"{o.kind}s list, or to registry/unbundled.yaml with a reason.",
+                file=sys.stderr,
+            )
+        for msg in allowlist_problems:
+            print(f"hint: {msg}", file=sys.stderr)
+        return 0
+
+    for o in orphans:
+        print(
+            f"::error file={o.path}::{o.name} ({o.kind}) is authored under {o.path} "
+            f"but no bundle references it — add it to a registry/bundles/*.yaml "
+            f"{o.kind}s list, or to registry/unbundled.yaml with a reason.",
+            file=sys.stderr,
+        )
+    for msg in allowlist_problems:
+        print(f"::error::{msg}", file=sys.stderr)
+
+    total = len(orphans) + len(allowlist_problems)
+    if total:
+        print(f"{total} exposure problem(s)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_exposure.py
+++ b/scripts/check_exposure.py
@@ -15,16 +15,29 @@ allowlist for exactly those cases; an allowlist entry that no longer matches
 anything on disk, or that a bundle now references anyway, is itself flagged as
 stale so the allowlist cannot silently rot.
 
-``mcp`` and ``prompt`` kinds are collected for completeness (there is currently
-no canonical ``mcp/<name>/`` server tree and no ``prompts/`` directory in this
-repo), but with nothing on disk to enumerate they never produce orphans today.
+A canonical item's *identity* is the name a bundle references, which is not
+always the on-disk basename:
+
+  * skill  — ``skills/<name>/SKILL.md``   -> ``<name>`` (a dir without the
+    SKILL.md marker is not a skill and is invisible here)
+  * agent  — ``agents/<name>/agent.md``   -> ``<name>``
+  * hook   — ``hooks/<name>.sh``          -> ``<name>``
+  * mcp    — ``mcp/<name>-go/``           -> ``<name>``: the ``-go`` suffix is a
+    directory-naming convention (AGENTS.md, mcp/README.md "Layout"), while a
+    bundle's ``mcp:`` key holds the *server* name from ``.mcp.json``
+    (``mcp: [lucid]``). Stripping it keeps the two namespaces comparable.
+  * prompt — ``prompts/<name>.md``        -> ``<name>``
+
+``mcp`` and ``prompt`` enumerate nothing today (``mcp/`` holds only README.md +
+.gitignore, and there is no ``prompts/`` directory), so they cannot produce an
+orphan yet; the identity mappings above are what they will use when they do.
 
 CLI:
     python3 scripts/check_exposure.py [REPO_ROOT] [--warn]
 Without ``--warn`` this exits non-zero (with ``::error::`` annotations) if any
-canonical item is unreferenced or any allowlist entry is stale. With
-``--warn`` it prints friendly ``hint:`` lines instead and always exits 0 (a
-local, non-blocking reminder — CI runs the strict form).
+canonical item is unreferenced, or any allowlist entry is stale or malformed.
+With ``--warn`` it prints friendly ``hint:`` lines instead and exits 0 — a
+local, non-blocking reminder; CI runs the strict form as the hard gate.
 """
 from __future__ import annotations
 
@@ -38,9 +51,11 @@ from _registry import normalize_member
 
 KINDS = ("skill", "agent", "hook", "mcp", "prompt")
 
-# The bundle-YAML list key for each kind. Note `mcp` does NOT pluralise — the
-# bundle key is `mcp:`, not `mcps:` — so messages must not naively append "s".
-KIND_TO_BUNDLE_KEY = {
+# The bundle-YAML list key that exposes each kind. Not derivable by appending
+# "s" to the kind — `mcp:` is singular in the bundle schema — so this map is the
+# single source of truth for both reading refs and telling a contributor which
+# key to add an orphan to.
+BUNDLE_KEY = {
     "skill": "skills",
     "agent": "agents",
     "hook": "hooks",
@@ -56,8 +71,95 @@ class Orphan:
     path: str = ""  # repo-relative canonical path, for CI annotations
 
 
+class RegistryError(Exception):
+    """The registry could not be read, so no verdict can be reached.
+
+    Distinct from a *finding*: a finding is a fact about the repo, this is the
+    check being unable to look. :func:`main` renders it — as a hard ``::error::``
+    in strict mode, a ``hint:`` under ``--warn`` — so the raiser carries only the
+    message and the optional file to anchor it to.
+    """
+
+    def __init__(self, message: str, file: Path | None = None):
+        super().__init__(message)
+        self.file = file
+
+
+def _require_dir(path: Path, premise: str) -> Path:
+    """Fail loudly when a directory the check depends on is absent.
+
+    A gate must never mistake "I read nothing" for "there is nothing wrong".
+    Pointed at a non-repo-root, every lookup below would come back empty on
+    *both* sides of the comparison, the orphan loop would iterate zero times,
+    and the check would report success without having examined anything.
+    """
+    if not path.is_dir():
+        raise RegistryError(
+            f"{path} does not exist — check_exposure.py was pointed at a directory "
+            f"that is not the repo root. Refusing to report success without "
+            f"reading {premise}."
+        )
+    return path
+
+
+def _load_yaml(path: Path) -> dict:
+    """Parse a registry YAML file into a mapping, or fail loudly.
+
+    Same reasoning as :func:`_require_dir`: an unreadable or malformed registry
+    file is a broken invocation, not an empty one. Swallowing it would drop the
+    bundle's refs and misreport its skills as orphans.
+    """
+    try:
+        with path.open() as fh:
+            data = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        raise RegistryError(f"cannot read {path}: {exc}", file=path) from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise RegistryError(
+            f"{path} must be a YAML mapping, got {type(data).__name__}", file=path
+        )
+    return data
+
+
+def _as_mapping(value, path: Path, key: str) -> dict:
+    """Coerce a registry value to a mapping, or fail loudly.
+
+    ``_load_yaml`` only vouches for the top level, so every nested access needs
+    its own guard: a scalar reaching ``.get()`` raises AttributeError from
+    *inside* the check, past :func:`main`'s ``except RegistryError`` — which is
+    how a half-written ``targets:`` used to traceback out of the ``--warn`` path
+    that promises to never block a commit.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise RegistryError(
+            f"{path}: '{key}' must be a mapping, got {type(value).__name__}", file=path
+        )
+    return value
+
+
+def _as_list(value, path: Path, key: str) -> list:
+    """Coerce a registry value to a list, or fail loudly.
+
+    Rejecting a bare string matters as much as rejecting an int: ``skills: demo``
+    is iterable, so it would silently read as the four members ``d``, ``e``,
+    ``m``, ``o`` rather than crashing — a wrong answer, which is worse than a
+    loud one.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RegistryError(
+            f"{path}: '{key}' must be a list, got {type(value).__name__}", file=path
+        )
+    return value
+
+
 def collect_bundle_refs(repo) -> dict[str, set[str]]:
-    """Union, across every ``registry/bundles/*.yaml``, the names referenced per kind.
+    """Union, across every enabled ``registry/bundles/*.yaml``, the names referenced per kind.
 
     Skills are keyed by their SOURCE (the canonical ``skills/<source>/`` dir),
     never the leaf — a member's leaf is plugin-local naming and does not
@@ -65,48 +167,57 @@ def collect_bundle_refs(repo) -> dict[str, set[str]]:
     """
     repo = Path(repo)
     refs: dict[str, set[str]] = {kind: set() for kind in KINDS}
-    bundles_dir = repo / "registry" / "bundles"
-    if not bundles_dir.is_dir():
-        return refs
+    bundles_dir = _require_dir(repo / "registry" / "bundles", "the bundle registry")
     bundle_files = sorted(
         list(bundles_dir.glob("*.yaml")) + list(bundles_dir.glob("*.yml"))
     )
     for bundle_file in bundle_files:
-        with bundle_file.open() as fh:
-            data = yaml.safe_load(fh) or {}
-        # A bundle whose Claude target is explicitly disabled ships nothing, so a
-        # reference from it does not make an artifact "exposed" (mirrors
-        # check_consistency.py, which reconciles only enabled Claude targets).
-        claude = (data.get("targets") or {}).get("claude") or {}
-        if claude.get("enabled") is False:
+        data = _load_yaml(bundle_file)
+        targets = _as_mapping(data.get("targets"), bundle_file, "targets")
+        claude = _as_mapping(targets.get("claude"), bundle_file, "targets.claude")
+        if not claude.get("enabled"):
+            # A disabled bundle syncs no plugin tree (sync-plugins.sh) and
+            # generates no manifest (generate_manifests.py), so it ships
+            # nothing — its refs expose nothing. Matches check_grouping.py and
+            # check_consistency.py, which skip disabled bundles the same way:
+            # `not enabled`, not `enabled is False`, so a bundle that omits the
+            # targets block reads as disabled here too.
             continue
-        for member in data.get("skills") or []:
+        for member in _as_list(
+            data.get(BUNDLE_KEY["skill"]), bundle_file, BUNDLE_KEY["skill"]
+        ):
             try:
                 source, _leaf = normalize_member(member)
             except ValueError:
+                # Malformed member shapes are check_grouping.py's to report
+                # (see check_bundle_refs.py) — skipping here is fail-closed:
+                # the skill it named simply reads as unexposed.
                 continue
             refs["skill"].add(source)
-        for name in data.get("agents") or []:
-            refs["agent"].add(name)
-        for name in data.get("hooks") or []:
-            refs["hook"].add(name)
-        for name in data.get("mcp") or []:
-            refs["mcp"].add(name)
-        for name in data.get("prompts") or []:
-            refs["prompt"].add(name)
+        for kind in ("agent", "hook", "mcp", "prompt"):
+            for name in _as_list(
+                data.get(BUNDLE_KEY[kind]), bundle_file, BUNDLE_KEY[kind]
+            ):
+                refs[kind].add(name)
     return refs
 
 
 def collect_canonical(repo) -> dict[str, dict[str, str]]:
-    """Return, per kind, a ``{name: repo-relative path}`` map of on-disk identities."""
+    """Return, per kind, a ``{name: repo-relative path}`` map of on-disk identities.
+
+    See the module docstring for the identity rules. Each path names a real
+    *file* wherever one identifies the item, because it is used as the
+    ``::error file=...::`` anchor and GitHub only renders an annotation inline
+    when it points at a file. ``mcp`` is the exception — a server is a whole
+    module directory with no single defining file.
+    """
     repo = Path(repo)
     canonical: dict[str, dict[str, str]] = {kind: {} for kind in KINDS}
 
-    skills_dir = repo / "skills"
-    if skills_dir.is_dir():
-        for d in sorted(skills_dir.iterdir()):
-            if d.is_dir() and (d / "SKILL.md").is_file():
-                canonical["skill"][d.name] = f"skills/{d.name}/"
+    skills_dir = _require_dir(repo / "skills", "the canonical skills tree")
+    for d in sorted(skills_dir.iterdir()):
+        if d.is_dir() and (d / "SKILL.md").is_file():
+            canonical["skill"][d.name] = f"skills/{d.name}/SKILL.md"
 
     agents_dir = repo / "agents"
     if agents_dir.is_dir():
@@ -123,40 +234,45 @@ def collect_canonical(repo) -> dict[str, dict[str, str]]:
     if mcp_dir.is_dir():
         for d in sorted(mcp_dir.iterdir()):
             if d.is_dir():
-                canonical["mcp"][d.name] = f"mcp/{d.name}/"
+                canonical["mcp"][d.name.removesuffix("-go")] = f"mcp/{d.name}/"
 
     prompts_dir = repo / "prompts"
     if prompts_dir.is_dir():
-        for p in sorted(prompts_dir.iterdir()):
-            canonical["prompt"][p.name] = f"prompts/{p.name}"
+        for p in sorted(prompts_dir.glob("*.md")):
+            canonical["prompt"][p.stem] = f"prompts/{p.name}"
 
     return canonical
+
+
+def _nonblank(value) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def load_allowlist(repo) -> tuple[set[tuple[str, str]], list[dict]]:
     """Parse ``registry/unbundled.yaml``. Returns (allowed set, raw entries).
 
-    A ``(kind, name)`` pair enters ``allowed`` (and therefore suppresses the
-    orphan) only when both are non-empty strings; the ``reason`` requirement is
-    validated separately by :func:`find_allowlist_problems`, which fails the
-    strict check on a missing reason so a malformed entry can never *silently*
-    suppress a genuine orphan. Missing file => empty allowlist.
+    A ``(kind, name)`` pair suppresses its orphan only when the entry is
+    *complete* — non-blank ``kind``, ``name``, and ``reason``. Validating the
+    reason here, at the point of the suppression decision rather than only in
+    :func:`find_allowlist_problems`, is what makes the requirement real: an
+    entry that skips the reason both fails the strict check *and* keeps
+    flagging its orphan, so the two messages agree instead of the CI output
+    naming only the allowlist entry while quietly hiding what it exempted.
+    Missing file => empty allowlist.
     """
     repo = Path(repo)
     path = repo / "registry" / "unbundled.yaml"
     if not path.is_file():
         return set(), []
-    with path.open() as fh:
-        data = yaml.safe_load(fh) or {}
-    entries = data.get("unbundled") or []
+    data = _load_yaml(path)
+    entries = _as_list(data.get("unbundled"), path, "unbundled")
     allowed = set()
     for entry in entries:
         if not isinstance(entry, dict):
             continue
-        kind = entry.get("kind")
-        name = entry.get("name")
-        if isinstance(kind, str) and kind and isinstance(name, str) and name:
-            allowed.add((kind, name))
+        kind, name, reason = entry.get("kind"), entry.get("name"), entry.get("reason")
+        if _nonblank(kind) and _nonblank(name) and _nonblank(reason):
+            allowed.add((kind.strip(), name.strip()))
     return allowed, entries
 
 
@@ -180,9 +296,11 @@ def find_unexposed(repo) -> list[Orphan]:
 def find_stale_allowlist_entries(repo) -> list[str]:
     """Return a message per allowlist entry that no longer needs to exist.
 
-    Stale means either: (a) the entry no longer matches anything canonical on
-    disk, or (b) a bundle now references it anyway, so the exemption is dead
-    weight.
+    Stale means: (a) the entry names a kind that does not exist, (b) it no
+    longer matches anything canonical on disk, or (c) a bundle now references
+    it anyway, so the exemption is dead weight. Only complete entries reach
+    here — :func:`load_allowlist` drops incomplete ones, which
+    :func:`find_allowlist_problems` reports instead.
     """
     repo = Path(repo)
     refs = collect_bundle_refs(repo)
@@ -209,14 +327,15 @@ def find_stale_allowlist_entries(repo) -> list[str]:
 
 
 def find_allowlist_problems(repo) -> list[str]:
-    """Return a message per structurally-invalid ``registry/unbundled.yaml`` entry.
+    """Return a message per missing field across ``registry/unbundled.yaml``.
 
-    Every entry must be a mapping with a non-empty ``kind``, ``name``, and
-    ``reason``. The ``reason`` requirement is load-bearing: without it the
-    allowlist becomes a friction-free way to silence the exposure check
-    ("wiring it up is inconvenient") rather than a deliberate, reviewable
-    exemption. A malformed entry is reported here — and so fails the strict
-    check — instead of quietly suppressing a genuine orphan.
+    One entry can yield several messages (a bare ``{}`` is missing all three
+    fields). Every entry must be a mapping with a non-empty ``kind``, ``name``,
+    and ``reason``. The ``reason`` requirement exists to force an exemption to
+    state its case in the diff, where a reviewer sees it, rather than letting
+    the allowlist become a frictionless way to silence the check ("wiring it up
+    is inconvenient"). Nothing validates that the reason is a *good* one — that
+    is the reviewer's job; this only guarantees there is something to review.
     """
     _allowed, entries = load_allowlist(repo)
     messages: list[str] = []
@@ -227,15 +346,13 @@ def find_allowlist_problems(repo) -> list[str]:
                 "'kind', 'name', and 'reason'"
             )
             continue
-        kind = entry.get("kind")
-        name = entry.get("name")
-        reason = entry.get("reason")
+        kind, name, reason = entry.get("kind"), entry.get("name"), entry.get("reason")
         label = f"{kind or '?'} '{name or '?'}'"
-        if not (isinstance(kind, str) and kind.strip()):
+        if not _nonblank(kind):
             messages.append(f"registry/unbundled.yaml entry {label} is missing a 'kind'")
-        if not (isinstance(name, str) and name.strip()):
+        if not _nonblank(name):
             messages.append(f"registry/unbundled.yaml entry {label} is missing a 'name'")
-        if not (isinstance(reason, str) and reason.strip()):
+        if not _nonblank(reason):
             messages.append(
                 f"registry/unbundled.yaml entry {label} is missing a 'reason' — "
                 "every exemption must document why the item is not bundled"
@@ -249,15 +366,28 @@ def main(argv=None) -> int:
     positional = [a for a in argv if a != "--warn"]
     repo = Path(positional[0]) if positional else Path(".")
 
-    orphans = find_unexposed(repo)
-    allowlist_problems = find_allowlist_problems(repo) + find_stale_allowlist_entries(repo)
+    try:
+        orphans = find_unexposed(repo)
+        allowlist_problems = find_allowlist_problems(repo) + find_stale_allowlist_entries(
+            repo
+        )
+    except RegistryError as exc:
+        # --warn is a local pre-commit reminder and must not block a commit over
+        # a half-written registry YAML; CI's strict run still fails on it.
+        if warn:
+            print(f"hint: {exc}", file=sys.stderr)
+            return 0
+        anchor = f" file={exc.file}" if exc.file else ""
+        print(f"::error{anchor}::{exc}", file=sys.stderr)
+        return 1
 
     if warn:
         for o in orphans:
             print(
-                f"hint: {o.name} ({o.kind}) is authored under {o.path} but no bundle "
+                f"hint: {o.name} ({o.kind}) is authored at {o.path} but no bundle "
                 "references it yet — add it to a registry/bundles/*.yaml "
-                f"`{KIND_TO_BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml with a reason.",
+                f"`{BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml "
+                "with a reason.",
                 file=sys.stderr,
             )
         for msg in allowlist_problems:
@@ -266,9 +396,9 @@ def main(argv=None) -> int:
 
     for o in orphans:
         print(
-            f"::error file={o.path}::{o.name} ({o.kind}) is authored under {o.path} "
+            f"::error file={o.path}::{o.name} ({o.kind}) is authored at {o.path} "
             f"but no bundle references it — add it to a registry/bundles/*.yaml "
-            f"`{KIND_TO_BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml with a reason.",
+            f"`{BUNDLE_KEY[o.kind]}:` list, or to registry/unbundled.yaml with a reason.",
             file=sys.stderr,
         )
     for msg in allowlist_problems:

--- a/skills/new-service-request/SKILL.md
+++ b/skills/new-service-request/SKILL.md
@@ -13,42 +13,52 @@ metadata:
 
 # New Service Request Skill
 
-Creates a new GitHub issue for the RDL Service Desk repository using one of the available templates.
+Create a new GitHub issue in the RDL Service Desk repository from one of its
+issue templates.
 
-**Repository:** https://github.com/rdl-service-desk/service-desk
+**Repository:** `rdl-service-desk/service-desk`
+(<https://github.com/rdl-service-desk/service-desk>)
 
-## Available Templates
+## How to run it
 
-1. **data-request** - Data Request Template
-   - Fields: Project title, Approval ID, Workflow Checklist
+This is an agent skill, not a CLI — there is no `new_service_request` binary.
+When it is invoked (e.g. `/rdl-team:new-service-request`), **you** create the
+issue using whatever GitHub tooling is available in the session, preferring:
 
-2. **enquiry** - Enquiry Request Template
-   - Fields: Overview, Priority (low/medium/high)
+1. the **GitHub MCP server**'s create-issue tool, or
+2. the **`gh` CLI**:
+   `gh issue create --repo rdl-service-desk/service-desk --template <name> ...`.
 
-3. **ict** - ICT Request Template
-   - Fields: Overview, Priority (low/medium/high)
+First confirm you can reach `rdl-service-desk/service-desk` (see *Compatibility*
+above). If you cannot, tell the user what access is missing instead of
+guessing.
 
-## Usage
+## Workflow
 
-Run `new_service_request` in your terminal and you'll be guided through:
-1. Selecting which template to use (1, 2, or 3)
-2. Entering the issue number you provide (you must supply this)
-3. Filling in the required fields for that template
-4. Creating the issue automatically and assigning it to you
+1. **Ask which template** the request uses — `data-request`, `enquiry`, or
+   `ict` (1, 2, or 3).
+2. **Ask for the issue number** — the user must supply this; never invent one.
+3. **Collect the template's required fields** (see *Template details* below).
+4. **Create the issue** in `rdl-service-desk/service-desk` from that template,
+   and **assign it to the requesting user**.
+5. **Return the new issue's URL** so the user can confirm it.
 
-Example: You provide issue number `1181`, and it creates `THHSRDLENQ-1181`
+**Title convention:** match the prefix the service-desk repo already uses for
+the chosen template — e.g. an enquiry with issue number `1181` is titled
+`THHSRDLENQ-1181`. If you are unsure of the prefix for a template, check an
+existing issue of that type in the repo rather than assuming one.
 
-## Template Details
+## Template details
 
-### Data Request
-- **Project title**: e.g., "Emergency Examination Authority Presentations in the Emergency Department"
-- **Approval ID**: e.g., THHSAQUIRE-1234 or SSAQTHS-123456
-- **Workflow items**: Mark checklist items as complete (repo bootstrapped, released)
+### 1. Data Request (`data-request`)
+- **Project title** — e.g. "Emergency Examination Authority Presentations in the Emergency Department"
+- **Approval ID** — e.g. `THHSAQUIRE-1234` or `SSAQTHS-123456`
+- **Workflow checklist** — mark items complete (e.g. repo bootstrapped, released)
 
-### Enquiry Request
-- **Overview**: Brief description (e.g., "Data management review")
-- **Priority**: low, medium, or high
+### 2. Enquiry Request (`enquiry`)
+- **Overview** — brief description (e.g. "Data management review")
+- **Priority** — `low`, `medium`, or `high`
 
-### ICT Request
-- **Overview**: Brief description (e.g., "New user account setup")
-- **Priority**: low, medium, or high
+### 3. ICT Request (`ict`)
+- **Overview** — brief description (e.g. "New user account setup")
+- **Priority** — `low`, `medium`, or `high`

--- a/skills/new-service-request/SKILL.md
+++ b/skills/new-service-request/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   GitHub issues for the RDL Service Desk repository with data request, enquiry,
   or ICT request templates.
 compatibility: >-
-  Requires access to the rdl-service-desk/service-desk GitHub repository.
+  Requires write access to the private rdl-service-desk/service-desk repository,
+  via either the GitHub MCP server or an authenticated GitHub CLI (`gh`).
 metadata:
   repo: https://github.com/nq-rdl/agent-extensions
 ---
@@ -26,27 +27,58 @@ When it is invoked (e.g. `/rdl-team:new-service-request`), **you** create the
 issue using whatever GitHub tooling is available in the session, preferring:
 
 1. the **GitHub MCP server**'s create-issue tool, or
-2. the **`gh` CLI**:
-   `gh issue create --repo rdl-service-desk/service-desk --template <name> ...`.
+2. the **`gh` CLI** (worked command below).
 
 First confirm you can reach `rdl-service-desk/service-desk` (see *Compatibility*
 above). If you cannot, tell the user what access is missing instead of
 guessing.
+
+## Available templates
+
+| Template | Label | Source | Fields |
+|---|---|---|---|
+| data-request | `data-request` | `data_request_template.md` | Project title, Approval ID, Workflow Checklist |
+| enquiry | `enquiry` | `enquiry_template.md` | Overview, Priority |
+| ict | `ICT` | `ict_request_template.md` | Overview, Priority |
+
+Labels are case-sensitive: `ICT` is uppercase, the other two are not.
 
 ## Workflow
 
 1. **Ask which template** the request uses — `data-request`, `enquiry`, or
    `ict` (1, 2, or 3).
 2. **Ask for the issue number** — the user must supply this; never invent one.
+   It is allocated outside this repository, so it cannot be derived or guessed.
 3. **Collect the template's required fields** (see *Template details* below).
-4. **Create the issue** in `rdl-service-desk/service-desk` from that template,
-   and **assign it to the requesting user**.
+4. **Create the issue** in `rdl-service-desk/service-desk`, and **assign it to
+   the requesting user**.
 5. **Return the new issue's URL** so the user can confirm it.
 
-**Title convention:** match the prefix the service-desk repo already uses for
-the chosen template — e.g. an enquiry with issue number `1181` is titled
-`THHSRDLENQ-1181`. If you are unsure of the prefix for a template, check an
-existing issue of that type in the repo rather than assuming one.
+**Title convention:** the issue number prefixed with `THHSRDLENQ-`, uniform
+across all three templates — issue number `1181` becomes the title
+`THHSRDLENQ-1181`.
+
+```bash
+gh issue create \
+  --repo rdl-service-desk/service-desk \
+  --title "THHSRDLENQ-1181" \
+  --label enquiry \
+  --assignee @me \
+  --body "$(cat <<'EOF'
+## Overview
+
+Data management review
+
+## Priority
+
+medium
+EOF
+)"
+```
+
+The body must use the template's `##` headings verbatim — the repo's
+`.github/ISSUE_TEMPLATE/*.md` files are the source of truth, so read the
+relevant one first if you need to confirm the current headings.
 
 ## Template details
 

--- a/tests/test_check_exposure.py
+++ b/tests/test_check_exposure.py
@@ -80,6 +80,39 @@ class TestUnreferencedSkills(unittest.TestCase):
             self.assertEqual(check_exposure.find_unexposed(repo), [])
 
 
+class TestDisabledBundles(unittest.TestCase):
+    def test_ref_from_disabled_bundle_does_not_expose(self):
+        # A bundle with targets.claude.enabled: false ships nothing, so a skill
+        # referenced only by it is still an orphan.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["shipped-nowhere"],
+                bundles={
+                    "off": (
+                        "id: off\nskills:\n  - shipped-nowhere\n"
+                        "targets:\n  claude:\n    enabled: false\n"
+                    )
+                },
+            )
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([o.name for o in orphans], ["shipped-nowhere"])
+
+    def test_ref_from_enabled_bundle_exposes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["shipped"],
+                bundles={
+                    "on": (
+                        "id: on\nskills:\n  - shipped\n"
+                        "targets:\n  claude:\n    enabled: true\n"
+                    )
+                },
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+
 class TestUnreferencedAgents(unittest.TestCase):
     def test_flags_orphan_agent(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -239,6 +272,19 @@ class TestCli(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertIn("orphan-skill", err.getvalue())
             self.assertIn("hint:", err.getvalue())
+
+    def test_mcp_orphan_message_uses_correct_bundle_key(self):
+        # The bundle key for mcp is `mcp:`, not the naive plural `mcps:`.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            (Path(repo) / "mcp" / "some-server").mkdir(parents=True)
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            out = err.getvalue()
+            self.assertIn("`mcp:`", out)
+            self.assertNotIn("mcps", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_exposure.py
+++ b/tests/test_check_exposure.py
@@ -1,0 +1,245 @@
+"""Tests for scripts/check_exposure.py — the reverse bundle-reference check.
+
+check_bundle_refs.py verifies every bundle reference resolves to something on
+disk; this is the other direction: every canonical skill/agent/hook must be
+referenced by at least one bundle, or explicitly allowlisted in
+registry/unbundled.yaml. Closes the "authored but unshipped" gap.
+"""
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import check_exposure  # noqa: E402
+
+
+def make_repo(tmp, bundles=None, skills=(), agents=(), hooks=(), unbundled=None):
+    """Build a throwaway repo skeleton with the given bundles/skills/agents/hooks."""
+    repo = Path(tmp)
+    (repo / "registry" / "bundles").mkdir(parents=True)
+    (repo / "skills").mkdir()
+    (repo / "agents").mkdir()
+    (repo / "hooks").mkdir()
+    for name in skills:
+        (repo / "skills" / name).mkdir()
+        (repo / "skills" / name / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+    for name in agents:
+        (repo / "agents" / name).mkdir()
+        (repo / "agents" / name / "agent.md").write_text(
+            f"---\nname: {name}\ndescription: x\n---\n"
+        )
+    for name in hooks:
+        (repo / "hooks" / f"{name}.sh").write_text("#!/usr/bin/env bash\n")
+    for stem, body in (bundles or {}).items():
+        (repo / "registry" / "bundles" / f"{stem}.yaml").write_text(body)
+    if unbundled is not None:
+        (repo / "registry" / "unbundled.yaml").write_text(unbundled)
+    return repo
+
+
+class TestUnreferencedSkills(unittest.TestCase):
+    def test_flags_orphan_skill(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["orphan-skill"])
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual(len(orphans), 1)
+            self.assertEqual(orphans[0].kind, "skill")
+            self.assertEqual(orphans[0].name, "orphan-skill")
+            self.assertEqual(orphans[0].path, "skills/orphan-skill/")
+
+    def test_referenced_skill_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["used"],
+                bundles={"b": "id: b\nskills:\n  - used\n"},
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+    def test_mapped_member_counts_source_as_referenced(self):
+        # A {source, leaf} member exposes the SOURCE dir, not the leaf name.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["go-gh"],
+                bundles={"gh": "id: gh\nskills:\n  - {source: go-gh, leaf: actions-go}\n"},
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+    def test_scans_yml_extension_bundles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["used"])
+            (repo / "registry" / "bundles" / "legacy.yml").write_text(
+                "id: legacy\nskills:\n  - used\n"
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+
+class TestUnreferencedAgents(unittest.TestCase):
+    def test_flags_orphan_agent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, agents=["orphan-agent"])
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([o.name for o in orphans], ["orphan-agent"])
+            self.assertEqual(orphans[0].kind, "agent")
+
+    def test_referenced_agent_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                agents=["used-agent"],
+                bundles={"b": "id: b\nagents:\n  - used-agent\n"},
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+
+class TestUnreferencedHooks(unittest.TestCase):
+    def test_flags_orphan_hook(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, hooks=["orphan-hook"])
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([o.name for o in orphans], ["orphan-hook"])
+            self.assertEqual(orphans[0].kind, "hook")
+
+    def test_referenced_hook_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["used-hook"],
+                bundles={"b": "id: b\nhooks:\n  - used-hook\n"},
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+
+class TestAllowlist(unittest.TestCase):
+    def test_allowlist_suppresses_orphan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["dev-hook"],
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: dev-hook\n    reason: repo-internal\n"
+                ),
+            )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+    def test_stale_allowlist_entry_for_missing_item(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: gone\n    reason: repo-internal\n"
+                ),
+            )
+            messages = check_exposure.find_stale_allowlist_entries(repo)
+            self.assertEqual(len(messages), 1)
+            self.assertIn("gone", messages[0])
+            self.assertIn("no longer exists", messages[0])
+
+    def test_stale_allowlist_entry_for_now_referenced_item(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["now-used"],
+                bundles={"b": "id: b\nhooks:\n  - now-used\n"},
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: now-used\n    reason: repo-internal\n"
+                ),
+            )
+            messages = check_exposure.find_stale_allowlist_entries(repo)
+            self.assertEqual(len(messages), 1)
+            self.assertIn("now-used", messages[0])
+            self.assertIn("references it", messages[0])
+
+    def test_missing_allowlist_file_is_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            allowed, entries = check_exposure.load_allowlist(repo)
+            self.assertEqual(allowed, set())
+            self.assertEqual(entries, [])
+
+    def test_allowlist_entry_without_reason_is_flagged(self):
+        # A bare {kind, name} exemption must not silently silence the check.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["dev-hook"],
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: dev-hook\n"
+                ),
+            )
+            problems = check_exposure.find_allowlist_problems(repo)
+            self.assertEqual(len(problems), 1)
+            self.assertIn("reason", problems[0])
+            # And the strict CLI must fail rather than exit 0.
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+
+    def test_allowlist_entry_with_blank_reason_is_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["dev-hook"],
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    '  - kind: hook\n    name: dev-hook\n    reason: "  "\n'
+                ),
+            )
+            problems = check_exposure.find_allowlist_problems(repo)
+            self.assertEqual(len(problems), 1)
+            self.assertIn("reason", problems[0])
+
+    def test_wellformed_allowlist_entry_has_no_problems(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["dev-hook"],
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: dev-hook\n    reason: repo-internal dev tool\n"
+                ),
+            )
+            self.assertEqual(check_exposure.find_allowlist_problems(repo), [])
+
+
+class TestCli(unittest.TestCase):
+    def test_main_exits_1_and_reports_name_on_orphan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["orphan-skill"])
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            self.assertIn("orphan-skill", err.getvalue())
+
+    def test_main_exits_0_when_clean(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp, skills=["ok"], bundles={"b": "id: b\nskills:\n  - ok\n"}
+            )
+            self.assertEqual(check_exposure.main([str(repo)]), 0)
+
+    def test_warn_flag_always_exits_0_with_orphans(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["orphan-skill"])
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo), "--warn"])
+            self.assertEqual(rc, 0)
+            self.assertIn("orphan-skill", err.getvalue())
+            self.assertIn("hint:", err.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_check_exposure.py
+++ b/tests/test_check_exposure.py
@@ -17,6 +17,18 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import check_exposure  # noqa: E402
 
+# Every real bundle carries a targets block; a bundle only ships when its Claude
+# target is enabled, so fixtures must say so explicitly or they test a state no
+# bundle occupies. Mirrors tests/test_check_grouping.py and test_check_consistency.py.
+ENABLED = "targets:\n  claude:\n    enabled: true\n    pluginName: {p}\n"
+DISABLED = "targets:\n  claude:\n    enabled: false\n    pluginName: {p}\n"
+
+
+def bundle(stem, body, enabled=True):
+    """A bundle YAML body with the targets block real bundles always carry."""
+    tmpl = ENABLED if enabled else DISABLED
+    return f"id: {stem}\n{body}{tmpl.format(p=stem)}"
+
 
 def make_repo(tmp, bundles=None, skills=(), agents=(), hooks=(), unbundled=None):
     """Build a throwaway repo skeleton with the given bundles/skills/agents/hooks."""
@@ -50,14 +62,15 @@ class TestUnreferencedSkills(unittest.TestCase):
             self.assertEqual(len(orphans), 1)
             self.assertEqual(orphans[0].kind, "skill")
             self.assertEqual(orphans[0].name, "orphan-skill")
-            self.assertEqual(orphans[0].path, "skills/orphan-skill/")
+            # The path anchors a GitHub annotation, so it must name a real file.
+            self.assertEqual(orphans[0].path, "skills/orphan-skill/SKILL.md")
 
     def test_referenced_skill_not_flagged(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = make_repo(
                 tmp,
                 skills=["used"],
-                bundles={"b": "id: b\nskills:\n  - used\n"},
+                bundles={"b": bundle("b", "skills:\n  - used\n")},
             )
             self.assertEqual(check_exposure.find_unexposed(repo), [])
 
@@ -67,7 +80,7 @@ class TestUnreferencedSkills(unittest.TestCase):
             repo = make_repo(
                 tmp,
                 skills=["go-gh"],
-                bundles={"gh": "id: gh\nskills:\n  - {source: go-gh, leaf: actions-go}\n"},
+                bundles={"gh": bundle("gh", "skills:\n  - {source: go-gh, leaf: actions-go}\n")},
             )
             self.assertEqual(check_exposure.find_unexposed(repo), [])
 
@@ -75,9 +88,30 @@ class TestUnreferencedSkills(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             repo = make_repo(tmp, skills=["used"])
             (repo / "registry" / "bundles" / "legacy.yml").write_text(
-                "id: legacy\nskills:\n  - used\n"
+                bundle("legacy", "skills:\n  - used\n")
             )
             self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+    def test_disabled_bundle_does_not_expose_its_skill(self):
+        # A disabled bundle syncs no plugin tree and generates no manifest, so
+        # a skill only it references ships nowhere and is still an orphan.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["parked"],
+                bundles={"dead": bundle("dead", "skills:\n  - parked\n", enabled=False)},
+            )
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([(o.kind, o.name) for o in orphans], [("skill", "parked")])
+
+    def test_bundle_without_targets_block_does_not_expose(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                skills=["parked"],
+                bundles={"b": "id: b\nskills:\n  - parked\n"},
+            )
+            self.assertEqual([o.name for o in check_exposure.find_unexposed(repo)], ["parked"])
 
 
 class TestDisabledBundles(unittest.TestCase):
@@ -126,7 +160,7 @@ class TestUnreferencedAgents(unittest.TestCase):
             repo = make_repo(
                 tmp,
                 agents=["used-agent"],
-                bundles={"b": "id: b\nagents:\n  - used-agent\n"},
+                bundles={"b": bundle("b", "agents:\n  - used-agent\n")},
             )
             self.assertEqual(check_exposure.find_unexposed(repo), [])
 
@@ -144,8 +178,46 @@ class TestUnreferencedHooks(unittest.TestCase):
             repo = make_repo(
                 tmp,
                 hooks=["used-hook"],
-                bundles={"b": "id: b\nhooks:\n  - used-hook\n"},
+                bundles={"b": bundle("b", "hooks:\n  - used-hook\n")},
             )
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+
+class TestMcpAndPromptIdentity(unittest.TestCase):
+    def test_mcp_dir_go_suffix_matches_bare_server_name_ref(self):
+        # Canonical servers live at mcp/<name>-go/, but a bundle's `mcp:` key
+        # holds the .mcp.json server name (`mcp: [lucid]`) — the -go suffix is
+        # a directory convention and must not make the server read as an orphan.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, bundles={"b": bundle("b", "mcp:\n  - lucid\n")})
+            (repo / "mcp" / "lucid-go").mkdir(parents=True)
+            self.assertEqual(check_exposure.find_unexposed(repo), [])
+
+    def test_unreferenced_mcp_server_is_flagged_by_bare_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            (repo / "mcp" / "lucid-go").mkdir(parents=True)
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([(o.kind, o.name) for o in orphans], [("mcp", "lucid")])
+
+    def test_mcp_orphan_hint_names_the_singular_mcp_key(self):
+        # The bundle key is `mcp:`, not `mcps:` — the message must not send a
+        # contributor to a field that does not exist.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp)
+            (repo / "mcp" / "lucid-go").mkdir(parents=True)
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            self.assertIn("`mcp:` list", err.getvalue())
+            self.assertNotIn("mcps", err.getvalue())
+
+    def test_prompt_identity_strips_the_md_extension(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, bundles={"b": bundle("b", "prompts:\n  - greet\n")})
+            (repo / "prompts").mkdir()
+            (repo / "prompts" / "greet.md").write_text("hi\n")
             self.assertEqual(check_exposure.find_unexposed(repo), [])
 
 
@@ -181,7 +253,7 @@ class TestAllowlist(unittest.TestCase):
             repo = make_repo(
                 tmp,
                 hooks=["now-used"],
-                bundles={"b": "id: b\nhooks:\n  - now-used\n"},
+                bundles={"b": bundle("b", "hooks:\n  - now-used\n")},
                 unbundled=(
                     "schemaVersion: v1\nunbundled:\n"
                     "  - kind: hook\n    name: now-used\n    reason: repo-internal\n"
@@ -218,6 +290,26 @@ class TestAllowlist(unittest.TestCase):
             with redirect_stderr(err):
                 rc = check_exposure.main([str(repo)])
             self.assertEqual(rc, 1)
+
+    def test_entry_without_reason_does_not_suppress_its_orphan(self):
+        # An incomplete exemption must not silence the very thing it exempts:
+        # the orphan stays reported, so CI names what is being hidden and not
+        # just the malformed entry hiding it.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(
+                tmp,
+                hooks=["dev-hook"],
+                unbundled=(
+                    "schemaVersion: v1\nunbundled:\n"
+                    "  - kind: hook\n    name: dev-hook\n"
+                ),
+            )
+            orphans = check_exposure.find_unexposed(repo)
+            self.assertEqual([o.name for o in orphans], ["dev-hook"])
+            err = io.StringIO()
+            with redirect_stderr(err):
+                check_exposure.main([str(repo)])
+            self.assertIn("dev-hook", err.getvalue())
 
     def test_allowlist_entry_with_blank_reason_is_flagged(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -259,7 +351,7 @@ class TestCli(unittest.TestCase):
     def test_main_exits_0_when_clean(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = make_repo(
-                tmp, skills=["ok"], bundles={"b": "id: b\nskills:\n  - ok\n"}
+                tmp, skills=["ok"], bundles={"b": bundle("b", "skills:\n  - ok\n")}
             )
             self.assertEqual(check_exposure.main([str(repo)]), 0)
 
@@ -285,6 +377,130 @@ class TestCli(unittest.TestCase):
             out = err.getvalue()
             self.assertIn("`mcp:`", out)
             self.assertNotIn("mcps", out)
+
+    def test_warn_flag_exits_0_on_malformed_registry_yaml(self):
+        # --warn is a pre-commit reminder; a half-written bundle YAML must not
+        # block the commit with a traceback.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["ok"])
+            (repo / "registry" / "bundles" / "broken.yaml").write_text(
+                "id: b\nskills: [\n  unclosed\n"
+            )
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo), "--warn"])
+            self.assertEqual(rc, 0)
+            self.assertIn("hint:", err.getvalue())
+
+    def test_strict_mode_fails_on_malformed_registry_yaml(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = make_repo(tmp, skills=["ok"])
+            (repo / "registry" / "bundles" / "broken.yaml").write_text(
+                "id: b\nskills: [\n  unclosed\n"
+            )
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            self.assertIn("::error", err.getvalue())
+            self.assertIn("cannot read", err.getvalue())
+
+
+class TestStructurallyInvalidRegistry(unittest.TestCase):
+    """Well-formed YAML whose *values* are the wrong shape.
+
+    Distinct from the syntax-error cases above, and the distinction is the whole
+    point: ``_load_yaml`` vouches only for the top-level mapping, so a scalar
+    where a mapping or list belongs parses cleanly and only blows up at the
+    dereference — past ``main``'s ``except RegistryError``. Testing only syntax
+    errors is what let that gap ship.
+    """
+
+    # (label, filename, content) — each puts a scalar where a shape is required.
+    CASES = (
+        ("targets", "registry/bundles/b.yaml", "id: b\nskills: [ok]\ntargets: invalid\n"),
+        (
+            "targets.claude",
+            "registry/bundles/b.yaml",
+            "id: b\nskills: [ok]\ntargets:\n  claude: nope\n",
+        ),
+        ("skills", "registry/bundles/b.yaml", bundle("b", "skills: 7\n")),
+        ("agents", "registry/bundles/b.yaml", bundle("b", "agents: 5\n")),
+        ("mcp", "registry/bundles/b.yaml", bundle("b", "mcp: 3\n")),
+        ("unbundled", "registry/unbundled.yaml", "unbundled: 1\n"),
+    )
+
+    def _repo(self, tmp, rel, content):
+        repo = make_repo(tmp, skills=["ok"], bundles={})
+        target = repo / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+        return repo
+
+    def test_warn_mode_never_blocks_on_a_bad_shape(self):
+        for label, rel, content in self.CASES:
+            with self.subTest(key=label), tempfile.TemporaryDirectory() as tmp:
+                repo = self._repo(tmp, rel, content)
+                err = io.StringIO()
+                with redirect_stderr(err):
+                    rc = check_exposure.main([str(repo), "--warn"])
+                self.assertEqual(rc, 0, f"{label}: --warn must not block a commit")
+                self.assertIn("hint:", err.getvalue())
+                self.assertNotIn("Traceback", err.getvalue())
+
+    def test_strict_mode_fails_cleanly_on_a_bad_shape(self):
+        for label, rel, content in self.CASES:
+            with self.subTest(key=label), tempfile.TemporaryDirectory() as tmp:
+                repo = self._repo(tmp, rel, content)
+                err = io.StringIO()
+                with redirect_stderr(err):
+                    rc = check_exposure.main([str(repo)])
+                self.assertEqual(rc, 1, f"{label}: strict mode must fail closed")
+                self.assertIn("::error", err.getvalue())
+                self.assertIn(label, err.getvalue())
+
+    def test_string_skills_list_is_rejected_not_iterated_per_character(self):
+        # `skills: ok` is iterable, so an unguarded loop reads it as the members
+        # 'o' and 'k' and reports the real skill as an orphan — a wrong answer
+        # rather than a loud failure.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self._repo(tmp, "registry/bundles/b.yaml", bundle("b", "skills: ok\n"))
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            self.assertIn("must be a list, got str", err.getvalue())
+
+
+class TestBrokenInvocation(unittest.TestCase):
+    """A gate that reads nothing must never report success."""
+
+    def test_non_repo_root_fails_instead_of_passing_vacuously(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([tmp])
+            self.assertEqual(rc, 1)
+            self.assertIn("not the repo root", err.getvalue())
+
+    def test_missing_skills_tree_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "registry" / "bundles").mkdir(parents=True)
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([str(repo)])
+            self.assertEqual(rc, 1)
+            self.assertIn("not the repo root", err.getvalue())
+
+    def test_warn_mode_does_not_block_on_broken_invocation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = check_exposure.main([tmp, "--warn"])
+            self.assertEqual(rc, 0)
+            self.assertIn("hint:", err.getvalue())
+            self.assertNotIn("::error", err.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `scripts/check_exposure.py`, a reverse-reference validation that ensures every canonical skill, agent, hook, and MCP server authored in the repo is exposed through at least one bundle. This closes the gap where content can be authored but never shipped in any plugin without triggering a CI failure.

## Key Changes

- **New script `scripts/check_exposure.py`**: Implements the reverse-reference check with three main functions:
  - `find_unexposed()` — flags canonical items not referenced by any bundle and not allowlisted
  - `find_stale_allowlist_entries()` — detects allowlist entries that no longer match anything on disk or are now referenced by a bundle
  - `find_allowlist_problems()` — validates that every allowlist entry has a non-empty `kind`, `name`, and `reason` (the reason requirement is load-bearing to prevent silent suppression)
  - Supports `--warn` flag for non-blocking local reminders (pre-commit) vs. strict CI failures

- **New allowlist file `registry/unbundled.yaml`**: Provides a reviewable exemption mechanism for repo-internal tooling (e.g., the `changie-fragment-lint` dev hook) that is intentionally not shipped through any plugin. Every entry requires a documented reason.

- **Comprehensive test suite `tests/test_check_exposure.py`**: 245 lines covering orphan detection, allowlist suppression, stale entry detection, malformed entry validation, and CLI behavior.

- **CI integration**: Added strict gate in `.github/workflows/validate.yml` that runs `check_exposure.py .` and fails if any canonical item is unexposed or any allowlist entry is stale.

- **Local pre-commit integration**: Wired into `lefthook.yml` as a non-blocking reminder (`--warn` flag) that surfaces newly-authored content not yet bundled, with a friendly hint message.

- **Fixed exposure gap**: Exposed the `new-service-request` skill through the `rdl-team` bundle (it was authored under `skills/` but never wired into any plugin).

- **Documentation updates**: Updated `CONTRIBUTING.md` and `AGENTS.md` to document the exposure check and its role in the validation pipeline.

## Implementation Details

- The script scans `skills/<name>/SKILL.md`, `agents/<name>/agent.md`, `hooks/<name>.sh`, and `mcp/<name>/` directories to enumerate canonical content
- Bundle references are collected from all `registry/bundles/*.yaml` files, with special handling for mapped skill members (`{source, leaf}` pairs) — the SOURCE directory is what gets exposed, not the leaf name
- The allowlist is strictly validated: missing or blank `reason` fields cause the strict check to fail, preventing the allowlist from becoming a friction-free way to silence the check
- Stale allowlist entries (those matching nothing on disk or now referenced by a bundle) are themselves flagged as failures, preventing silent rot
- The `--warn` mode always exits 0 for local use; CI runs the strict form as a hard gate

https://claude.ai/code/session_018eGjW1DJQLT8GS59fBibPi