### PR TITLE
ci(deps): pin all third-party actions to SHAs, bump four to current majors

### DIFF
--- a/.changes/unreleased/Security-20260728-130429.yaml
+++ b/.changes/unreleased/Security-20260728-130429.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: 'CI: bumped pinned actions to current majors — checkout v7.0.1, setup-node v7.0.0, setup-go v7.0.0, github-script v9.0.0. Supersedes dependabot PRs #253, #252, #246, #245.'
+time: 2026-07-28T13:04:29.439205+10:00

--- a/.changes/unreleased/Security-20260728-130444.yaml
+++ b/.changes/unreleased/Security-20260728-130444.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: 'CI: every third-party GitHub Action is now pinned to a full commit SHA with a version comment, replacing mutable floating tags across all workflows and docs.yml.tmpl.'
+time: 2026-07-28T13:04:44.07898+10:00

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,7 +15,7 @@ jobs:
     # (the bot has no way to run `changie new`). Human PRs still require one.
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codex-content-review.yml
+++ b/.github/workflows/codex-content-review.yml
@@ -57,7 +57,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out PR (full history, for base-ref diffing)
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -139,7 +139,7 @@ jobs:
       - name: Post review as PR comment
         if: steps.key.outputs.present == 'true'
         continue-on-error: true # informational — a comment-post failure must not gate the PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REVIEW_BODY: ${{ steps.codex.outputs.final-message }}
         with:

--- a/.github/workflows/docs.yml.tmpl
+++ b/.github/workflows/docs.yml.tmpl
@@ -15,15 +15,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: site
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         id: deployment

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,10 +13,10 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --version
           installOnly: true

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -65,7 +65,7 @@ jobs:
           permission-contents: write
 
       - name: Check out the merge commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
@@ -175,7 +175,7 @@ jobs:
 
       - name: Create GitHub release
         if: steps.v.outputs.do_release == 'true'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ steps.v.outputs.version }}
           body_path: release-notes.md

--- a/.github/workflows/release-pr-guard.yml
+++ b/.github/workflows/release-pr-guard.yml
@@ -33,7 +33,7 @@ jobs:
       # usually conflicts with main on VERSION/CHANGELOG, in which case the
       # merge ref does not exist and a default checkout would fail).
       - name: Check out PR head
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -50,7 +50,7 @@ jobs:
           permission-issues: write
 
       - name: Check out main
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           fetch-depth: 0
@@ -96,7 +96,7 @@ jobs:
           fi
 
       - name: Install changie
-        uses: miniscruff/changie-action@v3
+        uses: miniscruff/changie-action@3223cb29b92a0972dedc864ace3da01e04780ae4 # v3.0.1
         with:
           version: latest
 

--- a/.github/workflows/skillspector.yml
+++ b/.github/workflows/skillspector.yml
@@ -11,7 +11,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run SkillSpector
         id: scan
@@ -31,7 +31,7 @@ jobs:
       - name: Upload SARIF
         if: always() && hashFiles('skillspector.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: skillspector.sarif
           category: skillspector

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validate bundle references + registry consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml
@@ -50,7 +50,7 @@ jobs:
     name: Validate skill + agent symlinks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check all symlinks resolve
         run: |
@@ -78,7 +78,7 @@ jobs:
     name: Validate Claude plugin structure, hooks, and agents
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install PyYAML for agent frontmatter validation
         run: python3 -m pip install --user pyyaml
@@ -90,7 +90,7 @@ jobs:
     name: Unit tests (pipeline scripts)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml
@@ -98,7 +98,7 @@ jobs:
       - name: Run pipeline-script unit tests
         run: python3 -m unittest discover -s tests -p 'test_*.py' -v
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 
@@ -109,12 +109,12 @@ jobs:
     name: Validate skills against the agentskills.io spec (asctl)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # asctl is the spec validator for skills/ (imported from the former
       # nq-rdl/agent-skills repo when it was merged here). It replaces the
       # upstream-side validation that the old vendoring sync relied on.
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: tools/asctl/go.mod
           cache: true


### PR DESCRIPTION
Bulk-merges the four open dependabot PRs — #253, #252, #246, #245 — and fixes the pinning inconsistency that produced the churn in the first place.

## Why one PR

They could not be merged independently. #253, #252 and #245 all touch `validate.yml`; #253 and #246 both touch `codex-content-review.yml`. Merging any one would have stale-rebased the rest — and #245 was already based on an older `main`.

## Why not take #253 verbatim

Eight of #253's nine hunks rewrote `actions/checkout@v7` → `@v7.0.1`. That is not a version bump — `main` was already on v7 — but a swap of a floating **major** tag for a floating **patch** tag. It buys no supply-chain safety, since a patch tag is just as mutable, and it opens a fresh PR touching seven files on every checkout patch release.

The root cause was mixed pinning styles: SHA pins in `codex-content-review.yml`, floating tags everywhere else. That mix is what makes dependabot normalise them. So this PR pins **every** third-party action to a full commit SHA with a `# vX.Y.Z` comment, matching the policy in `CLAUDE.md` (§Language Policy → `gh:github-actions-expert`: *"action pinning to full commit SHAs"*).

## Version bumps

| Action | From | To | Supersedes |
|---|---|---|---|
| `actions/checkout` | v5.0.1 | v7.0.1 | #253 |
| `actions/setup-node` | v4 | v7.0.0 | #252 |
| `actions/github-script` | v7.1.0 | v9.0.0 | #246 |
| `actions/setup-go` | v6 | v7.0.0 | #245 |

## Breaking changes, checked against actual usage

- **github-script v9** drops `require('@actions/github')` and makes `getOctokit` an injected parameter, so `const`/`let getOctokit` throws `SyntaxError`. The only script here (`codex-content-review.yml`) uses `github.rest.issues.createComment` and `context` — neither pattern.
- **setup-node v5** auto-caches when `package.json` has a `packageManager` field; v6 narrowed that to npm. This `package.json` has no such field and there is no lockfile, so auto-caching is a no-op.
- **checkout v7** blocks checking out fork PRs under `pull_request_target` and `workflow_run`. No workflow here uses either trigger.
- **setup-go v7** is an ESM migration plus `@actions/cache` 6.2.0; the `go-version-file` / `cache` / `cache-dependency-path` inputs are unchanged.

Every SHA was verified twice: the commit exists upstream, **and** the claimed tag dereferences to exactly that commit (github-script v9.0.0 is an annotated tag, so its ref object needed dereferencing).

## Pin-only — no version change

`configure-pages` v5.0.0 · `setup-python` v5.6.0 · `upload-pages-artifact` v4.0.0 · `deploy-pages` v4.0.5 · `create-github-app-token` v3.2.0 · `lychee-action` v2.9.0 · `action-gh-release` v3.0.2 · `changie-action` v3.0.1 · `codeql-action` v4.37.3

## Also included

`docs.yml.tmpl` — dependabot cannot see it (a `.tmpl` is not a parsed workflow), so its actions had drifted; checkout was still on v5. **It stays outside dependabot's view after this change**, so it will drift again.

## Deliberately left alone

The two `nq-rdl/.github` reusable workflows stay on `@main`. They are first-party, same org and same admin control, and pinning would freeze them against upstream fixes.

## Safety

No job `name:` changed, so `main`'s required status checks stay matched (per the warning in `CLAUDE.md`).

---

Closes #253, closes #252, closes #246, closes #245.

Co-authored-by: Claude <noreply@anthropic.com>