### PR TITLE
fix(tests): never spawn through a shell in the codex test helper

### DIFF
--- a/.changes/unreleased/Security-20260728-133857.yaml
+++ b/.changes/unreleased/Security-20260728-133857.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: 'Tests: the codex test helper never spawns through a shell now, so environment-derived absolute paths cannot be re-parsed by cmd.exe (CodeQL js/shell-command-injection-from-environment).'
+time: 2026-07-28T13:38:57.852397+10:00

--- a/tests/codex/git.test.mjs
+++ b/tests/codex/git.test.mjs
@@ -50,12 +50,10 @@ test("default branch names with special characters are passed to git literally",
   fs.writeFileSync(path.join(cwd, "app.js"), "console.log('base');\n");
   run("git", ["add", "app.js", "branch-helper.cmd"], { cwd });
   run("git", ["commit", "-m", "base"], { cwd });
-  run("git", ["branch", "-m", branchName], { cwd, shell: false });
-  run("git", ["update-ref", `refs/remotes/origin/${branchName}`, branchName], { cwd, shell: false });
-  run("git", ["symbolic-ref", "refs/remotes/origin/HEAD", `refs/remotes/origin/${branchName}`], {
-    cwd,
-    shell: false
-  });
+  // `run` never uses a shell, so the `&` in branchName reaches git verbatim.
+  run("git", ["branch", "-m", branchName], { cwd });
+  run("git", ["update-ref", `refs/remotes/origin/${branchName}`, branchName], { cwd });
+  run("git", ["symbolic-ref", "refs/remotes/origin/HEAD", `refs/remotes/origin/${branchName}`], { cwd });
   run("git", ["checkout", "-b", "feature/test"], { cwd });
   fs.writeFileSync(path.join(cwd, "app.js"), "console.log('feature');\n");
   run("git", ["add", "app.js"], { cwd });

--- a/tests/codex/helpers.mjs
+++ b/tests/codex/helpers.mjs
@@ -4,7 +4,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import process from "node:process";
 import { spawnSync } from "node:child_process";
 
 export function makeTempDir(prefix = "codex-plugin-test-") {
@@ -15,13 +14,19 @@ export function writeExecutable(filePath, source) {
   fs.writeFileSync(filePath, source, { encoding: "utf8", mode: 0o755 });
 }
 
+// Never spawns through a shell. Callers hand this helper environment-derived
+// absolute paths -- the repo root off import.meta.url, process.execPath, mkdtemp
+// dirs -- and a shell would re-parse those on spaces and metacharacters. The
+// commands used here (node, git, bash, process.execPath) are all directly
+// executable, so there is nothing to gain from a shell and no `shell` option to
+// override: shell interpretation is not a per-call decision.
 export function run(command, args, options = {}) {
   return spawnSync(command, args, {
     cwd: options.cwd,
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
+    shell: false,
     windowsHide: true
   });
 }


### PR DESCRIPTION
Fixes CodeQL alert [#437](https://github.com/nq-rdl/agent-extensions/security/code-scanning/437) — `js/shell-command-injection-from-environment` (medium), *Shell command built from environment values*.

## The defect

`run()` in `tests/codex/helpers.mjs` computed its `shell` option as:

```js
shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
```

On Windows, a non-absolute command (`node`, `git`, `bash`) turned on `shell: true`, which sends the whole command line through `cmd.exe` **unquoted**. Every caller feeds this helper environment-derived absolute paths — the repo root off `import.meta.url`, `process.execPath`, `mkdtemp` directories. A checkout under a path with a space (`C:\Users\First Last\...`) would split into two arguments; a shell metacharacter would change which command runs. CodeQL traced ten such flows, e.g. `hooks.test.mjs:23` → `run("node", [SESSION_HOOK], …)` where `SESSION_HOOK` is an absolute path built from `import.meta.url`.

## The fix

Hardcode `shell: false` and remove the per-call `shell` option, so shell interpretation is no longer a decision a caller can get wrong.

The Windows fallback was inherited from `openai/codex-plugin-cc` and buys nothing here — the only commands this helper spawns (`node`, `git`, `bash`, `process.execPath`) are directly executable, so there is no `.cmd`/`.bat` wrapper needing a shell to resolve.

`git.test.mjs`'s three explicit `shell: false` call sites become redundant; they're replaced by a comment recording the guarantee they were relying on.

## Not touched

Production spawn paths are unaffected and were not flagged:
- `plugins/codex/scripts/lib/git.mjs` already forces `shell: false` for repository-derived arguments.
- `process.mjs` / `app-server.mjs` keep the win32 shell they genuinely need to resolve npm's `codex.cmd` wrapper for the real `codex` binary.

## Verification

`node --test tests/codex/*.test.mjs`, run at `main` (`a50bf8c`) and on this branch:

| | tests | pass | fail |
|---|---|---|---|
| baseline (`a50bf8c`) | 210 | 206 | 4 |
| this branch | 210 | 206 | 4 |

Identical, including the same four failing test names. Those four (`status shows phases…`, `status preserves adversarial review kind labels`, `result returns the stored output…`, `resolveStateDir uses a temp-backed per-workspace directory`) are pre-existing and reproduce unchanged on `main` — they are local-macOS-environment failures (temp-dir path resolution) and none of them spawn a subprocess. CI is ubuntu-only and green on `main`.

Also run clean: `scripts/validate-plugins.sh`, `check_bundle_refs.py`, `check_grouping.py`, `check_consistency.py`, `generate_manifests.py --check`, `generate_bundles_doc.py --check`, `check_changie_length.py`.